### PR TITLE
refactor(pr-log): Use `graphql-client` to get typesafety on query struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 /.direnv/
 /result
+# symlinked from flake input
+/src/gh/github.graphql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -275,6 +275,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -524,7 +534,7 @@ dependencies = [
  "chrono",
  "log",
  "nu-ansi-term",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -673,6 +683,63 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "graphql-introspection-query"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e063446242093b0acecc78a2313801e6c4faafa3501277b409a2b1972eff5d85"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "graphql-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
+dependencies = [
+ "combine",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "graphql_client"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f04840854efa7b06377d86fab117f598f5f5c95727067463417ccaf8aa7635"
+dependencies = [
+ "graphql_query_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "graphql_client_codegen"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0141e66c8d0302f8a586df12ad5d0cf87c0fa8c391f2f5b5dc296312dce569"
+dependencies = [
+ "graphql-introspection-query",
+ "graphql-parser",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "graphql_query_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16ecf9bb87a6760cf5227f66cbe48bad7b89505aeb002aa9439ea090e6038a3"
+dependencies = [
+ "graphql_client_codegen",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -998,6 +1065,7 @@ dependencies = [
  "clap",
  "figment",
  "flexi_logger",
+ "graphql_client",
  "http",
  "log",
  "nu-ansi-term",
@@ -1008,7 +1076,7 @@ dependencies = [
  "serde_yml",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "url",
@@ -1785,7 +1853,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1909,11 +1977,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ figment = { version = "0.10", features = ["toml"] }
 flexi_logger = { version = "0.31", default-features = false, features = [
   "colors",
 ] }
+graphql_client = "0.16"
 http = "1"
 log = "0.4"
 nu-ansi-term = "0.50"
@@ -33,3 +34,6 @@ url = "2"
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }
+
+[profile.release]
+strip = "symbols"

--- a/flake.nix
+++ b/flake.nix
@@ -42,18 +42,22 @@
 
         nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);
         craneLibNightly = (crane.mkLib pkgs).overrideToolchain nightlyToolchain;
-
         src =
           let
             root = ./.;
+            baseSrc = pkgs.lib.fileset.toSource {
+              inherit root;
+              fileset = pkgs.lib.fileset.unions [
+                (craneLib.fileset.commonCargoSources root)
+                (pkgs.lib.fileset.fileFilter (f: f.hasExt "gql") root)
+              ];
+            };
           in
-          pkgs.lib.fileset.toSource {
-            inherit root;
-            fileset = pkgs.lib.fileset.unions [
-              (craneLib.fileset.commonCargoSources root)
-              (pkgs.lib.fileset.fileFilter (f: f.hasExt "gql") root)
-            ];
-          };
+          pkgs.runCommand "jj-gh-src" { } ''
+            cp -r ${baseSrc} $out
+            chmod -R u+w $out
+            cp ${github-graphql-schema} $out/src/gh/github.graphql
+          '';
         commonArgs = {
           inherit src;
           strictDeps = true;
@@ -110,6 +114,9 @@
             pkgs.rust-analyzer
             treefmtEval.config.build.wrapper
           ];
+          shellHook = ''
+            ln -sfn ${github-graphql-schema} src/gh/github.graphql
+          '';
         };
         checks = {
           inherit jj-gh;

--- a/src/gh/prs_with_ci_status.gql
+++ b/src/gh/prs_with_ci_status.gql
@@ -1,6 +1,7 @@
-query PrsWithCiStatus($query: String!) {
+query PrsWithCiStatusInternal($query: String!) {
   search(query: $query, type: ISSUE, first: 100) {
     nodes {
+      __typename # required for the type generator
       ... on PullRequest {
         id
         number

--- a/src/gh/prs_with_ci_status.rs
+++ b/src/gh/prs_with_ci_status.rs
@@ -1,43 +1,20 @@
-use serde::Deserialize;
+use crate::logging::ResultExt;
+use anyhow::Context;
 
-#[derive(Deserialize)]
-#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
-enum StatusState {
-    ERROR,
-    EXPECTED,
-    FAILURE,
-    PENDING,
-    SUCCESS,
-}
+// required to satisfy GraphQL interfaces for the `PullRequest` type
+type GitObjectID = String;
+#[expect(clippy::upper_case_acronyms)]
+type URI = String;
 
-#[derive(Deserialize)]
-struct StatusCheckRollup {
-    state: StatusState,
-}
+#[derive(graphql_client::GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gh/github.graphql",
+    query_path = "src/gh/prs_with_ci_status.gql"
+)]
+#[expect(dead_code, reason = "never used directly")]
+struct PrsWithCiStatusInternal;
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PullRequest {
-    id: String,
-    number: u64,
-    url: String,
-    title: String,
-    merged: bool,
-    head_ref_oid: String,
-    is_draft: bool,
-    is_in_merge_queue: bool,
-    status_check_rollup: Option<StatusCheckRollup>,
-}
-
-#[derive(Deserialize)]
-struct SearchResults {
-    nodes: Vec<PullRequest>,
-}
-
-#[derive(Deserialize)]
-pub struct PrsWithCiStatusInternal {
-    search: SearchResults,
-}
+pub use prs_with_ci_status_internal::ResponseData as PrsWithCiStatusResponseData;
 
 /// Status of CI checks for a pull request.
 #[derive(Debug, Clone, Copy)]
@@ -52,14 +29,20 @@ pub enum CiStatus {
     None,
 }
 
-impl From<Option<StatusCheckRollup>> for CiStatus {
-    fn from(value: Option<StatusCheckRollup>) -> Self {
+impl From<Option<prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequestStatusCheckRollup>>
+    for CiStatus
+{
+    fn from(
+        value: Option<prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequestStatusCheckRollup>,
+    ) -> Self {
+        use prs_with_ci_status_internal::StatusState;
         match value {
             None => Self::None,
             Some(rollup) => match rollup.state {
                 StatusState::ERROR | StatusState::FAILURE => Self::Failed,
                 StatusState::EXPECTED | StatusState::PENDING => Self::Pending,
                 StatusState::SUCCESS => Self::Success,
+                StatusState::Other(_) => Self::None,
             },
         }
     }
@@ -90,26 +73,40 @@ pub struct PrWithCiStatus {
     pub ci_status: CiStatus,
 }
 
-impl From<PrsWithCiStatusInternal> for Vec<PrWithCiStatus> {
-    fn from(value: PrsWithCiStatusInternal) -> Self {
-        value
-            .search
-            .nodes
+impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
+    fn from(value: prs_with_ci_status_internal::ResponseData) -> Self {
+        let Some(nodes) = value.search.nodes else {
+            return vec![];
+        };
+        nodes
             .into_iter()
+            .filter_map(|n| match n {
+                Some(
+                    prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodes::PullRequest(
+                        pr,
+                    ),
+                ) => Some(pr),
+                _ => None,
+            })
             .map(
-                |PullRequest {
+                |prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequest {
                      id,
                      number,
                      url,
                      title,
-                     merged,
                      head_ref_oid,
                      is_draft,
+                     merged,
                      is_in_merge_queue,
                      status_check_rollup,
                  }| PrWithCiStatus {
                     id,
-                    number,
+                    // PR numbers will always fit in a u64, this is fine.
+                    number: number
+                        .try_into()
+                        .context("Encountered invalid PR number")
+                        .log_err()
+                        .unwrap(),
                     url,
                     title,
                     merged,

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -3,7 +3,7 @@
 use super::{CreatePrRequest, Gh, PrCreated, PrDetails, PrSummary};
 use crate::{
     config::AutoMergeMethod,
-    gh::prs_with_ci_status::{PrWithCiStatus, PrsWithCiStatusInternal},
+    gh::prs_with_ci_status::{PrWithCiStatus, PrsWithCiStatusResponseData},
 };
 use anyhow::{Context, Result, anyhow};
 use octocrab::{Octocrab, params};
@@ -170,7 +170,7 @@ impl Gh for OctocrabGh {
             });
             let batch: Vec<PrWithCiStatus> = self
                 .octo
-                .graphql::<PrsWithCiStatusInternal>(&payload)
+                .graphql::<PrsWithCiStatusResponseData>(&payload)
                 .await
                 .map_err(humanize)
                 .context("fetching local PRs")?

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,8 +7,26 @@ use log::Record;
 use nu_ansi_term::{Color, Style};
 
 pub use log::{LevelFilter, debug, error, info, warn};
+use std::fmt::Display;
 
 const ENV_FILTER: &str = "JJ_GH_LOG";
+
+pub trait ResultExt {
+    #[must_use]
+    fn log_err(self) -> Self;
+}
+
+impl<T, E> ResultExt for Result<T, E>
+where
+    E: Display,
+{
+    fn log_err(self) -> Self {
+        if let Err(e) = &self {
+            log::error!("{e}");
+        }
+        self
+    }
+}
 
 /// Initialize the global logger. Holding onto the returned handle keeps the
 /// logger alive for the duration of the program.


### PR DESCRIPTION
Refactors how the GraphQL query is submitted using `graphql_client` crate to generate the response types.

This works well because the schema file will update with `flake.lock` and we will get CI failures telling us we need to update the query.

Closes #49 