### PR TITLE
feat(pr-log): Show whether auto-merge is enabled

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -121,7 +121,11 @@ Enable auto-merge on a PR. Accepts either a PR number or a revision; with a revi
 
 ## `jj-gh pr log`
 
-Like `jj log`, but injects PR metadata (number, CI status, URL) as template aliases keyed by `commit_id` and renders inline PR info in the default template. Any arguments after `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`
+Like `jj log`, but injects PR metadata (number, CI status, URL) as template aliases keyed by `commit_id` and renders inline PR info in the default template. Any arguments after `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`.
+
+The following template aliases are available for use if you pass your own template instead of using the default:
+
+`pr_number`, `pr_url`, `pr_ci_status`, `pr_merge_status`, `pr_meta` (formatted string containing all PR information).
 
 **Usage:** `jj-gh pr log [OPTIONS] [-- <JJ_LOG_ARGS>...]`
 

--- a/src/gh/prs_with_ci_status.gql
+++ b/src/gh/prs_with_ci_status.gql
@@ -11,6 +11,9 @@ query PrsWithCiStatusInternal($query: String!) {
         isDraft
         merged
         isInMergeQueue
+        autoMergeRequest {
+          enabledAt
+        }
         statusCheckRollup {
           state
         }

--- a/src/gh/prs_with_ci_status.rs
+++ b/src/gh/prs_with_ci_status.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 
 // required to satisfy GraphQL interfaces for the `PullRequest` type
 type GitObjectID = String;
+type DateTime = String;
 #[expect(clippy::upper_case_acronyms)]
 type URI = String;
 
@@ -51,6 +52,7 @@ impl From<Option<prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodes
 /// Open PR with CI status and head commit SHA. Used by `jj-gh pr log` to map
 /// jj revisions to their PR metadata.
 #[derive(Debug)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct PrWithCiStatus {
     /// GraphQL node ID.
     pub id: String,
@@ -71,6 +73,8 @@ pub struct PrWithCiStatus {
     pub is_in_merge_queue: bool,
     /// Rolled-up CI status across all required checks.
     pub ci_status: CiStatus,
+    /// Whether auto-merge enabled for this PR
+    pub auto_merge_enabled: bool,
 }
 
 impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
@@ -99,6 +103,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                      merged,
                      is_in_merge_queue,
                      status_check_rollup,
+                     auto_merge_request,
                  }| PrWithCiStatus {
                     id,
                     // PR numbers will always fit in a u64, this is fine.
@@ -114,6 +119,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                     is_in_merge_queue,
                     head_sha: head_ref_oid,
                     ci_status: status_check_rollup.into(),
+                    auto_merge_enabled: auto_merge_request.is_some_and(|r| r.enabled_at.is_some()),
                 },
             )
             .collect()

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -51,6 +51,12 @@ pub enum PrAction {
     /// template aliases keyed by `commit_id` and renders inline PR info in the
     /// default template. Any arguments after `--` are forwarded to the
     /// underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`.
+    ///
+    /// The following template aliases are available for use if you pass your
+    /// own template instead of using the default:
+    ///
+    /// `pr_number`, `pr_url`, `pr_ci_status`, `pr_merge_status`, `pr_meta` (formatted string
+    /// containing all PR information).
     #[command(visible_alias = "l")]
     Log(PrLogArgs),
 }
@@ -81,7 +87,7 @@ pub async fn dispatch(action: PrAction) -> Result<()> {
         PrAction::Create(args) => create::run(&jj, &gh, &editor, &config, &args).await?,
         PrAction::Fetch(args) => fetch::run(&jj, &gh, &config, &args).await?,
         PrAction::AutoMerge(args) => auto_merge::run(&jj, &gh, &config, &args).await?,
-        PrAction::Log(args) => pr_log::log(&args, &config, &gh, &jj).await?,
+        PrAction::Log(args) => pr_log::run(&args, &config, &gh, &jj).await?,
     }
 
     Ok(())

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -57,7 +57,7 @@ pub struct PrLogArgs {
     pub no_nerdfonts: bool,
 }
 
-pub async fn log(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
+pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
     let origin_url = jj
         .remote_url("origin")
         .await?
@@ -113,6 +113,9 @@ fn render_config(prs: &[PrWithCiStatus], config: &Config) -> String {
     let number = if_chain_alias(prs, |pr| format!(r#""{}""#, pr.number));
     let url = if_chain_alias(prs, |pr| format!(r#""{}""#, escape_toml_dq(&pr.url)));
     let status = if_chain_alias(prs, |pr| format!(r#""{}""#, ci_status_str(pr.ci_status)));
+    let merge_status = if_chain_alias(prs, |pr| {
+        format!(r#""{}""#, merge_status(pr, config).unwrap_or_default())
+    });
     let meta = if_chain_alias(prs, |pr| render_pr_meta_body(pr, config));
 
     format!(
@@ -121,6 +124,7 @@ pr_number = '''{number}'''
 pr_url = '''{url}'''
 pr_ci_status = '''{status}'''
 pr_meta = '''{meta}'''
+pr_merge_status = '''{merge_status}'''
 pr_log = '''
 if(root,
   format_root_commit(self),
@@ -168,19 +172,32 @@ fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
         None => template,
     };
 
-    template = match merge_metadata(pr) {
-        Some(metadata) => format!(r#"{template} ++ " " ++ {metadata}"#),
+    template = match merge_status(pr, config) {
+        Some(metadata) => {
+            format!(
+                r#"{template} ++ " " ++ label("gh-pr-merge-status", "(") ++ {metadata} ++ label("gh-pr-merge-status", ")")"#
+            )
+        }
         None => template,
     };
 
     template
 }
 
-fn merge_metadata(pr: &PrWithCiStatus) -> Option<&'static str> {
+fn merge_status(pr: &PrWithCiStatus, config: &Config) -> Option<String> {
     if pr.merged {
-        Some(r#"label("gh-pr-merge-status", "( merged)")"#)
+        let icon = if config.nerdfonts { " " } else { "" };
+        Some(format!(r#"label("gh-pr-merge-status", "{icon}merged")"#))
     } else if pr.is_in_merge_queue {
-        Some(r#"label("gh-pr-merge-status", "( in merge queue)")"#)
+        let icon = if config.nerdfonts { " " } else { "" };
+        Some(format!(
+            r#"label("gh-pr-merge-status", "{icon}in merge queue")"#
+        ))
+    } else if pr.auto_merge_enabled {
+        let icon = if config.nerdfonts { "󰾨 " } else { "" };
+        Some(format!(
+            r#"label("gh-pr-merge-status", "{icon}auto-merge enabled")"#
+        ))
     } else {
         None
     }
@@ -243,10 +260,16 @@ mod tests {
             is_in_merge_queue: false,
             ci_status: status,
             merged: false,
+            auto_merge_enabled: false,
         }
     }
 
-    fn pr_merge_status(number: u64, merged: bool, is_in_merge_queue: bool) -> PrWithCiStatus {
+    fn pr_merge_status(
+        number: u64,
+        merged: bool,
+        is_in_merge_queue: bool,
+        auto_merge_enabled: bool,
+    ) -> PrWithCiStatus {
         PrWithCiStatus {
             id: format!("ID{number}"),
             number,
@@ -255,6 +278,7 @@ mod tests {
             head_sha: number.to_string(),
             is_draft: false,
             ci_status: CiStatus::Success,
+            auto_merge_enabled,
             is_in_merge_queue,
             merged,
         }
@@ -323,13 +347,17 @@ mod tests {
 
     #[test]
     fn default_template_shows_merge_metadata() {
-        let prs = vec![
-            pr_merge_status(1, true, false),
-            pr_merge_status(2, false, true),
-        ];
+        let prs = vec![pr_merge_status(1, true, false, false)];
         let cfg = render_config(&prs, &Config::default());
-        assert!(cfg.contains("( in merge queue)"));
-        assert!(cfg.contains("( merged)"));
+        assert!(cfg.contains(" merged"));
+
+        let prs = vec![pr_merge_status(2, false, true, false)];
+        let cfg = render_config(&prs, &Config::default());
+        assert!(cfg.contains(" in merge queue"), "{}", cfg);
+
+        let prs = vec![pr_merge_status(3, false, false, true)];
+        let cfg = render_config(&prs, &Config::default());
+        assert!(cfg.contains("󰾨 auto-merge enabled"));
     }
 
     #[test]


### PR DESCRIPTION
Add an indicator as to whether auto-merge is enabled in the default template
