### PR TITLE
feat(pr-log): Show merge status in `pr log` default template

### DIFF
--- a/src/gh/prs_with_ci_status.gql
+++ b/src/gh/prs_with_ci_status.gql
@@ -8,6 +8,7 @@ query PrsWithCiStatus($query: String!) {
         title
         headRefOid
         isDraft
+        merged
         isInMergeQueue
         statusCheckRollup {
           state

--- a/src/gh/prs_with_ci_status.rs
+++ b/src/gh/prs_with_ci_status.rs
@@ -22,6 +22,7 @@ struct PullRequest {
     number: u64,
     url: String,
     title: String,
+    merged: bool,
     head_ref_oid: String,
     is_draft: bool,
     is_in_merge_queue: bool,
@@ -81,6 +82,8 @@ pub struct PrWithCiStatus {
     pub head_sha: String,
     /// Whether the PR is a draft.
     pub is_draft: bool,
+    /// Whether the PR is merged
+    pub merged: bool,
     /// Whether the PR is in the merge queue.
     pub is_in_merge_queue: bool,
     /// Rolled-up CI status across all required checks.
@@ -99,6 +102,7 @@ impl From<PrsWithCiStatusInternal> for Vec<PrWithCiStatus> {
                      number,
                      url,
                      title,
+                     merged,
                      head_ref_oid,
                      is_draft,
                      is_in_merge_queue,
@@ -108,9 +112,10 @@ impl From<PrsWithCiStatusInternal> for Vec<PrWithCiStatus> {
                     number,
                     url,
                     title,
-                    head_sha: head_ref_oid,
+                    merged,
                     is_draft,
                     is_in_merge_queue,
+                    head_sha: head_ref_oid,
                     ci_status: status_check_rollup.into(),
                 },
             )

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -195,7 +195,7 @@ const MAX_SEARCH_QUERY_LEN: usize = 900;
 /// `repo:owner/repo is:pr is:open head:b1 head:b2 ...`, each under
 /// [`MAX_SEARCH_QUERY_LEN`].
 fn build_search_queries(owner: &str, repo: &str, branches: &[String]) -> Vec<String> {
-    let prefix = format!("repo:{owner}/{repo} is:pr is:open");
+    let prefix = format!("repo:{owner}/{repo} is:pr");
     let mut queries = Vec::new();
     let mut current = prefix.clone();
     for branch in branches {
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn single_query_when_under_limit() {
         let qs = build_search_queries("o", "r", &["a".into(), "b".into()]);
-        assert_eq!(qs, vec!["repo:o/r is:pr is:open head:a head:b".to_string()]);
+        assert_eq!(qs, vec!["repo:o/r is:pr head:a head:b".to_string()]);
     }
 
     #[test]
@@ -263,7 +263,7 @@ mod tests {
         assert!(qs.len() >= 2, "expected multiple batches, got {qs:?}");
         for q in &qs {
             assert!(q.len() <= MAX_SEARCH_QUERY_LEN, "batch too long: {q}");
-            assert!(q.starts_with("repo:o/r is:pr is:open"));
+            assert!(q.starts_with("repo:o/r is:pr"));
         }
     }
 }

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -109,9 +109,10 @@ if(root,
 '''
 
 [colors]
-ci-success = "green"
-ci-failed = "red"
-ci-pending = "yellow"
+gh-ci-success = "green"
+gh-ci-failed = "red"
+gh-ci-pending = "yellow"
+gh-pr-merge-status = "bright black"
 "#
     )
 }
@@ -121,23 +122,41 @@ ci-pending = "yellow"
 fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
     let github_icon = if config.nerdfonts { " " } else { "" };
     let url = escape_toml_dq(&pr.url);
-    let link = format!(
+    let mut template = format!(
         r##""{github_icon}" ++ hyperlink("{url}", "#{n}")"##,
         n = pr.number
     );
-    match icon_label(pr.ci_status) {
-        Some(icon) => format!(r#"{link} ++ " " ++ {icon}"#),
-        None => link,
+
+    template = match ci_status_icon_label(pr) {
+        Some(icon) => format!(r#"{template} ++ " " ++ {icon}"#),
+        None => template,
+    };
+
+    template = match merge_metadata(pr) {
+        Some(metadata) => format!(r#"{template} ++ " " ++ {metadata}"#),
+        None => template,
+    };
+
+    template
+}
+
+fn merge_metadata(pr: &PrWithCiStatus) -> Option<&'static str> {
+    if pr.merged {
+        Some(r#"label("gh-pr-merge-status", "( merged)")"#)
+    } else if pr.is_in_merge_queue {
+        Some(r#"label("gh-pr-merge-status", "( in merge queue)")"#)
+    } else {
+        None
     }
 }
 
-fn icon_label(status: CiStatus) -> Option<&'static str> {
-    match status {
-        CiStatus::Success => Some(r#"label("ci-success", "✓")"#),
-        CiStatus::Failed => Some(r#"label("ci-failed", "✗")"#),
-        CiStatus::Pending => Some(r#"label("ci-pending", "●")"#),
-        CiStatus::None => None,
-    }
+fn ci_status_icon_label(pr: &PrWithCiStatus) -> Option<&'static str> {
+    Some(match pr.ci_status {
+        CiStatus::Success => r#"label("gh-ci-success", "✓")"#,
+        CiStatus::Failed => r#"label("gh-ci-failed", "✗")"#,
+        CiStatus::Pending => r#"label("gh-ci-pending", "●")"#,
+        CiStatus::None => return None,
+    })
 }
 
 /// Build a nested `if(commit_id.short(40) == "<sha>", <body>, ...)` chain that
@@ -187,6 +206,21 @@ mod tests {
             is_draft: false,
             is_in_merge_queue: false,
             ci_status: status,
+            merged: false,
+        }
+    }
+
+    fn pr_merge_status(number: u64, merged: bool, is_in_merge_queue: bool) -> PrWithCiStatus {
+        PrWithCiStatus {
+            id: format!("ID{number}"),
+            number,
+            url: format!("https://github.com/o/r/pull/{number}"),
+            title: format!("PR {number}"),
+            head_sha: number.to_string(),
+            is_draft: false,
+            ci_status: CiStatus::Success,
+            is_in_merge_queue,
+            merged,
         }
     }
 
@@ -247,8 +281,19 @@ mod tests {
         );
         assert!(cfg.contains(r#""42""#));
         assert!(cfg.contains(r#""SUCCESS""#));
-        assert!(cfg.contains(r#"label("ci-success", "✓")"#));
+        assert!(cfg.contains(r#"label("gh-ci-success", "✓")"#));
         assert!(cfg.contains(r#"hyperlink(""#));
+    }
+
+    #[test]
+    fn default_template_shows_merge_metadata() {
+        let prs = vec![
+            pr_merge_status(1, true, false),
+            pr_merge_status(2, false, true),
+        ];
+        let cfg = render_config(&prs, &Config::default());
+        assert!(cfg.contains("( in merge queue)"));
+        assert!(cfg.contains("( merged)"));
     }
 
     #[test]


### PR DESCRIPTION
Show merge status in `pr log` default template

<img width="1263" height="221" alt="image" src="https://github.com/user-attachments/assets/605d47a7-2000-47e1-b143-f32a00007357" />
