### PR TITLE
fix(docs): Fix `jj` alias in example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can either use the overlay directly, or use the `home-manager` module.
   imports = [ jj-gh.homeManagerModules.default ];
   programs.jujutsu.gh = {
     # this will set up some jj aliases like
-    # pr = ["util", "exec", "--", "jj-gh", "pr", "--"]
+    # pr = ["util", "exec", "--", "jj-gh", "pr"]
     enable = true;
     settings = {
       gh_askpass = [


### PR DESCRIPTION
Fix Nix installation example
