### PR TITLE
refactor(cli): Simplify argument handling by using `figment` more

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -10,7 +10,7 @@
 //! canned outcomes without having to run an actual subprocess or touch the
 //! filesystem.
 
-use crate::{cli::AuthArgs, config::Config};
+use crate::config::Config;
 use anyhow::{Context, Result, anyhow};
 use secrecy::SecretString;
 use std::time::Duration;
@@ -66,38 +66,28 @@ impl ProcessRunner for TokioProcessRunner {
 }
 
 /// Resolve a [`SecretString`] using the production [`TokioProcessRunner`]. CLI
-/// `--gh-askpass` / `--askpass-timeout` flags in `auth` take precedence over
-/// `config`.
+/// `--gh-askpass` / `--askpass-timeout` flags are folded into `config` by the
+/// figment overlay in `pr::dispatch`.
 ///
 /// # Errors
 ///
 /// See [`resolve_token_with`].
-pub async fn resolve_token(auth: &AuthArgs, config: &Config) -> Result<SecretString> {
-    resolve_token_with(auth, config, &TokioProcessRunner).await
+pub async fn resolve_token(config: &Config) -> Result<SecretString> {
+    resolve_token_with(config, &TokioProcessRunner).await
 }
 
-/// Resolve a [`SecretString`] using an explicit runner. Used in tests. CLI
-/// flags in `auth` override matching fields in `config`.
+/// Resolve a [`SecretString`] using an explicit runner. Used in tests.
 ///
 /// # Errors
 ///
 /// Returns an error if the askpass helper fails (timeout, non-zero exit, empty
 /// or oversize output) or if neither source is configured.
-pub async fn resolve_token_with<R: ProcessRunner>(
-    auth: &AuthArgs,
-    config: &Config,
-    runner: &R,
-) -> Result<SecretString> {
-    let askpass = auth.gh_askpass.as_deref().or(config.gh_askpass.as_deref());
-    let timeout_secs = auth
-        .askpass_timeout_secs
-        .unwrap_or(config.askpass_timeout_secs);
-
-    if let Some(argv) = askpass {
+async fn resolve_token_with<R: ProcessRunner>(config: &Config, runner: &R) -> Result<SecretString> {
+    if let Some(argv) = config.gh_askpass.as_deref() {
         if argv.is_empty() {
             return Err(anyhow!("`gh_askpass` is set but empty"));
         }
-        let dur = Duration::from_secs(timeout_secs);
+        let dur = Duration::from_secs(config.askpass_timeout_secs);
         return run_askpass(runner, argv, dur)
             .await
             .with_context(|| format!("askpass `{}` failed", shell_words::join(argv)));
@@ -177,13 +167,6 @@ mod tests {
         }
     }
 
-    fn empty_auth() -> AuthArgs {
-        AuthArgs {
-            gh_askpass: None,
-            askpass_timeout_secs: None,
-        }
-    }
-
     fn config_with_askpass() -> Config {
         Config {
             gh_askpass: Some(vec!["/fake/askpass".into()]),
@@ -199,7 +182,7 @@ mod tests {
             stdout: b"ghp_from_askpass\n".to_vec(),
             stderr: vec![],
         });
-        let token = resolve_token_with(&empty_auth(), &config_with_askpass(), &runner)
+        let token = resolve_token_with(&config_with_askpass(), &runner)
             .await
             .unwrap();
         assert_eq!(token.expose_secret(), "ghp_from_askpass");
@@ -212,7 +195,7 @@ mod tests {
             stdout: vec![],
             stderr: b"something went wrong".to_vec(),
         });
-        let err = resolve_token_with(&empty_auth(), &config_with_askpass(), &runner)
+        let err = resolve_token_with(&config_with_askpass(), &runner)
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -227,7 +210,7 @@ mod tests {
             stdout: vec![],
             stderr: vec![],
         });
-        let err = resolve_token_with(&empty_auth(), &config_with_askpass(), &runner)
+        let err = resolve_token_with(&config_with_askpass(), &runner)
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -241,7 +224,7 @@ mod tests {
             stdout: vec![b'a'; ASKPASS_STDOUT_LIMIT + 1],
             stderr: vec![],
         });
-        let err = resolve_token_with(&empty_auth(), &config_with_askpass(), &runner)
+        let err = resolve_token_with(&config_with_askpass(), &runner)
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -251,7 +234,7 @@ mod tests {
     #[tokio::test]
     async fn errors_on_timeout() {
         let runner = FakeRunner::new(SpawnOutcome::TimedOut);
-        let err = resolve_token_with(&empty_auth(), &config_with_askpass(), &runner)
+        let err = resolve_token_with(&config_with_askpass(), &runner)
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -263,7 +246,7 @@ mod tests {
         let runner = FakeRunner::new(SpawnOutcome::SpawnFailed(
             "no such file or directory".into(),
         ));
-        let err = resolve_token_with(&empty_auth(), &config_with_askpass(), &runner)
+        let err = resolve_token_with(&config_with_askpass(), &runner)
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -277,16 +260,14 @@ mod tests {
             gh_token: Some(SecretString::from("ghp_plain".to_string())),
             ..Config::default()
         };
-        let token = resolve_token_with(&empty_auth(), &config, &runner)
-            .await
-            .unwrap();
+        let token = resolve_token_with(&config, &runner).await.unwrap();
         assert_eq!(token.expose_secret(), "ghp_plain");
     }
 
     #[tokio::test]
     async fn errors_when_neither_source_configured() {
         let runner = FakeRunner::new(SpawnOutcome::TimedOut); // unused
-        let err = resolve_token_with(&empty_auth(), &Config::default(), &runner)
+        let err = resolve_token_with(&Config::default(), &runner)
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -300,9 +281,7 @@ mod tests {
             gh_askpass: Some(vec![]),
             ..Config::default()
         };
-        let err = resolve_token_with(&empty_auth(), &config, &runner)
-            .await
-            .unwrap_err();
+        let err = resolve_token_with(&config, &runner).await.unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("`gh_askpass` is set but empty"), "msg: {msg}");
     }
@@ -323,46 +302,7 @@ mod tests {
             askpass_timeout_secs: 5,
             ..Config::default()
         };
-        let token = resolve_token_with(&empty_auth(), &config, &runner)
-            .await
-            .unwrap();
+        let token = resolve_token_with(&config, &runner).await.unwrap();
         assert_eq!(token.expose_secret(), "ghp_from_op");
-    }
-
-    #[tokio::test]
-    async fn cli_askpass_overrides_config() {
-        let runner = FakeRunner::new(SpawnOutcome::Completed {
-            code: Some(0),
-            stdout: b"ghp_from_cli\n".to_vec(),
-            stderr: vec![],
-        });
-        let auth = AuthArgs {
-            gh_askpass: Some(vec!["cli-askpass".into()]),
-            askpass_timeout_secs: Some(99),
-        };
-        let token = resolve_token_with(&auth, &config_with_askpass(), &runner)
-            .await
-            .unwrap();
-        assert_eq!(token.expose_secret(), "ghp_from_cli");
-    }
-
-    #[tokio::test]
-    async fn cli_timeout_overrides_config_when_only_config_has_askpass() {
-        // With askpass only on config and a CLI-set timeout, the CLI timeout wins
-        // (we can't observe it directly through FakeRunner, but the resolution
-        // path still works end-to-end).
-        let runner = FakeRunner::new(SpawnOutcome::Completed {
-            code: Some(0),
-            stdout: b"ghp_x\n".to_vec(),
-            stderr: vec![],
-        });
-        let auth = AuthArgs {
-            gh_askpass: None,
-            askpass_timeout_secs: Some(1),
-        };
-        let token = resolve_token_with(&auth, &config_with_askpass(), &runner)
-            .await
-            .unwrap();
-        assert_eq!(token.expose_secret(), "ghp_x");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@
 use crate::pr::PrAction;
 use clap::{Parser, Subcommand};
 use log::LevelFilter;
+use serde::Serialize;
 
 #[derive(Debug, Parser)]
 #[command(name = "jj-gh", version, about)]
@@ -43,16 +44,18 @@ pub enum Command {
     },
 }
 
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Args, Serialize)]
 pub struct AuthArgs {
     /// Askpass helper command that prints a GitHub token on stdout;
     /// shell-words split, e.g. `--gh-askpass "op read op://Vault/gh/token"`.
     /// Default: `gh_askpass` in config, then `$GH_ASKPASS`.
     #[arg(long = "gh-askpass", value_name = "CMD", value_parser = shell_words::split)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gh_askpass: Option<Vec<String>>,
 
     /// Timeout in seconds for the askpass helper. Default: 20.
     #[arg(long = "askpass-timeout", value_name = "SECS")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub askpass_timeout_secs: Option<u64>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,18 @@ impl AutoMergeMethod {
     }
 }
 
+/// Build the layered figment without extracting. Callers (e.g. CLI dispatch)
+/// can stack additional providers (like `Serialized::defaults(&args)`) before
+/// calling [`extract`].
+#[must_use]
+pub fn load_figment() -> Figment {
+    let mut fig = defaults_figment();
+    for path in discover_layers() {
+        fig = fig.merge(JjConfProvider::from_file(path));
+    }
+    fig.merge(Serialized::defaults(EnvOverlay::from_env()))
+}
+
 /// Discover config layers and merge them into a [`Config`].
 ///
 /// # Errors
@@ -85,12 +97,7 @@ impl AutoMergeMethod {
 /// Returns an error if any layer is malformed or fails serde extraction, or if
 /// `pr_fetch_bookmark_template` references an unknown placeholder.
 pub fn load() -> Result<Config> {
-    let mut fig = defaults_figment();
-    for path in discover_layers() {
-        fig = fig.merge(JjConfProvider::from_file(path));
-    }
-    fig = fig.merge(Serialized::defaults(EnvOverlay::from_env()));
-    let config: Config = extract(&fig)?;
+    let config: Config = extract(&load_figment())?;
     validate(&config)?;
     Ok(config)
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -34,16 +34,9 @@ fn print_config() -> Result<()> {
 
 async fn check_auth() -> Result<()> {
     let config = config::load()?;
-    auth::resolve_token(&empty_auth(), &config).await?;
+    auth::resolve_token(&config).await?;
     println!("ok");
     Ok(())
-}
-
-fn empty_auth() -> crate::cli::AuthArgs {
-    crate::cli::AuthArgs {
-        gh_askpass: None,
-        askpass_timeout_secs: None,
-    }
 }
 
 async fn print_rev(rev: &str) -> Result<()> {
@@ -91,7 +84,7 @@ async fn print_rev(rev: &str) -> Result<()> {
 async fn print_pr_lookup(rev: &str) -> Result<()> {
     let jj = JjCli;
     let config = config::load()?;
-    let token = auth::resolve_token(&empty_auth(), &config).await?;
+    let token = auth::resolve_token(&config).await?;
     let gh = OctocrabGh::new(&token)?;
 
     let lookup = pr::resolve_pr(&jj, &gh, rev).await?;

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -55,7 +55,7 @@ pub struct PrCreated {
 }
 
 pub trait Gh {
-    /// First open PR whose `head` matches `head_spec`. Must be `owner:branch` —
+    /// First open PR whose `head` matches `head_spec`. Must be `owner:branch`;
     /// GitHub silently ignores the `head` filter without the owner prefix.
     ///
     /// # Errors

--- a/src/pr/editor.rs
+++ b/src/pr/editor.rs
@@ -3,7 +3,7 @@
 //! Production [`TempfileEditor`] writes the initial buffer to a tempfile, spawns
 //! the editor (inheriting stdio), then reads back. Tests use a fake.
 
-use crate::{config::Config, pr::CreateArgs};
+use crate::config::Config;
 use anyhow::{Context, Result, anyhow};
 use tokio::process::Command;
 
@@ -16,27 +16,23 @@ pub trait EditorRoundTrip {
     async fn edit(&self, argv: &[String], initial: &str) -> Result<String>;
 }
 
-/// Resolve the editor argv from CLI, config, and shell env.
+/// Resolve the editor argv from the merged config and shell env. CLI
+/// `--editor` is folded into `config.editor` by the figment overlay in
+/// `pr::dispatch`.
 ///
 /// Precedence (high to low):
-/// 1. `--editor` CLI flag
-/// 2. `editor` in config
-/// 3. `$VISUAL`
-/// 4. `$EDITOR`
+/// 1. `editor` in (merged) config, including `--editor` if passed
+/// 2. `$VISUAL`
+/// 3. `$EDITOR`
 ///
 /// # Errors
 ///
 /// Returns an error if no source produced a non-empty argv.
 pub fn resolve_editor_argv(
-    args: &CreateArgs,
     config: &Config,
     visual: Option<&str>,
     editor: Option<&str>,
 ) -> Result<Vec<String>> {
-    if let Some(argv) = args.editor.as_deref().filter(|v| !v.is_empty()) {
-        return Ok(argv.to_vec());
-    }
-
     if let Some(argv) = config.editor.as_deref().filter(|v| !v.is_empty()) {
         return Ok(argv.to_vec());
     }
@@ -89,74 +85,47 @@ impl EditorRoundTrip for TempfileEditor {
 mod tests {
     use super::*;
 
-    fn args() -> CreateArgs {
-        CreateArgs {
-            rev: "@-".into(),
-            base: None,
-            draft: false,
-            no_draft: false,
-            auto_merge: false,
-            no_auto_merge: false,
-            auto_merge_method: None,
-            template: None,
-            no_template: false,
-            editor: None,
-            auth: crate::cli::AuthArgs {
-                gh_askpass: None,
-                askpass_timeout_secs: None,
-            },
-        }
-    }
-
     fn cfg() -> Config {
         Config::default()
     }
 
     #[test]
-    fn cli_takes_priority() {
-        let mut a = args();
-        a.editor = Some(vec!["nvim".into(), "+7".into()]);
-        let argv = resolve_editor_argv(&a, &cfg(), Some("vim"), Some("vi")).unwrap();
-        assert_eq!(argv, vec!["nvim".to_string(), "+7".into()]);
-    }
-
-    #[test]
-    fn falls_back_to_config_when_no_cli() {
+    fn config_used_when_set() {
         let mut c = cfg();
         c.editor = Some(vec!["code".into(), "--wait".into()]);
-        let argv = resolve_editor_argv(&args(), &c, Some("vim"), Some("vi")).unwrap();
+        let argv = resolve_editor_argv(&c, Some("vim"), Some("vi")).unwrap();
         assert_eq!(argv, vec!["code".to_string(), "--wait".into()]);
     }
 
     #[test]
     fn visual_outranks_editor() {
-        let argv = resolve_editor_argv(&args(), &cfg(), Some("nvim +7"), Some("vi")).unwrap();
+        let argv = resolve_editor_argv(&cfg(), Some("nvim +7"), Some("vi")).unwrap();
         assert_eq!(argv, vec!["nvim".to_string(), "+7".into()]);
     }
 
     #[test]
     fn editor_env_used_when_visual_absent() {
-        let argv = resolve_editor_argv(&args(), &cfg(), None, Some("vi")).unwrap();
+        let argv = resolve_editor_argv(&cfg(), None, Some("vi")).unwrap();
         assert_eq!(argv, vec!["vi".to_string()]);
     }
 
     #[test]
-    fn empty_strings_are_skipped() {
-        let argv = resolve_editor_argv(&args(), &cfg(), Some(""), Some("vi")).unwrap();
+    fn empty_visual_falls_through_to_editor() {
+        let argv = resolve_editor_argv(&cfg(), Some(""), Some("vi")).unwrap();
         assert_eq!(argv, vec!["vi".to_string()]);
     }
 
     #[test]
-    fn empty_cli_falls_through() {
-        let mut a = args();
-        a.editor = Some(vec![]);
-        let argv = resolve_editor_argv(&a, &cfg(), None, Some("vi")).unwrap();
+    fn empty_config_editor_falls_through() {
+        let mut c = cfg();
+        c.editor = Some(vec![]);
+        let argv = resolve_editor_argv(&c, None, Some("vi")).unwrap();
         assert_eq!(argv, vec!["vi".to_string()]);
     }
 
     #[test]
     fn no_sources_errors() {
-        let err = resolve_editor_argv(&args(), &cfg(), None, None).unwrap_err();
+        let err = resolve_editor_argv(&cfg(), None, None).unwrap_err();
         assert!(err.to_string().contains("no editor configured"));
     }
 }

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -87,10 +87,10 @@ fn ensure_colocated(workspace_root: &Path) -> Result<()> {
     ))
 }
 
-fn resolve_template<'a>(args: &'a FetchArgs, config: &'a Config) -> &'a str {
-    args.template
+fn resolve_template(config: &Config) -> &str {
+    config
+        .pr_fetch_bookmark_template
         .as_deref()
-        .or(config.pr_fetch_bookmark_template.as_deref())
         .unwrap_or(DEFAULT_FETCH_TEMPLATE)
 }
 
@@ -127,7 +127,7 @@ pub async fn run_with<J: Jj, G: Gh, GO: GitOps>(
 
     let pr = gh.get_pr(&owner, &repo, args.pr).await?;
 
-    let template = resolve_template(args, config);
+    let template = resolve_template(config);
     let bookmark = bookmark_template::render(
         template,
         &Fields {
@@ -384,7 +384,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cli_template_overrides_config() {
+    async fn config_template_is_used() {
         let dir = colocated_workspace();
         let jj = jj_for(&dir, Some("git@github.com:o/r.git"));
         let gh = gh_for(details(), "o", "r");
@@ -393,21 +393,15 @@ mod tests {
             fetches: RefCell::new(vec![]),
         };
         let config = Config {
-            pr_fetch_bookmark_template: Some("from-config-{number}".into()),
+            pr_fetch_bookmark_template: Some("cfg-{number}-{user}".into()),
             ..Config::default()
         };
 
-        run_with(
-            &jj,
-            &gh,
-            &git,
-            &config,
-            &args(1234, Some("cli-{number}-{user}"), false),
-        )
-        .await
-        .unwrap();
+        run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+            .await
+            .unwrap();
 
-        assert_eq!(git.fetches.borrow()[0].bookmark, "cli-1234-octocat");
+        assert_eq!(git.fetches.borrow()[0].bookmark, "cfg-1234-octocat");
     }
 
     #[tokio::test]
@@ -439,17 +433,14 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
+        let config = Config {
+            pr_fetch_bookmark_template: Some("pr-{nope}".into()),
+            ..Config::default()
+        };
 
-        let err = run_with(
-            &jj,
-            &gh,
-            &git,
-            &config,
-            &args(1234, Some("pr-{nope}"), false),
-        )
-        .await
-        .unwrap_err();
+        let err = run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+            .await
+            .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown placeholder"), "msg: {msg}");
         assert!(msg.contains("{nope}"), "msg: {msg}");
@@ -525,17 +516,14 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
+        let config = Config {
+            pr_fetch_bookmark_template: Some("pr-{number}-{user}".into()),
+            ..Config::default()
+        };
 
-        let err = run_with(
-            &jj,
-            &gh,
-            &git,
-            &config,
-            &args(1234, Some("pr-{number}-{user}"), false),
-        )
-        .await
-        .unwrap_err();
+        let err = run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+            .await
+            .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("{user}"), "msg: {msg}");
         assert!(

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -20,6 +20,8 @@ use crate::{
 };
 use anyhow::{Context, Result, anyhow};
 use clap::Subcommand;
+use figment::providers::Serialized;
+use serde::Serialize;
 
 #[derive(Debug, Subcommand)]
 pub enum PrAction {
@@ -38,25 +40,29 @@ pub enum PrAction {
     AutoMerge(AutoMergeArgs),
 }
 
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Args, Serialize)]
 pub struct AutoMergeArgs {
     /// PR number, or revision ID to look up a PR from.
     #[arg(value_name = "PR_NUM|REV")]
+    #[serde(skip)]
     pub number_or_rev: String,
 
     /// Merge method used when enabling auto-merge. Overrides config
     /// `auto_merge_method` (default `merge`).
     #[arg(long = "method", short = 'm', value_name = "METHOD", value_enum)]
+    #[serde(rename = "auto_merge_method", skip_serializing_if = "Option::is_none")]
     pub method: Option<AutoMergeMethod>,
 
     #[command(flatten)]
+    #[serde(flatten)]
     pub auth: AuthArgs,
 }
 
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Args, Serialize)]
 pub struct FetchArgs {
     /// PR number to fetch.
     #[arg(value_name = "PR_NUM")]
+    #[serde(skip)]
     pub pr: u64,
 
     /// Override the bookmark template. Default: `pr_fetch_bookmark_template`
@@ -65,85 +71,121 @@ pub struct FetchArgs {
     /// (head.user.login), `{repo}` (head.repo.name). `{{` / `}}` are literal
     /// braces.
     #[arg(short = 't', long, value_name = "STR")]
+    #[serde(
+        rename = "pr_fetch_bookmark_template",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub template: Option<String>,
 
     /// Replace an existing local bookmark of the same name.
     #[arg(short = 'f', long)]
+    #[serde(skip)]
     pub force: bool,
 
     #[command(flatten)]
+    #[serde(flatten)]
     pub auth: AuthArgs,
 }
 
-#[derive(Debug, clap::Args)]
-#[expect(clippy::struct_excessive_bools)]
+#[derive(Debug, clap::Args, Serialize)]
 pub struct CreateArgs {
     /// Revision to create the PR from.
     #[arg(value_name = "REV")]
+    #[serde(skip)]
     pub rev: String,
 
     /// Override the base bookmark. Default: closest ancestor bookmark on the
     /// stack, falling back to the remote's `main` / `master` / configured
     /// `default_base_branch`.
     #[arg(long, value_name = "BRANCH")]
+    #[serde(skip)]
     pub base: Option<String>,
 
     /// Force the PR to be a draft. Overrides config (default: `draft = false`).
-    #[arg(long)]
-    pub draft: bool,
+    /// Use `--draft=false` or `--no-draft` to force non-draft.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        default_value_if("no_draft", "true", Some("false")),
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
 
-    /// Force the PR to be non-draft. Overrides config.
+    /// Force the PR to be non-draft. Overrides config. Equivalent to `--draft false`.
     #[arg(long = "no-draft", conflicts_with = "draft")]
+    #[serde(skip)]
     pub no_draft: bool,
 
     /// Enable auto-merge on the PR after creation (merges once required checks
-    /// pass). Overrides config (default: `auto_merge = false`).
-    #[arg(long = "auto-merge")]
-    pub auto_merge: bool,
+    /// pass). Overrides config (default: `auto_merge = false`). Use
+    /// `--auto-merge=false` or `--no-auto-merge` force no auto merge.
+    #[arg(
+        long = "auto-merge",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        default_value_if("no_auto_merge", "true", Some("false")),
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_merge: Option<bool>,
 
-    /// Disable auto-merge on the created PR. Overrides config.
+    /// Disable auto-merge on the created PR. Overrides config. Equivalent to
+    /// `--auto-merge=false`.
     #[arg(long = "no-auto-merge", conflicts_with = "auto_merge")]
+    #[serde(skip)]
     pub no_auto_merge: bool,
 
     /// Merge method used when auto-merge is enabled. Overrides config
     /// `auto_merge_method` (default `merge`).
     #[arg(long = "auto-merge-method", value_name = "METHOD", value_enum)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_merge_method: Option<AutoMergeMethod>,
 
     /// Template path or name under `.github/PULL_REQUEST_TEMPLATE/`. Default:
     /// `template_path` in config, else auto-detect
-    /// `.github/PULL_REQUEST_TEMPLATE.md`.
+    /// `.github/PULL_REQUEST_TEMPLATE.md`. CLI path resolution needs the repo
+    /// root, so this stays out of figment merging and is handled by
+    /// `resolve_template_path` at handler time.
     #[arg(long, value_name = "PATH_OR_NAME")]
+    #[serde(skip)]
     pub template: Option<String>,
 
     /// Skip template selection entirely.
     #[arg(long = "no-template", conflicts_with = "template")]
+    #[serde(skip)]
     pub no_template: bool,
 
     /// Editor command; shell-words split, e.g. `--editor "nvim +7"`. Default:
     /// `editor` in config, then `$VISUAL`, then `$EDITOR`.
     #[arg(short = 'e', long, value_name = "CMD", value_parser = shell_words::split)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub editor: Option<Vec<String>>,
 
     #[command(flatten)]
+    #[serde(flatten)]
     pub auth: AuthArgs,
 }
 
 pub async fn dispatch(action: PrAction) -> Result<()> {
-    let config = config::load()?;
-    let auth = match &action {
-        PrAction::Create(a) => &a.auth,
-        PrAction::Fetch(a) => &a.auth,
-        PrAction::AutoMerge(a) => &a.auth,
+    let mut fig = config::load_figment();
+    fig = match &action {
+        PrAction::Create(a) => fig.merge(Serialized::defaults(a)),
+        PrAction::Fetch(a) => fig.merge(Serialized::defaults(a)),
+        PrAction::AutoMerge(a) => fig.merge(Serialized::defaults(a)),
     };
-    let token = auth::resolve_token(auth, &config).await?;
+    let config = config::extract(&fig)?;
+    config::validate(&config)?;
+
+    let token = auth::resolve_token(&config).await?;
     let jj = jj::real::JjCli;
     let gh = gh::real::OctocrabGh::new(&token)?;
     let editor = TempfileEditor;
     match action {
         PrAction::Create(args) => create(&jj, &gh, &editor, &config, &args).await?,
         PrAction::Fetch(args) => fetch::run(&jj, &gh, &config, &args).await?,
-        PrAction::AutoMerge(args) => auto_merge(&jj, &gh, &config, &args).await?,
+        PrAction::AutoMerge(args) => auto_merge(&jj, &gh, &config, &args.number_or_rev).await?,
     }
 
     Ok(())
@@ -204,12 +246,12 @@ pub async fn resolve_pr<J: Jj, G: Gh>(jj: &J, gh: &G, rev: &str) -> Result<PrLoo
     })
 }
 
-async fn auto_merge<J, G>(jj: &J, gh: &G, config: &Config, args: &AutoMergeArgs) -> Result<()>
+async fn auto_merge<J, G>(jj: &J, gh: &G, config: &Config, number_or_rev: &str) -> Result<()>
 where
     J: Jj,
     G: Gh,
 {
-    let pr = if let Ok(num) = args.number_or_rev.parse::<u64>() {
+    let pr = if let Ok(num) = number_or_rev.parse::<u64>() {
         let origin_url = jj
             .remote_url("origin")
             .await?
@@ -218,11 +260,10 @@ where
         let target = remote::target(&origin_url, upstream_url.as_deref())?;
         gh.get_pr(&target.owner, &target.repo, num).await?
     } else {
-        let lookup = resolve_pr(jj, gh, &args.number_or_rev).await?;
+        let lookup = resolve_pr(jj, gh, number_or_rev).await?;
         let summary = lookup.summary.ok_or_else(|| {
             anyhow!(
-                "no open PR for revision `{}` (head `{}`)",
-                args.number_or_rev,
+                "no open PR for revision `{number_or_rev}` (head `{}`)",
                 lookup.head_spec,
             )
         })?;
@@ -230,8 +271,7 @@ where
             .await?
     };
 
-    let method = args.method.unwrap_or(config.auto_merge_method);
-    gh.enable_auto_merge(&pr.graphql_node_id, method)
+    gh.enable_auto_merge(&pr.graphql_node_id, config.auto_merge_method)
         .await
         .with_context(|| format!("enabling auto-merge on #{}", pr.number))?;
 
@@ -310,16 +350,16 @@ where
         title: default_title,
         base: base.clone(),
         labels: vec![],
-        draft: resolve_draft(args, config),
-        auto_merge: resolve_auto_merge(args, config),
-        auto_merge_method: resolve_auto_merge_method(args, config),
+        draft: config.draft,
+        auto_merge: config.auto_merge,
+        auto_merge_method: config.auto_merge_method,
     };
     let initial_buffer = initial_fm.render(raw_template.as_deref().unwrap_or(""))?;
     let raw_template_body = raw_template.unwrap_or_default();
 
     let visual = std::env::var("VISUAL").ok();
     let editor_env = std::env::var("EDITOR").ok();
-    let editor_argv = resolve_editor_argv(args, config, visual.as_deref(), editor_env.as_deref())?;
+    let editor_argv = resolve_editor_argv(config, visual.as_deref(), editor_env.as_deref())?;
     let edited = editor.edit(&editor_argv, &initial_buffer).await?;
     let (final_fm, body) = Frontmatter::parse(&edited)?;
     validation::validate(&final_fm, &body, &raw_template_body)?;
@@ -379,34 +419,6 @@ fn resolve_base(args: &CreateArgs, ancestor: Option<&str>, detected: &str) -> St
         .unwrap_or_else(|| detected.to_string())
 }
 
-fn resolve_draft(args: &CreateArgs, config: &Config) -> bool {
-    if args.draft {
-        return true;
-    }
-
-    if args.no_draft {
-        return false;
-    }
-
-    config.draft
-}
-
-fn resolve_auto_merge(args: &CreateArgs, config: &Config) -> bool {
-    if args.auto_merge {
-        return true;
-    }
-
-    if args.no_auto_merge {
-        return false;
-    }
-
-    config.auto_merge
-}
-
-fn resolve_auto_merge_method(args: &CreateArgs, config: &Config) -> AutoMergeMethod {
-    args.auto_merge_method.unwrap_or(config.auto_merge_method)
-}
-
 fn load_template_for<J: Jj>(args: &CreateArgs, config: &Config, _jj: &J) -> Result<Option<String>> {
     let repo_root = std::env::current_dir().context("could not read cwd")?;
     let fs = RealFs;
@@ -420,13 +432,13 @@ fn load_template_for<J: Jj>(args: &CreateArgs, config: &Config, _jj: &J) -> Resu
 mod tests {
     use super::*;
 
-    fn cli(draft: bool, no_draft: bool) -> CreateArgs {
+    fn cli() -> CreateArgs {
         CreateArgs {
             rev: "@-".into(),
             base: None,
-            draft,
-            no_draft,
-            auto_merge: false,
+            draft: None,
+            no_draft: false,
+            auto_merge: None,
             no_auto_merge: false,
             auto_merge_method: None,
             template: None,
@@ -439,8 +451,28 @@ mod tests {
         }
     }
 
+    fn merge_into_config(
+        config_draft: Option<bool>,
+        config_auto: Option<bool>,
+        config_method: Option<AutoMergeMethod>,
+        args: &CreateArgs,
+    ) -> Config {
+        let mut fig = config::defaults_figment();
+        if let Some(v) = config_draft {
+            fig = fig.merge(Serialized::default("draft", v));
+        }
+        if let Some(v) = config_auto {
+            fig = fig.merge(Serialized::default("auto_merge", v));
+        }
+        if let Some(v) = config_method {
+            fig = fig.merge(Serialized::default("auto_merge_method", v));
+        }
+        fig = fig.merge(Serialized::defaults(args));
+        config::extract(&fig).unwrap()
+    }
+
     fn args_with_base(base: Option<&str>) -> CreateArgs {
-        let mut a = cli(false, false);
+        let mut a = cli();
         a.base = base.map(str::to_string);
         a
     }
@@ -466,88 +498,133 @@ mod tests {
         assert_eq!(resolve_base(&args_with_base(None), None, "main"), "main");
     }
 
-    fn cfg_with_draft(draft: bool) -> Config {
-        Config {
-            draft,
-            ..Config::default()
+    #[test]
+    fn cli_draft_overrides_config() {
+        let mut a = cli();
+        a.draft = Some(true);
+        let c = merge_into_config(Some(false), None, None, &a);
+        assert!(c.draft);
+    }
+
+    #[test]
+    fn cli_no_draft_overrides_config() {
+        let mut a = cli();
+        a.draft = Some(false);
+        let c = merge_into_config(Some(true), None, None, &a);
+        assert!(!c.draft);
+    }
+
+    #[test]
+    fn draft_defaults_to_config_when_cli_unset() {
+        let c1 = merge_into_config(Some(true), None, None, &cli());
+        assert!(c1.draft);
+        let c2 = merge_into_config(Some(false), None, None, &cli());
+        assert!(!c2.draft);
+    }
+
+    #[test]
+    fn cli_auto_merge_overrides_config() {
+        let mut a = cli();
+        a.auto_merge = Some(true);
+        let c = merge_into_config(None, Some(false), None, &a);
+        assert!(c.auto_merge);
+    }
+
+    #[test]
+    fn cli_no_auto_merge_overrides_config() {
+        let mut a = cli();
+        a.auto_merge = Some(false);
+        let c = merge_into_config(None, Some(true), None, &a);
+        assert!(!c.auto_merge);
+    }
+
+    #[test]
+    fn auto_merge_defaults_to_config_when_cli_unset() {
+        let c = merge_into_config(None, Some(true), None, &cli());
+        assert!(c.auto_merge);
+    }
+
+    #[test]
+    fn cli_auto_merge_method_overrides_config() {
+        let mut a = cli();
+        a.auto_merge_method = Some(AutoMergeMethod::Squash);
+        let c = merge_into_config(None, None, Some(AutoMergeMethod::Rebase), &a);
+        assert_eq!(c.auto_merge_method, AutoMergeMethod::Squash);
+    }
+
+    #[test]
+    fn auto_merge_method_defaults_to_config_when_cli_unset() {
+        let c = merge_into_config(None, None, Some(AutoMergeMethod::Rebase), &cli());
+        assert_eq!(c.auto_merge_method, AutoMergeMethod::Rebase);
+    }
+
+    fn empty_auth() -> crate::cli::AuthArgs {
+        crate::cli::AuthArgs {
+            gh_askpass: None,
+            askpass_timeout_secs: None,
         }
     }
 
     #[test]
-    fn draft_flag_forces_true() {
-        assert!(resolve_draft(&cli(true, false), &cfg_with_draft(false)));
-    }
-
-    #[test]
-    fn no_draft_flag_forces_false_even_when_config_draft() {
-        assert!(!resolve_draft(&cli(false, true), &cfg_with_draft(true)));
-    }
-
-    #[test]
-    fn draft_defaults_to_config() {
-        assert!(resolve_draft(&cli(false, false), &cfg_with_draft(true)));
-        assert!(!resolve_draft(&cli(false, false), &cfg_with_draft(false)));
-    }
-
-    fn cfg_with_auto_merge(auto_merge: bool, method: AutoMergeMethod) -> Config {
-        Config {
-            auto_merge,
-            auto_merge_method: method,
-            ..Config::default()
-        }
-    }
-
-    fn cli_with_auto_merge(
-        auto_merge: bool,
-        no_auto_merge: bool,
-        method: Option<AutoMergeMethod>,
-    ) -> CreateArgs {
-        let mut a = cli(false, false);
-        a.auto_merge = auto_merge;
-        a.no_auto_merge = no_auto_merge;
-        a.auto_merge_method = method;
-        a
-    }
-
-    #[test]
-    fn auto_merge_flag_forces_true() {
-        assert!(resolve_auto_merge(
-            &cli_with_auto_merge(true, false, None),
-            &cfg_with_auto_merge(false, AutoMergeMethod::Merge),
-        ));
-    }
-
-    #[test]
-    fn no_auto_merge_flag_forces_false() {
-        assert!(!resolve_auto_merge(
-            &cli_with_auto_merge(false, true, None),
-            &cfg_with_auto_merge(true, AutoMergeMethod::Merge),
-        ));
-    }
-
-    #[test]
-    fn auto_merge_defaults_to_config() {
-        assert!(resolve_auto_merge(
-            &cli_with_auto_merge(false, false, None),
-            &cfg_with_auto_merge(true, AutoMergeMethod::Merge),
-        ));
-    }
-
-    #[test]
-    fn auto_merge_method_cli_wins() {
-        let m = resolve_auto_merge_method(
-            &cli_with_auto_merge(true, false, Some(AutoMergeMethod::Squash)),
-            &cfg_with_auto_merge(false, AutoMergeMethod::Rebase),
+    fn fetch_cli_template_overrides_config() {
+        let args = FetchArgs {
+            pr: 1,
+            template: Some("cli-{number}".into()),
+            force: false,
+            auth: empty_auth(),
+        };
+        let fig = config::defaults_figment()
+            .merge(Serialized::default(
+                "pr_fetch_bookmark_template",
+                "cfg-{number}",
+            ))
+            .merge(Serialized::defaults(&args));
+        let c = config::extract(&fig).unwrap();
+        assert_eq!(
+            c.pr_fetch_bookmark_template.as_deref(),
+            Some("cli-{number}")
         );
-        assert_eq!(m, AutoMergeMethod::Squash);
     }
 
     #[test]
-    fn auto_merge_method_defaults_to_config() {
-        let m = resolve_auto_merge_method(
-            &cli_with_auto_merge(true, false, None),
-            &cfg_with_auto_merge(true, AutoMergeMethod::Rebase),
+    fn auto_merge_args_method_overrides_config_via_rename() {
+        let args = AutoMergeArgs {
+            number_or_rev: "1".into(),
+            method: Some(AutoMergeMethod::Squash),
+            auth: empty_auth(),
+        };
+        let fig = config::defaults_figment()
+            .merge(Serialized::default(
+                "auto_merge_method",
+                AutoMergeMethod::Rebase,
+            ))
+            .merge(Serialized::defaults(&args));
+        let c = config::extract(&fig).unwrap();
+        assert_eq!(c.auto_merge_method, AutoMergeMethod::Squash);
+    }
+
+    #[test]
+    fn auth_cli_overrides_config_via_flatten() {
+        let args = AutoMergeArgs {
+            number_or_rev: "1".into(),
+            method: None,
+            auth: crate::cli::AuthArgs {
+                gh_askpass: Some(vec!["cli-askpass".into()]),
+                askpass_timeout_secs: Some(99),
+            },
+        };
+        let fig = config::defaults_figment()
+            .merge(Serialized::default(
+                "gh_askpass",
+                vec!["cfg-askpass".to_string()],
+            ))
+            .merge(Serialized::default("askpass_timeout_secs", 5u64))
+            .merge(Serialized::defaults(&args));
+        let c = config::extract(&fig).unwrap();
+        assert_eq!(
+            c.gh_askpass.as_deref(),
+            Some(&["cli-askpass".to_string()][..])
         );
-        assert_eq!(m, AutoMergeMethod::Rebase);
+        assert_eq!(c.askpass_timeout_secs, 99);
     }
 }

--- a/src/pr/template.rs
+++ b/src/pr/template.rs
@@ -101,9 +101,9 @@ mod tests {
         CreateArgs {
             rev: rev.into(),
             base: None,
-            draft: false,
+            draft: None,
             no_draft: false,
-            auto_merge: false,
+            auto_merge: None,
             no_auto_merge: false,
             auto_merge_method: None,
             template: None,


### PR DESCRIPTION
Simplify argument handling by using `figment` more.

So we end up with basically a single shared struct that represents all required options, merged/resolved from layers: global config, local config, environment variables, CLI arguments.
