### PR TITLE
refactor(cli): Consistently use `tokio::process:Command`

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -20,7 +20,7 @@ pub async fn dispatch(action: DebugAction) -> Result<()> {
     match action {
         DebugAction::Config => print_config(),
         DebugAction::Auth => check_auth().await,
-        DebugAction::Rev { rev } => print_rev(&rev),
+        DebugAction::Rev { rev } => print_rev(&rev).await,
         DebugAction::PrLookup { rev } => print_pr_lookup(&rev).await,
     }
 }
@@ -45,7 +45,7 @@ fn empty_auth() -> crate::cli::AuthArgs {
     }
 }
 
-fn print_rev(rev: &str) -> Result<()> {
+async fn print_rev(rev: &str) -> Result<()> {
     let jj = JjCli;
 
     let CommitInfo {
@@ -53,16 +53,16 @@ fn print_rev(rev: &str) -> Result<()> {
         commit_id,
         description,
         bookmarks,
-    } = jj.resolve_rev(rev)?;
-    let ancestor = jj.stacked_ancestor_bookmark(rev)?;
+    } = jj.resolve_rev(rev).await?;
+    let ancestor = jj.stacked_ancestor_bookmark(rev).await?;
     let title_revset = jj::title_base_revset(rev, ancestor.as_deref());
-    let default_title = jj.first_commit_description(&title_revset)?;
+    let default_title = jj.first_commit_description(&title_revset).await?;
 
-    let origin_url = jj.remote_url("origin")?;
-    let upstream_url = jj.remote_url("upstream")?;
-    let default_branch = jj.trunk_branch()?;
+    let origin_url = jj.remote_url("origin").await?;
+    let upstream_url = jj.remote_url("upstream").await?;
+    let default_branch = jj.trunk_branch().await?;
     let default_branch_sha = match &default_branch {
-        Some(branch) => jj.remote_bookmark_sha(branch, "origin")?,
+        Some(branch) => jj.remote_bookmark_sha(branch, "origin").await?,
         None => None,
     };
 
@@ -89,7 +89,7 @@ fn print_rev(rev: &str) -> Result<()> {
 
 async fn print_pr_lookup(rev: &str) -> Result<()> {
     let jj = JjCli;
-    let info = jj.resolve_rev(rev)?;
+    let info = jj.resolve_rev(rev).await?;
     let branch = info
         .bookmarks
         .first()
@@ -97,14 +97,16 @@ async fn print_pr_lookup(rev: &str) -> Result<()> {
         .ok_or_else(|| anyhow!("no local bookmark on `{rev}`; nothing to look up"))?;
 
     let origin_url = jj
-        .remote_url("origin")?
+        .remote_url("origin")
+        .await?
         .ok_or_else(|| anyhow!("origin remote is not configured"))?;
-    let upstream_url = jj.remote_url("upstream")?;
+    let upstream_url = jj.remote_url("upstream").await?;
     let target = remote::target(&origin_url, upstream_url.as_deref())?;
     let head_spec = target.head_spec(&branch);
 
     let default_base = jj
-        .trunk_branch()?
+        .trunk_branch()
+        .await?
         .ok_or_else(|| anyhow!("could not detect trunk() bookmark"))?;
 
     let config = config::load()?;

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -26,14 +26,14 @@ pub trait Jj {
     ///
     /// Returns an error if the revset does not resolve to exactly one commit or if
     /// the jj invocation fails.
-    fn resolve_rev(&self, rev: &str) -> Result<CommitInfo>;
+    async fn resolve_rev(&self, rev: &str) -> Result<CommitInfo>;
 
     /// Closest ancestor commit (excluding `rev` itself) that carries a bookmark.
     ///
     /// # Errors
     ///
     /// Propagates jj errors. Returns `Ok(None)` when no such ancestor exists.
-    fn stacked_ancestor_bookmark(&self, rev: &str) -> Result<Option<String>>;
+    async fn stacked_ancestor_bookmark(&self, rev: &str) -> Result<Option<String>>;
 
     /// First-line description of the oldest commit in `revset`. Used to compute the
     /// default PR title.
@@ -41,21 +41,21 @@ pub trait Jj {
     /// # Errors
     ///
     /// Propagates jj errors.
-    fn first_commit_description(&self, revset: &str) -> Result<String>;
+    async fn first_commit_description(&self, revset: &str) -> Result<String>;
 
     /// URL configured for the given git remote, or `Ok(None)` if unset.
     ///
     /// # Errors
     ///
     /// Propagates failures from the embedded git store query.
-    fn remote_url(&self, name: &str) -> Result<Option<String>>;
+    async fn remote_url(&self, name: &str) -> Result<Option<String>>;
 
     /// Commit SHA of `bookmark@remote` if it exists, else `Ok(None)`.
     ///
     /// # Errors
     ///
     /// Propagates jj errors.
-    fn remote_bookmark_sha(&self, bookmark: &str, remote: &str) -> Result<Option<String>>;
+    async fn remote_bookmark_sha(&self, bookmark: &str, remote: &str) -> Result<Option<String>>;
 
     /// `jj git push -c <rev>`. Pushes the change and creates a bookmark if needed.
     ///
@@ -71,14 +71,14 @@ pub trait Jj {
     /// # Errors
     ///
     /// Propagates jj errors.
-    fn trunk_branch(&self) -> Result<Option<String>>;
+    async fn trunk_branch(&self) -> Result<Option<String>>;
 
     /// Absolute path to the jj workspace root.
     ///
     /// # Errors
     ///
     /// Propagates jj errors.
-    fn workspace_root(&self) -> Result<PathBuf>;
+    async fn workspace_root(&self) -> Result<PathBuf>;
 
     /// Run `jj git import` to re-read refs from the underlying git store.
     ///

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -6,7 +6,8 @@
 
 use super::{CommitInfo, Jj};
 use anyhow::{Context, Result, anyhow};
-use std::{path::PathBuf, process::Command};
+use std::path::PathBuf;
+use tokio::process::Command;
 
 /// Build a jj template that emits a JSON object: each `(key, expr)` becomes
 /// `"key": json(expr)`.
@@ -23,7 +24,7 @@ fn json_object_template(fields: &[(&str, &str)]) -> String {
 pub struct JjCli;
 
 impl Jj for JjCli {
-    fn resolve_rev(&self, rev: &str) -> Result<CommitInfo> {
+    async fn resolve_rev(&self, rev: &str) -> Result<CommitInfo> {
         let template = json_object_template(&[
             ("change_id", "change_id"),
             ("commit_id", "commit_id"),
@@ -39,12 +40,13 @@ impl Jj for JjCli {
             "1",
             "-T",
             &template,
-        ])?;
+        ])
+        .await?;
         serde_json::from_slice(&stdout)
             .with_context(|| format!("could not parse jj log output for `{rev}`"))
     }
 
-    fn stacked_ancestor_bookmark(&self, rev: &str) -> Result<Option<String>> {
+    async fn stacked_ancestor_bookmark(&self, rev: &str) -> Result<Option<String>> {
         let revset = format!("ancestors(({rev})-) & bookmarks()");
         let stdout = run_jj(&[
             "log",
@@ -55,7 +57,8 @@ impl Jj for JjCli {
             "1",
             "-T",
             "json(bookmarks.map(|b| b.name()))",
-        ])?;
+        ])
+        .await?;
         if stdout.is_empty() {
             return Ok(None);
         }
@@ -64,7 +67,7 @@ impl Jj for JjCli {
         Ok(bookmarks.into_iter().next())
     }
 
-    fn first_commit_description(&self, revset: &str) -> Result<String> {
+    async fn first_commit_description(&self, revset: &str) -> Result<String> {
         let stdout = run_jj(&[
             "log",
             "--no-graph",
@@ -75,15 +78,16 @@ impl Jj for JjCli {
             "1",
             "-T",
             "description.first_line()",
-        ])?;
+        ])
+        .await?;
         Ok(std::str::from_utf8(&stdout)
             .context("jj log output is not UTF-8")?
             .trim()
             .to_string())
     }
 
-    fn remote_url(&self, name: &str) -> Result<Option<String>> {
-        let config_path = git_backend_dir()?.join("config");
+    async fn remote_url(&self, name: &str) -> Result<Option<String>> {
+        let config_path = git_backend_dir().await?.join("config");
         let contents = match std::fs::read_to_string(&config_path) {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -96,7 +100,7 @@ impl Jj for JjCli {
     }
 
     async fn push(&self, rev: &str) -> Result<()> {
-        let status = tokio::process::Command::new("jj")
+        let status = Command::new("jj")
             .args(["git", "push", "-c", rev])
             .status()
             .await
@@ -107,7 +111,7 @@ impl Jj for JjCli {
         Ok(())
     }
 
-    fn trunk_branch(&self) -> Result<Option<String>> {
+    async fn trunk_branch(&self) -> Result<Option<String>> {
         let stdout = run_jj(&[
             "log",
             "--no-graph",
@@ -117,7 +121,8 @@ impl Jj for JjCli {
             "1",
             "-T",
             "json(bookmarks.map(|b| b.name()))",
-        ])?;
+        ])
+        .await?;
         if stdout.is_empty() {
             return Ok(None);
         }
@@ -126,7 +131,7 @@ impl Jj for JjCli {
         Ok(names.into_iter().next())
     }
 
-    fn remote_bookmark_sha(&self, bookmark: &str, remote: &str) -> Result<Option<String>> {
+    async fn remote_bookmark_sha(&self, bookmark: &str, remote: &str) -> Result<Option<String>> {
         let revset = format!("remote_bookmarks(exact:{bookmark:?}, remote=exact:{remote:?})");
         let stdout = run_jj(&[
             "log",
@@ -137,7 +142,8 @@ impl Jj for JjCli {
             "1",
             "-T",
             "commit_id",
-        ])?;
+        ])
+        .await?;
         let sha = std::str::from_utf8(&stdout)
             .context("jj log output is not UTF-8")?
             .trim()
@@ -145,12 +151,12 @@ impl Jj for JjCli {
         Ok(Some(sha).filter(|s| !s.is_empty()))
     }
 
-    fn workspace_root(&self) -> Result<PathBuf> {
-        workspace_root()
+    async fn workspace_root(&self) -> Result<PathBuf> {
+        workspace_root().await
     }
 
     async fn git_import(&self) -> Result<()> {
-        let status = tokio::process::Command::new("jj")
+        let status = Command::new("jj")
             .args(["git", "import"])
             .status()
             .await
@@ -162,8 +168,8 @@ impl Jj for JjCli {
     }
 }
 
-fn workspace_root() -> Result<PathBuf> {
-    let stdout = run_jj(&["workspace", "root"])?;
+async fn workspace_root() -> Result<PathBuf> {
+    let stdout = run_jj(&["workspace", "root"]).await?;
     let path = std::str::from_utf8(&stdout)
         .context("jj workspace root output is not UTF-8")?
         .trim()
@@ -179,8 +185,12 @@ fn workspace_root() -> Result<PathBuf> {
 /// jj writes the path to its git backend in `.jj/repo/store/git_target` as a
 /// path relative to `.jj/repo/store/`. Colocated repos point at `../../../.git`;
 /// pure-jj repos point to a git dir embedded under `.jj/`.
-fn git_backend_dir() -> Result<PathBuf> {
-    let store_dir = workspace_root()?.join(".jj").join("repo").join("store");
+async fn git_backend_dir() -> Result<PathBuf> {
+    let store_dir = workspace_root()
+        .await?
+        .join(".jj")
+        .join("repo")
+        .join("store");
     let target = std::fs::read_to_string(store_dir.join("git_target"))
         .context("could not read `.jj/repo/store/git_target`")?;
     let target = target.trim();
@@ -234,11 +244,12 @@ fn parse_key_value(line: &str, key: &str) -> Option<String> {
     }
 }
 
-fn run_jj(args: &[&str]) -> Result<Vec<u8>> {
+async fn run_jj(args: &[&str]) -> Result<Vec<u8>> {
     let output = Command::new("jj")
         .arg("--ignore-working-copy")
         .args(args)
         .output()
+        .await
         .context("failed to spawn `jj`")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -55,13 +55,14 @@ where
     G: Gh,
     E: EditorRoundTrip,
 {
-    let info = jj.resolve_rev(&args.rev)?;
+    let info = jj.resolve_rev(&args.rev).await?;
     let existing_branch = info.bookmarks.first().cloned();
 
     let origin_url = jj
-        .remote_url("origin")?
+        .remote_url("origin")
+        .await?
         .ok_or_else(|| anyhow!("origin remote is not configured"))?;
-    let upstream_url = jj.remote_url("upstream")?;
+    let upstream_url = jj.remote_url("upstream").await?;
     let target = remote::target(&origin_url, upstream_url.as_deref())?;
 
     // Pre-flight only when we already have a bookmark; an unpushed rev can't have
@@ -84,9 +85,10 @@ where
         }
     }
 
-    let ancestor = jj.stacked_ancestor_bookmark(&args.rev)?;
+    let ancestor = jj.stacked_ancestor_bookmark(&args.rev).await?;
     let detected_base = jj
-        .trunk_branch()?
+        .trunk_branch()
+        .await?
         .unwrap_or_else(|| config.default_base_branch.clone());
     let base = resolve_base(args, ancestor.as_deref(), &detected_base);
 
@@ -99,7 +101,7 @@ where
     }
 
     let title_revset = jj::title_base_revset(&args.rev, ancestor.as_deref());
-    let default_title = jj.first_commit_description(&title_revset)?;
+    let default_title = jj.first_commit_description(&title_revset).await?;
 
     let raw_template = load_template_for(args, config, jj)?;
     let initial_fm = Frontmatter {
@@ -123,7 +125,7 @@ where
     let branch = if let Some(b) = existing_branch {
         b
     } else {
-        let refreshed = jj.resolve_rev(&args.rev)?;
+        let refreshed = jj.resolve_rev(&args.rev).await?;
         refreshed
             .bookmarks
             .into_iter()


### PR DESCRIPTION
Consistently use `tokio::process:Command`
