### PR TITLE
fix(nix): Fix jj alias definition in home-manager module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -116,6 +116,7 @@ in
           "exec"
           "--"
           "${cfg.package}/bin/jj-gh"
+          "--"
           "pr"
         ];
       }


### PR DESCRIPTION
Fix `jj` alias definition to use `--`
