### PR TITLE
fix(lints): Show warnings normally in LSP but deny in flake checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,5 @@ tokio = { version = "1", features = ["macros", "rt", "process", "time"] }
 toml = "1"
 url = "2"
 
-[lints.rust]
-warnings = "deny"
-
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }


### PR DESCRIPTION
Show warnings normally in LSP but deny in flake checks
