### PR TITLE
feat(cli): Add `pr log` subcommand

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -11,6 +11,7 @@ This document contains the help content for the `jj-gh` command-line program.
 - [`jj-gh pr create`↴](#jj-gh-pr-create)
 - [`jj-gh pr fetch`↴](#jj-gh-pr-fetch)
 - [`jj-gh pr auto-merge`↴](#jj-gh-pr-auto-merge)
+- [`jj-gh pr log`↴](#jj-gh-pr-log)
 - [`jj-gh debug`↴](#jj-gh-debug)
 - [`jj-gh debug config`↴](#jj-gh-debug-config)
 - [`jj-gh debug auth`↴](#jj-gh-debug-auth)
@@ -45,6 +46,7 @@ Commands to work with PRs
 - `create` — Open your preferred editor to create a PR from a revision. Opens your editor to a markdown file where you can write the PR description, and set PR metadata like title, labels, auto-merge, etc. via the markdown frontmatter. This supports stacked PRs; by default the base branch is set to the closest ancestor bookmark if one exists, otherwise `trunk()`
 - `fetch` — Fetch a pull request into a local bookmark. This command accepts either a revision ID or a PR number. If given a revision ID, the PR number will be looked up via the API. Requires a colocated git repository; the special `refs/pull/123/head` ref is fetched via `git` because `jj` cannot yet fetch arbitrary refs
 - `auto-merge` — Enable auto-merge on a PR. Accepts either a PR number or a revision; with a revision, the PR is looked up by the rev's local bookmark. Fails if the repo does not allow auto-merge
+- `log` — Like `jj log`, but injects PR metadata (number, CI status, URL) as template aliases keyed by `commit_id` and renders inline PR info in the default template. Any arguments after `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`
 
 ## `jj-gh pr create`
 
@@ -116,6 +118,28 @@ Enable auto-merge on a PR. Accepts either a PR number or a revision; with a revi
 
 - `--gh-askpass <CMD>` — Askpass helper command that prints a GitHub token on stdout; shell-words split, e.g. `--gh-askpass "op read op://Vault/gh/token"`. Default: `gh_askpass` in config, then `$GH_ASKPASS`
 - `--askpass-timeout <SECS>` — Timeout in seconds for the askpass helper. Default: 20
+
+## `jj-gh pr log`
+
+Like `jj log`, but injects PR metadata (number, CI status, URL) as template aliases keyed by `commit_id` and renders inline PR info in the default template. Any arguments after `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`
+
+**Usage:** `jj-gh pr log [OPTIONS] [-- <JJ_LOG_ARGS>...]`
+
+**Command Alias:** `l`
+
+###### **Arguments:**
+
+- `<JJ_LOG_ARGS>` — Arguments forwarded verbatim to the underlying `jj log` invocation. Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`. If you pass `-T` / `--template`, the default PR-aware template is not applied; use the injected aliases (`pr_number`, `pr_url`, `pr_ci_status`, `pr_meta`) from your own template. `pr_meta` is the pre-formatted hyperlinked PR number + colored CI icon (empty for commits without a PR)
+
+###### **Options:**
+
+- `--gh-askpass <CMD>` — Askpass helper command that prints a GitHub token on stdout; shell-words split, e.g. `--gh-askpass "op read op://Vault/gh/token"`. Default: `gh_askpass` in config, then `$GH_ASKPASS`
+- `--askpass-timeout <SECS>` — Timeout in seconds for the askpass helper. Default: 20
+- `--nerdfonts` — Force enable the use of nerdfont icons in the default `pr log` template. Overrides config
+
+  Default value: `true`
+
+- `--no-nerdfonts` — Force the default `pr log` template not to use nerdfont icons. Overrides config. Equivalent to `--nerdfonts=false`
 
 ## `jj-gh debug`
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ editor = [
   "nvim",
   "+9",   # +9 jumps your cursor past the frontmatter
 ]
+
+# enable or disable the use of nerdfont icons
+# (e.g. in the `pr log` default template)
+nerdfonts = true
 ```
 
 Precedence (low to high):

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - Intelligently supports stacked PRs by choosing the correct base if the revision has an ancestor bookmark for which an open PR exists
 - Enable auto-merge for a PR by its revision ID, without having to know/find its PR number (e.g. `jj pr auto-merge zqxy`)
 - Create local bookmarks for PRs, including across forks (e.g. `jj pr fetch 1234 && jj new pr-1234/...`, useful for testing PRs to OSS repos)
+- Show PR metadata like number and CI status in commit graph (e.g. `jj pr log`)
 
 all from the comfort of your terminal, without touching GitHub's clunky web UI.
 Works great when combined with the [jj megamerge](https://isaaccorbrey.com/notes/jujutsu-megamerges-for-fun-and-profit) workflow!

--- a/graphql.config.toml
+++ b/graphql.config.toml
@@ -1,0 +1,1 @@
+schema = "https://docs.github.com/public/fpt/schema.docs.graphql"

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
     pub auto_merge_method: AutoMergeMethod,
     pub editor: Option<Vec<String>>,
     pub pr_fetch_bookmark_template: Option<String>,
+    pub nerdfonts: bool,
 }
 
 impl Default for Config {
@@ -51,6 +52,7 @@ impl Default for Config {
             auto_merge_method: AutoMergeMethod::default(),
             editor: None,
             pr_fetch_bookmark_template: None,
+            nerdfonts: true,
         }
     }
 }
@@ -96,7 +98,7 @@ pub fn load_figment() -> Figment {
 ///
 /// Returns an error if any layer is malformed or fails serde extraction, or if
 /// `pr_fetch_bookmark_template` references an unknown placeholder.
-pub fn load() -> Result<Config> {
+pub fn debug_load() -> Result<Config> {
     let config: Config = extract(&load_figment())?;
     validate(&config)?;
     Ok(config)
@@ -280,17 +282,31 @@ struct DefaultsOverlay {
     draft: bool,
     auto_merge: bool,
     auto_merge_method: AutoMergeMethod,
+    nerdfonts: bool,
 }
 
 impl DefaultsOverlay {
     fn from_defaults() -> Self {
-        let d = Config::default();
+        let Config {
+            askpass_timeout_secs,
+            auto_merge,
+            auto_merge_method,
+            default_base_branch,
+            draft,
+            nerdfonts,
+            editor: _,
+            gh_askpass: _,
+            gh_token: _,
+            pr_fetch_bookmark_template: _,
+            template_path: _,
+        } = Config::default();
         Self {
-            askpass_timeout_secs: d.askpass_timeout_secs,
-            default_base_branch: d.default_base_branch,
-            draft: d.draft,
-            auto_merge: d.auto_merge,
-            auto_merge_method: d.auto_merge_method,
+            askpass_timeout_secs,
+            default_base_branch,
+            draft,
+            auto_merge,
+            auto_merge_method,
+            nerdfonts,
         }
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -27,13 +27,13 @@ pub async fn dispatch(action: DebugAction) -> Result<()> {
 }
 
 fn print_config() -> Result<()> {
-    let config = config::load()?;
+    let config = config::debug_load()?;
     println!("{config:#?}");
     Ok(())
 }
 
 async fn check_auth() -> Result<()> {
-    let config = config::load()?;
+    let config = config::debug_load()?;
     auth::resolve_token(&config).await?;
     println!("ok");
     Ok(())
@@ -83,7 +83,7 @@ async fn print_rev(rev: &str) -> Result<()> {
 
 async fn print_pr_lookup(rev: &str) -> Result<()> {
     let jj = JjCli;
-    let config = config::load()?;
+    let config = config::debug_load()?;
     let token = auth::resolve_token(&config).await?;
     let gh = OctocrabGh::new(&token)?;
 

--- a/src/gh/enable_auto_merge.gql
+++ b/src/gh/enable_auto_merge.gql
@@ -1,9 +1,6 @@
-mutation EnableAutoMerge($prId: ID!, $method: PullRequestMergeMethod!) {
+mutation EnableAutoMerge($pr_id: ID!, $method: PullRequestMergeMethod!) {
   enablePullRequestAutoMerge(
-    input: {
-      pullRequestId: $prId,
-      mergeMethod: $method
-    }
+    input: { pullRequestId: $pr_id, mergeMethod: $method }
   ) {
     pullRequest {
       id

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -116,11 +116,23 @@ pub trait Gh {
     /// is already mergeable.
     async fn enable_auto_merge(&self, pr_node_id: &str, method: AutoMergeMethod) -> Result<()>;
 
-    /// Fetch open PRs with head commit SHA and CI status. Used by `pr log` to
-    /// build a `commit_id` → PR mapping for jj template aliases.
+    /// Fetch open PRs with head commit SHA and CI status, scoped to the given
+    /// `branches` (head ref names). Used by `pr log` to build a `commit_id` →
+    /// PR mapping for jj template aliases.
+    ///
+    /// The search is `is:pr is:open head:<b1> head:<b2> ...`. Implementations
+    /// may batch large `branches` lists into multiple requests to stay under
+    /// GitHub's search query length limit.
+    ///
+    /// Returns an empty vec when `branches` is empty (skips the API call).
     ///
     /// # Errors
     ///
     /// Propagates GraphQL/API errors.
-    async fn local_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PrWithCiStatus>>;
+    async fn local_pulls(
+        &self,
+        owner: &str,
+        repo: &str,
+        branches: &[String],
+    ) -> Result<Vec<PrWithCiStatus>>;
 }

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -6,8 +6,11 @@
 use crate::config::AutoMergeMethod;
 use anyhow::Result;
 
+mod prs_with_ci_status;
+
 pub mod real;
 pub mod remote;
+pub use prs_with_ci_status::{CiStatus, PrWithCiStatus};
 
 /// Summary of an existing pull request. Just the fields we render.
 #[derive(Debug, Clone)]
@@ -112,4 +115,12 @@ pub trait Gh {
     /// auto-merge enabled, required branch protections are missing, or the PR
     /// is already mergeable.
     async fn enable_auto_merge(&self, pr_node_id: &str, method: AutoMergeMethod) -> Result<()>;
+
+    /// Fetch open PRs with head commit SHA and CI status. Used by `pr log` to
+    /// build a `commit_id` → PR mapping for jj template aliases.
+    ///
+    /// # Errors
+    ///
+    /// Propagates GraphQL/API errors.
+    async fn local_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PrWithCiStatus>>;
 }

--- a/src/gh/prs_with_ci_status.gql
+++ b/src/gh/prs_with_ci_status.gql
@@ -1,0 +1,25 @@
+query PrsWithCiStatus($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    # TODO improve the accuracy of this query, can we figure out ahead of time
+    # what filters might get the relevant PRs? Find all revisions in your
+    # direct ancestor tree up to `trunk()`? First 50 is naive.
+    pullRequests(
+      first: 50
+      states: [OPEN]
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        id
+        number
+        url
+        title
+        headRefOid
+        isDraft
+        isInMergeQueue
+        statusCheckRollup {
+          state
+        }
+      }
+    }
+  }
+}

--- a/src/gh/prs_with_ci_status.gql
+++ b/src/gh/prs_with_ci_status.gql
@@ -1,14 +1,7 @@
-query PrsWithCiStatus($owner: String!, $repo: String!) {
-  repository(owner: $owner, name: $repo) {
-    # TODO improve the accuracy of this query, can we figure out ahead of time
-    # what filters might get the relevant PRs? Find all revisions in your
-    # direct ancestor tree up to `trunk()`? First 50 is naive.
-    pullRequests(
-      first: 50
-      states: [OPEN]
-      orderBy: { field: UPDATED_AT, direction: DESC }
-    ) {
-      nodes {
+query PrsWithCiStatus($query: String!) {
+  search(query: $query, type: ISSUE, first: 100) {
+    nodes {
+      ... on PullRequest {
         id
         number
         url

--- a/src/gh/prs_with_ci_status.rs
+++ b/src/gh/prs_with_ci_status.rs
@@ -1,0 +1,126 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+enum StatusState {
+    ERROR,
+    EXPECTED,
+    FAILURE,
+    PENDING,
+    SUCCESS,
+}
+
+#[derive(Deserialize)]
+struct StatusCheckRollup {
+    state: StatusState,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequest {
+    id: String,
+    number: u64,
+    url: String,
+    title: String,
+    head_ref_oid: String,
+    is_draft: bool,
+    is_in_merge_queue: bool,
+    status_check_rollup: Option<StatusCheckRollup>,
+}
+
+#[derive(Deserialize)]
+struct PullRequestsConnection {
+    nodes: Vec<PullRequest>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Repository {
+    pull_requests: PullRequestsConnection,
+}
+
+#[derive(Deserialize)]
+pub struct PrsWithCiStatusInternal {
+    repository: Repository,
+}
+
+/// Status of CI checks for a pull request.
+#[derive(Debug, Clone, Copy)]
+pub enum CiStatus {
+    /// All checks succeeded.
+    Success,
+    /// At least one check failed.
+    Failed,
+    /// Checks still running or expected.
+    Pending,
+    /// No checks have been configured for the PR.
+    None,
+}
+
+impl From<Option<StatusCheckRollup>> for CiStatus {
+    fn from(value: Option<StatusCheckRollup>) -> Self {
+        match value {
+            None => Self::None,
+            Some(rollup) => match rollup.state {
+                StatusState::ERROR | StatusState::FAILURE => Self::Failed,
+                StatusState::EXPECTED | StatusState::PENDING => Self::Pending,
+                StatusState::SUCCESS => Self::Success,
+            },
+        }
+    }
+}
+
+/// Open PR with CI status and head commit SHA. Used by `jj-gh pr log` to map
+/// jj revisions to their PR metadata.
+#[derive(Debug)]
+pub struct PrWithCiStatus {
+    /// GraphQL node ID.
+    pub id: String,
+    /// PR number.
+    pub number: u64,
+    /// PR URL.
+    pub url: String,
+    /// PR title.
+    pub title: String,
+    /// SHA of the commit at the head of the PR's branch. Matches a jj
+    /// `commit_id` in colocated repos.
+    pub head_sha: String,
+    /// Whether the PR is a draft.
+    pub is_draft: bool,
+    /// Whether the PR is in the merge queue.
+    pub is_in_merge_queue: bool,
+    /// Rolled-up CI status across all required checks.
+    pub ci_status: CiStatus,
+}
+
+impl From<PrsWithCiStatusInternal> for Vec<PrWithCiStatus> {
+    fn from(value: PrsWithCiStatusInternal) -> Self {
+        value
+            .repository
+            .pull_requests
+            .nodes
+            .into_iter()
+            .map(
+                |PullRequest {
+                     id,
+                     number,
+                     url,
+                     title,
+                     head_ref_oid,
+                     is_draft,
+                     is_in_merge_queue,
+                     status_check_rollup,
+                 }| PrWithCiStatus {
+                    id,
+                    number,
+                    url,
+                    title,
+                    head_sha: head_ref_oid,
+                    is_draft,
+                    is_in_merge_queue,
+                    ci_status: status_check_rollup.into(),
+                },
+            )
+            .collect()
+    }
+}

--- a/src/gh/prs_with_ci_status.rs
+++ b/src/gh/prs_with_ci_status.rs
@@ -29,19 +29,13 @@ struct PullRequest {
 }
 
 #[derive(Deserialize)]
-struct PullRequestsConnection {
+struct SearchResults {
     nodes: Vec<PullRequest>,
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Repository {
-    pull_requests: PullRequestsConnection,
-}
-
-#[derive(Deserialize)]
 pub struct PrsWithCiStatusInternal {
-    repository: Repository,
+    search: SearchResults,
 }
 
 /// Status of CI checks for a pull request.
@@ -96,8 +90,7 @@ pub struct PrWithCiStatus {
 impl From<PrsWithCiStatusInternal> for Vec<PrWithCiStatus> {
     fn from(value: PrsWithCiStatusInternal) -> Self {
         value
-            .repository
-            .pull_requests
+            .search
             .nodes
             .into_iter()
             .map(

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -1,7 +1,10 @@
 //! `octocrab`-backed [`Gh`] implementation.
 
 use super::{CreatePrRequest, Gh, PrCreated, PrDetails, PrSummary};
-use crate::config::AutoMergeMethod;
+use crate::{
+    config::AutoMergeMethod,
+    gh::prs_with_ci_status::{PrWithCiStatus, PrsWithCiStatusInternal},
+};
 use anyhow::{Context, Result, anyhow};
 use octocrab::{Octocrab, params};
 use secrecy::{ExposeSecret, SecretString};
@@ -105,24 +108,6 @@ impl Gh for OctocrabGh {
         Ok(())
     }
 
-    async fn enable_auto_merge(&self, pr_node_id: &str, method: AutoMergeMethod) -> Result<()> {
-        const MUTATION: &str = include_str!("./enable_auto_merge.gql");
-
-        let payload = json!({
-            "query": MUTATION,
-            "variables": {
-                "prId": pr_node_id,
-                "method": method.as_graphql(),
-            },
-        });
-        self.octo
-            .graphql::<serde_json::Value>(&payload)
-            .await
-            .map_err(humanize)
-            .context("enabling auto-merge")?;
-        Ok(())
-    }
-
     async fn get_pr(&self, owner: &str, repo: &str, number: u64) -> Result<PrDetails> {
         let pr = match self.octo.pulls(owner, repo).get(number).await {
             Ok(pr) => pr,
@@ -144,6 +129,43 @@ impl Gh for OctocrabGh {
             head_repo_name: pr.head.repo.as_ref().map(|r| r.name.clone()),
             graphql_node_id: pr.node_id,
         })
+    }
+
+    async fn enable_auto_merge(&self, pr_node_id: &str, method: AutoMergeMethod) -> Result<()> {
+        const MUTATION: &str = include_str!("./enable_auto_merge.gql");
+
+        let payload = json!({
+            "query": MUTATION,
+            "variables": {
+                "pr_id": pr_node_id,
+                "method": method.as_graphql(),
+            },
+        });
+        self.octo
+            .graphql::<serde_json::Value>(&payload)
+            .await
+            .map_err(humanize)
+            .context("enabling auto-merge")?;
+        Ok(())
+    }
+
+    async fn local_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PrWithCiStatus>> {
+        const QUERY: &str = include_str!("./prs_with_ci_status.gql");
+
+        let payload = json!({
+            "query": QUERY,
+            "variables": {
+                "owner": owner,
+                "repo": repo,
+            },
+        });
+        Ok(self
+            .octo
+            .graphql::<PrsWithCiStatusInternal>(&payload)
+            .await
+            .map_err(humanize)
+            .context("fetching local PRs")?
+            .into())
     }
 }
 

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -149,24 +149,66 @@ impl Gh for OctocrabGh {
         Ok(())
     }
 
-    async fn local_pulls(&self, owner: &str, repo: &str) -> Result<Vec<PrWithCiStatus>> {
+    async fn local_pulls(
+        &self,
+        owner: &str,
+        repo: &str,
+        branches: &[String],
+    ) -> Result<Vec<PrWithCiStatus>> {
         const QUERY: &str = include_str!("./prs_with_ci_status.gql");
 
-        let payload = json!({
-            "query": QUERY,
-            "variables": {
-                "owner": owner,
-                "repo": repo,
-            },
-        });
-        Ok(self
-            .octo
-            .graphql::<PrsWithCiStatusInternal>(&payload)
-            .await
-            .map_err(humanize)
-            .context("fetching local PRs")?
-            .into())
+        if branches.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut out: Vec<PrWithCiStatus> = Vec::new();
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for search_query in build_search_queries(owner, repo, branches) {
+            let payload = json!({
+                "query": QUERY,
+                "variables": { "query": search_query },
+            });
+            let batch: Vec<PrWithCiStatus> = self
+                .octo
+                .graphql::<PrsWithCiStatusInternal>(&payload)
+                .await
+                .map_err(humanize)
+                .context("fetching local PRs")?
+                .into();
+            for pr in batch {
+                if seen.insert(pr.number) {
+                    out.push(pr);
+                }
+            }
+        }
+        Ok(out)
     }
+}
+
+/// GitHub's search query string limit is documented as 256 chars for some
+/// endpoints but issue/PR search tolerates more in practice. We cap well
+/// below the worst-case so a single oversized branch name can't break a
+/// whole batch.
+const MAX_SEARCH_QUERY_LEN: usize = 900;
+
+/// Split `branches` into one or more search query strings of the form
+/// `repo:owner/repo is:pr is:open head:b1 head:b2 ...`, each under
+/// [`MAX_SEARCH_QUERY_LEN`].
+fn build_search_queries(owner: &str, repo: &str, branches: &[String]) -> Vec<String> {
+    let prefix = format!("repo:{owner}/{repo} is:pr is:open");
+    let mut queries = Vec::new();
+    let mut current = prefix.clone();
+    for branch in branches {
+        let addition = format!(" head:{branch}");
+        if current.len() + addition.len() > MAX_SEARCH_QUERY_LEN && current != prefix {
+            queries.push(std::mem::replace(&mut current, prefix.clone()));
+        }
+        current.push_str(&addition);
+    }
+    if current != prefix {
+        queries.push(current);
+    }
+    queries
 }
 
 fn is_not_found(e: &octocrab::Error) -> bool {
@@ -195,5 +237,33 @@ fn humanize(e: octocrab::Error) -> anyhow::Error {
             "GitHub rejected the request (422): {message}. Common causes: the head branch is not pushed, there are no commits between head and base, or a PR already exists."
         ),
         _ => anyhow!("GitHub error ({status}): {message}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_branches_produces_no_queries() {
+        assert!(build_search_queries("o", "r", &[]).is_empty());
+    }
+
+    #[test]
+    fn single_query_when_under_limit() {
+        let qs = build_search_queries("o", "r", &["a".into(), "b".into()]);
+        assert_eq!(qs, vec!["repo:o/r is:pr is:open head:a head:b".to_string()]);
+    }
+
+    #[test]
+    fn splits_into_batches_when_over_limit() {
+        let long = "x".repeat(200);
+        let branches: Vec<String> = (0..10).map(|i| format!("{long}-{i}")).collect();
+        let qs = build_search_queries("o", "r", &branches);
+        assert!(qs.len() >= 2, "expected multiple batches, got {qs:?}");
+        for q in &qs {
+            assert!(q.len() <= MAX_SEARCH_QUERY_LEN, "batch too long: {q}");
+            assert!(q.starts_with("repo:o/r is:pr is:open"));
+        }
     }
 }

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -86,6 +86,15 @@ pub trait Jj {
     ///
     /// Propagates jj failures.
     async fn git_import(&self) -> Result<()>;
+
+    /// Names of bookmarks that have a tracking branch on the `origin` remote.
+    /// Used to scope GitHub PR lookups to branches the user has actually
+    /// pushed. Sorted, deduped, with empty entries removed.
+    ///
+    /// # Errors
+    ///
+    /// Propagates jj errors.
+    async fn pushed_bookmarks(&self) -> Result<Vec<String>>;
 }
 
 /// Compose the revset used to compute the default PR title.

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -166,6 +166,28 @@ impl Jj for JjCli {
         }
         Ok(())
     }
+
+    async fn pushed_bookmarks(&self) -> Result<Vec<String>> {
+        let stdout = run_jj(&[
+            "log",
+            "--no-graph",
+            "-r",
+            r#"bookmarks() & remote_bookmarks(remote=exact:"origin")"#,
+            "-T",
+            r#"bookmarks.map(|b| b.name() ++ "\n")"#,
+        ])
+        .await?;
+        let mut names: Vec<String> = std::str::from_utf8(&stdout)
+            .context("jj log output is not UTF-8")?
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+        names.sort();
+        names.dedup();
+        Ok(names)
+    }
 }
 
 async fn workspace_root() -> Result<PathBuf> {

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -243,6 +243,14 @@ mod tests {
             assert_eq!(number, self.expected.2);
             Ok(self.pr.clone())
         }
+
+        async fn local_pulls(
+            &self,
+            _owner: &str,
+            _repo: &str,
+        ) -> Result<Vec<crate::gh::PrWithCiStatus>> {
+            unimplemented!("fetch does not call local_pulls")
+        }
     }
 
     #[derive(Debug, Clone)]

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -205,6 +205,9 @@ mod tests {
             *self.import_calls.lock().unwrap() += 1;
             Ok(())
         }
+        async fn pushed_bookmarks(&self) -> Result<Vec<String>> {
+            unimplemented!("fetch does not call pushed_bookmarks")
+        }
     }
 
     struct FakeGh {
@@ -248,6 +251,7 @@ mod tests {
             &self,
             _owner: &str,
             _repo: &str,
+            _branches: &[String],
         ) -> Result<Vec<crate::gh::PrWithCiStatus>> {
             unimplemented!("fetch does not call local_pulls")
         }

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -3,6 +3,7 @@
 mod editor;
 pub mod fetch;
 mod frontmatter;
+pub mod pr_log;
 mod template;
 mod validation;
 
@@ -45,6 +46,31 @@ pub enum PrAction {
     /// repo does not allow auto-merge.
     #[command(visible_alias = "am")]
     AutoMerge(AutoMergeArgs),
+
+    /// Like `jj log`, but injects PR metadata (number, CI status, URL) as
+    /// template aliases keyed by `commit_id` and renders inline PR info in the
+    /// default template. Any arguments after `--` are forwarded to the
+    /// underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`.
+    #[command(visible_alias = "l")]
+    Log(PrLogArgs),
+}
+
+#[derive(Debug, clap::Args, Serialize)]
+pub struct PrLogArgs {
+    /// Arguments forwarded verbatim to the underlying `jj log` invocation.
+    /// Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`.
+    /// If you pass `-T` / `--template`, the default PR-aware template is not
+    /// applied; use the injected aliases (`pr_number`, `pr_url`,
+    /// `pr_ci_status`, `pr_meta`) from your own template. `pr_meta` is the
+    /// pre-formatted hyperlinked PR number + colored CI icon (empty for
+    /// commits without a PR).
+    #[arg(last = true, allow_hyphen_values = true, value_name = "JJ_LOG_ARGS")]
+    #[serde(skip)]
+    pub jj_log_args: Vec<String>,
+
+    #[command(flatten)]
+    #[serde(flatten)]
+    pub auth: AuthArgs,
 }
 
 #[derive(Debug, clap::Args, Serialize)]
@@ -184,6 +210,7 @@ pub async fn dispatch(action: PrAction) -> Result<()> {
         PrAction::Create(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Fetch(a) => fig.merge(Serialized::defaults(a)),
         PrAction::AutoMerge(a) => fig.merge(Serialized::defaults(a)),
+        PrAction::Log(a) => fig.merge(Serialized::defaults(a)),
     };
     let config = config::extract(&fig)?;
     config::validate(&config)?;
@@ -196,6 +223,7 @@ pub async fn dispatch(action: PrAction) -> Result<()> {
         PrAction::Create(args) => create(&jj, &gh, &editor, &config, &args).await?,
         PrAction::Fetch(args) => fetch::run(&jj, &gh, &config, &args).await?,
         PrAction::AutoMerge(args) => auto_merge(&jj, &gh, &config, &args.number_or_rev).await?,
+        PrAction::Log(args) => pr_log::log(&args, &gh, &jj).await?,
     }
 
     Ok(())

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -71,6 +71,23 @@ pub struct PrLogArgs {
     #[command(flatten)]
     #[serde(flatten)]
     pub auth: AuthArgs,
+
+    /// Force enable the use of nerdfont icons in the default
+    /// `pr log` template. Overrides config.
+    #[arg(
+        long,
+        action = clap::ArgAction::SetTrue,
+        default_value = "true",
+        default_value_if("no_nerdfonts", "true", Some("false")),
+    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nerdfonts: Option<bool>,
+
+    /// Force the default `pr log` template not to use nerdfont icons.
+    /// Overrides config. Equivalent to `--nerdfonts=false`
+    #[arg(long = "no-nerdfonts", conflicts_with = "nerdfonts")]
+    #[serde(skip)]
+    pub no_nerdfonts: bool,
 }
 
 #[derive(Debug, clap::Args, Serialize)]
@@ -223,7 +240,7 @@ pub async fn dispatch(action: PrAction) -> Result<()> {
         PrAction::Create(args) => create(&jj, &gh, &editor, &config, &args).await?,
         PrAction::Fetch(args) => fetch::run(&jj, &gh, &config, &args).await?,
         PrAction::AutoMerge(args) => auto_merge(&jj, &gh, &config, &args.number_or_rev).await?,
-        PrAction::Log(args) => pr_log::log(&args, &gh, &jj).await?,
+        PrAction::Log(args) => pr_log::log(&args, &config, &gh, &jj).await?,
     }
 
     Ok(())

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -26,7 +26,8 @@ pub async fn log(args: &PrLogArgs, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
         .await?
         .ok_or_else(|| anyhow!("origin remote is not configured"))?;
     let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
-    let prs = gh.local_pulls(&owner, &repo).await?;
+    let branches = jj.pushed_bookmarks().await?;
+    let prs = gh.local_pulls(&owner, &repo, &branches).await?;
 
     let config_toml = render_config(&prs);
     let mut tmp = NamedTempFile::with_suffix(".toml").context("creating temp config file")?;

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -1,0 +1,252 @@
+//! `jj-gh pr log`: wraps `jj log` with PR metadata injected as template
+//! aliases keyed by `commit_id`.
+//!
+//! We don't re-implement log rendering. We fetch open PRs, build a TOML config that
+//! defines template aliases like `pr_number(commit_id)` as nested
+//! `if(commit_id.short(40) == "<sha>", "<value>", ...)` chains, write it to a
+//! temp file, then spawn `jj --config-file <file> log` with the user's
+//! forwarded args. We also ship a default `pr_log` template that inlines a
+//! hyperlinked PR number and CI-status icon, applied only when the user
+//! didn't pass their own `-T` / `--template`.
+
+use crate::{
+    gh::{CiStatus, Gh, PrWithCiStatus},
+    git,
+    jj::Jj,
+    pr::PrLogArgs,
+};
+use anyhow::{Context, Result, anyhow};
+use std::io::Write;
+use tempfile::NamedTempFile;
+use tokio::process::Command;
+
+pub async fn log(args: &PrLogArgs, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
+    let origin_url = jj
+        .remote_url("origin")
+        .await?
+        .ok_or_else(|| anyhow!("origin remote is not configured"))?;
+    let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
+    let prs = gh.local_pulls(&owner, &repo).await?;
+
+    let config_toml = render_config(&prs);
+    let mut tmp = NamedTempFile::with_suffix(".toml").context("creating temp config file")?;
+    tmp.write_all(config_toml.as_bytes())
+        .context("writing template-alias config")?;
+    let tmp = tmp.into_temp_path();
+
+    let mut cmd = Command::new("jj");
+    cmd.arg("--config-file").arg(&tmp).arg("log");
+    if !user_set_template(&args.jj_log_args) {
+        cmd.args(["-T", "pr_log"]);
+    }
+    cmd.args(&args.jj_log_args);
+
+    let status = cmd.status().await.context("failed to spawn `jj log`")?;
+    if !status.success() {
+        return Err(anyhow!("`jj log` failed with {status}"));
+    }
+    Ok(())
+}
+
+/// Whether the user already passed `-T` / `--template` in the forwarded args.
+fn user_set_template(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        a == "-T"
+            || a == "--template"
+            || a.starts_with("-T") && a.len() > 2
+            || a.starts_with("--template=")
+    })
+}
+
+/// Build the TOML config that defines our `pr_*` template aliases, default
+/// colors, and the `pr_log` template.
+///
+/// jj template aliases lose static type info when called from another alias
+/// (their return type becomes `Any`), which breaks `if(pr_x, ...)` and
+/// `pr_x == ""` in nested aliases. To sidestep this we render the *entire*
+/// inline PR fragment (hyperlinked number + colored CI icon) as a single
+/// `pr_meta` alias whose body is a per-commit if-chain; the default `pr_log`
+/// template then wraps it with `surround(" ", "", pr_meta)` so spacing only
+/// appears for commits that actually have a PR. We still expose `pr_number` /
+/// `pr_url` / `pr_ci_status` as raw String aliases for users who want to
+/// build custom templates — they work in direct contexts even if they can't
+/// be re-chained through `if()`.
+fn render_config(prs: &[PrWithCiStatus]) -> String {
+    let number = if_chain_alias(prs, |pr| format!(r#""{}""#, pr.number));
+    let url = if_chain_alias(prs, |pr| format!(r#""{}""#, escape_toml_dq(&pr.url)));
+    let status = if_chain_alias(prs, |pr| format!(r#""{}""#, ci_status_str(pr.ci_status)));
+    let meta = if_chain_alias(prs, render_pr_meta_body);
+
+    format!(
+        r#"[template-aliases]
+pr_number = '''{number}'''
+pr_url = '''{url}'''
+pr_ci_status = '''{status}'''
+pr_meta = '''{meta}'''
+pr_log = '''
+if(root,
+  format_root_commit(self),
+  label(
+    separate(" ",
+      if(current_working_copy, "working_copy"),
+      if(immutable, "immutable", "mutable"),
+      if(conflict, "conflicted"),
+    ),
+    concat(
+      format_short_commit_header(self) ++ surround(" ", "", pr_meta) ++ "\n",
+      separate(" ",
+        if(empty, empty_commit_marker),
+        if(description,
+          description.first_line(),
+          label(if(empty, "empty"), description_placeholder),
+        ),
+      ) ++ "\n",
+    ),
+  )
+)
+'''
+
+[colors]
+ci-success = "green"
+ci-failed = "red"
+ci-pending = "yellow"
+"#
+    )
+}
+
+/// Render the body of a single `pr_meta` if-chain arm: the full template
+/// fragment for one PR (hyperlinked number plus colored CI-status icon).
+fn render_pr_meta_body(pr: &PrWithCiStatus) -> String {
+    let url = escape_toml_dq(&pr.url);
+    let link = format!(r##"hyperlink("{url}", "#{n}")"##, n = pr.number);
+    match icon_label(pr.ci_status) {
+        Some(icon) => format!(r#"{link} ++ " " ++ {icon}"#),
+        None => link,
+    }
+}
+
+fn icon_label(status: CiStatus) -> Option<&'static str> {
+    match status {
+        CiStatus::Success => Some(r#"label("ci-success", "✓")"#),
+        CiStatus::Failed => Some(r#"label("ci-failed", "✗")"#),
+        CiStatus::Pending => Some(r#"label("ci-pending", "●")"#),
+        CiStatus::None => None,
+    }
+}
+
+/// Build a nested `if(commit_id.short(40) == "<sha>", <body>, ...)` chain that
+/// terminates in the empty string. Generated PR SHAs are 40-char hex (SHA-1).
+fn if_chain_alias<F>(prs: &[PrWithCiStatus], render: F) -> String
+where
+    F: Fn(&PrWithCiStatus) -> String,
+{
+    let mut expr = String::from(r#""""#);
+    for pr in prs.iter().rev() {
+        expr = format!(
+            r#"if(commit_id.short(40) == "{sha}", {body}, {expr})"#,
+            sha = pr.head_sha,
+            body = render(pr),
+        );
+    }
+    expr
+}
+
+fn ci_status_str(status: CiStatus) -> &'static str {
+    match status {
+        CiStatus::Success => "SUCCESS",
+        CiStatus::Failed => "FAILED",
+        CiStatus::Pending => "PENDING",
+        CiStatus::None => "",
+    }
+}
+
+/// Escape a value for embedding in a TOML double-quoted string. We only ever
+/// embed PR URLs and SHAs (no control chars), so handling `\` and `"` is
+/// sufficient.
+fn escape_toml_dq(s: &str) -> String {
+    s.replace('\\', r"\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr(sha: &str, number: u64, status: CiStatus) -> PrWithCiStatus {
+        PrWithCiStatus {
+            id: format!("ID{number}"),
+            number,
+            url: format!("https://github.com/o/r/pull/{number}"),
+            title: format!("PR {number}"),
+            head_sha: sha.into(),
+            is_draft: false,
+            is_in_merge_queue: false,
+            ci_status: status,
+        }
+    }
+
+    #[test]
+    fn if_chain_empty_returns_empty_string_literal() {
+        let expr = if_chain_alias::<fn(&PrWithCiStatus) -> String>(&[], |_| String::new());
+        assert_eq!(expr, r#""""#);
+    }
+
+    #[test]
+    fn if_chain_nests_in_input_order() {
+        let prs = vec![
+            pr(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                1,
+                CiStatus::None,
+            ),
+            pr(
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                2,
+                CiStatus::None,
+            ),
+        ];
+        let expr = if_chain_alias(&prs, |pr| format!(r#""{}""#, pr.number));
+        assert_eq!(
+            expr,
+            r#"if(commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "1", if(commit_id.short(40) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "2", ""))"#
+        );
+    }
+
+    #[test]
+    fn user_set_template_detects_short_form() {
+        assert!(user_set_template(&["-T".into(), "x".into()]));
+    }
+
+    #[test]
+    fn user_set_template_detects_glued_short_form() {
+        assert!(user_set_template(&["-Tx".into()]));
+    }
+
+    #[test]
+    fn user_set_template_detects_long_form() {
+        assert!(user_set_template(&["--template".into(), "x".into()]));
+        assert!(user_set_template(&["--template=x".into()]));
+    }
+
+    #[test]
+    fn user_set_template_ignores_other_args() {
+        assert!(!user_set_template(&["-r".into(), "@-".into()]));
+    }
+
+    #[test]
+    fn config_contains_alias_for_each_pr() {
+        let prs = vec![pr("a".repeat(40).as_str(), 42, CiStatus::Success)];
+        let cfg = render_config(&prs);
+        assert!(
+            cfg.contains(r#"commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""#)
+        );
+        assert!(cfg.contains(r#""42""#));
+        assert!(cfg.contains(r#""SUCCESS""#));
+        assert!(cfg.contains(r#"label("ci-success", "✓")"#));
+        assert!(cfg.contains(r#"hyperlink(""#));
+    }
+
+    #[test]
+    fn escape_toml_dq_handles_backslash_and_quote() {
+        assert_eq!(escape_toml_dq(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+}

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -10,6 +10,7 @@
 //! didn't pass their own `-T` / `--template`.
 
 use crate::{
+    config::Config,
     gh::{CiStatus, Gh, PrWithCiStatus},
     git,
     jj::Jj,
@@ -20,7 +21,7 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 use tokio::process::Command;
 
-pub async fn log(args: &PrLogArgs, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
+pub async fn log(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
     let origin_url = jj
         .remote_url("origin")
         .await?
@@ -29,7 +30,7 @@ pub async fn log(args: &PrLogArgs, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
     let branches = jj.pushed_bookmarks().await?;
     let prs = gh.local_pulls(&owner, &repo, &branches).await?;
 
-    let config_toml = render_config(&prs);
+    let config_toml = render_config(&prs, config);
     let mut tmp = NamedTempFile::with_suffix(".toml").context("creating temp config file")?;
     tmp.write_all(config_toml.as_bytes())
         .context("writing template-alias config")?;
@@ -72,11 +73,11 @@ fn user_set_template(args: &[String]) -> bool {
 /// `pr_url` / `pr_ci_status` as raw String aliases for users who want to
 /// build custom templates — they work in direct contexts even if they can't
 /// be re-chained through `if()`.
-fn render_config(prs: &[PrWithCiStatus]) -> String {
+fn render_config(prs: &[PrWithCiStatus], config: &Config) -> String {
     let number = if_chain_alias(prs, |pr| format!(r#""{}""#, pr.number));
     let url = if_chain_alias(prs, |pr| format!(r#""{}""#, escape_toml_dq(&pr.url)));
     let status = if_chain_alias(prs, |pr| format!(r#""{}""#, ci_status_str(pr.ci_status)));
-    let meta = if_chain_alias(prs, render_pr_meta_body);
+    let meta = if_chain_alias(prs, |pr| render_pr_meta_body(pr, config));
 
     format!(
         r#"[template-aliases]
@@ -94,7 +95,7 @@ if(root,
       if(conflict, "conflicted"),
     ),
     concat(
-      format_short_commit_header(self) ++ surround(" ", "", pr_meta) ++ "\n",
+      format_short_commit_header(self)  ++ surround(" ", "", pr_meta) ++ "\n",
       separate(" ",
         if(empty, empty_commit_marker),
         if(description,
@@ -117,9 +118,13 @@ ci-pending = "yellow"
 
 /// Render the body of a single `pr_meta` if-chain arm: the full template
 /// fragment for one PR (hyperlinked number plus colored CI-status icon).
-fn render_pr_meta_body(pr: &PrWithCiStatus) -> String {
+fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
+    let github_icon = if config.nerdfonts { " " } else { "" };
     let url = escape_toml_dq(&pr.url);
-    let link = format!(r##"hyperlink("{url}", "#{n}")"##, n = pr.number);
+    let link = format!(
+        r##""{github_icon}" ++ hyperlink("{url}", "#{n}")"##,
+        n = pr.number
+    );
     match icon_label(pr.ci_status) {
         Some(icon) => format!(r#"{link} ++ " " ++ {icon}"#),
         None => link,
@@ -236,7 +241,7 @@ mod tests {
     #[test]
     fn config_contains_alias_for_each_pr() {
         let prs = vec![pr("a".repeat(40).as_str(), 42, CiStatus::Success)];
-        let cfg = render_config(&prs);
+        let cfg = render_config(&prs, &Config::default());
         assert!(
             cfg.contains(r#"commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""#)
         );


### PR DESCRIPTION
Adds `jj pr log` (alias `l`), which runs `jj log` with open PRs injected as template-aliases keyed by `commit_id`. Any args after `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`.

The default template inlines the PR number as an OSC 8 hyperlink and a colored CI-status icon (✓ / ✗ / ●), so a typical log line looks like:

```
○  qpvuntsm me 2026-05-24 12:34:56 abc12345 #42 ✓
│  feat: do the thing
```

When the user passes their own `-T` / `--template`, the default isn't applied; the injected aliases (`pr_number`, `pr_url`, `pr_ci_status`, `pr_meta`) are still available for custom templates.

We don't reimplement log rendering. Instead, we fetch open PRs, build a TOML config that defines per-commit `if(commit_id.short(40) == "<sha>", "<value>", ...)` chains for each alias, write it to a temp file, and spawn `jj --config-file <file> log <user_args>` with inherited stdio.

Closes #31
