### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/mrjones2014/jj-gh/releases/tag/jj-gh-v0.1.0) - 2026-05-25
+
+### Added
+
+- *(ci)* Setup `release-plz` to publish to crates.io
+- *(pr-log)* Show whether auto-merge is enabled
+- *(pr-log)* Show merge status in `pr log` default template
+- *(log)* Use nerdfont icons in default template
+- *(cli)* Add `pr log` subcommand
+- *(docs)* Auto generate docs
+- *(cli)* Prettier log format
+- *(nix)* Add home-manager module
+- *(cli)* Add feature to fetch PRs across forks
+- *(ci)* Use `cargo-udeps`
+- *(ci)* Add nix cache action
+- *(cli)* Use `trunk()` revset to detect default branch
+- *(pr)* End-to-end `pr create` orchestrator
+- *(gh)* GitHub API client and PR target resolution
+- *(jj)* Read layer for revs, bookmarks, and remotes
+- *(config)* Implement configuration and `gh-askpass` functionality
+- *(cli)* Initial setup
+
+### Fixed
+
+- *(docs)* Fix `jj` alias in example docs
+- *(cli)* Fix boolean argument parsing and config layering
+- *(treefmt)* Format `*.gql` files with prettier
+- *(graphql)* Use search query to pull PRs more precisely
+- *(lints)* Show warnings normally in LSP but deny in flake checks
+- *(alias)* Fix how `jj` alias is set up
+- *(alias)* Fix how `jj` alias is set up
+- *(docs)* Fix `jj` alias docs for manual install
+- *(cli)* Fix boolean option handling
+- *(cli)* Fix help text
+- move graphql-validate script out of nix/ directory
+- *(docs)* Fix home-manager module
+- *(docs)* Fix home-manager module
+- *(nix)* Fix home-manager module definition
+- *(docs)* Fix home-manager module docs
+- *(template)* Add additional newline
+- *(pr)* Fix open PR resolution w.r.t forks vs. not fork
+- *(config)* Use `jj` to resolve canonical config files
+- *(config)* Use `[jj-gh]` key for config
+- *(ci)* Allow dispatching manually
+- *(ci)* Add correct permissions for caching
+- *(ci)* Run on correct branch
+
+### Other
+
+- *(pr)* Add utility to lookup PR from number or revision
+- *(cli)* Improve `pr` module organization
+- *(cli)* Simplify argument handling by using `figment` more
+- *(ci)* Automated flake.lock updates
+- *(tools)* Set up treefmt.nix
+- *(docs)* Document required GitHub token permissions
+- *(cli)* Consistently use `tokio::process:Command`
+- *(docs)* Document using nix to build
+- *(cli)* Use dispatcher pattern for `pr` subcommand
+- *(docs)* Add README.md
+- *(cli)* Drop dependency on `git` on `$PATH`
+- *(ci)* Add GitHub Actions


### PR DESCRIPTION



## 🤖 New release

* `jj-gh`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/mrjones2014/jj-gh/releases/tag/jj-gh-v0.1.0) - 2026-05-25

### Added

- *(ci)* Setup `release-plz` to publish to crates.io
- *(pr-log)* Show whether auto-merge is enabled
- *(pr-log)* Show merge status in `pr log` default template
- *(log)* Use nerdfont icons in default template
- *(cli)* Add `pr log` subcommand
- *(docs)* Auto generate docs
- *(cli)* Prettier log format
- *(nix)* Add home-manager module
- *(cli)* Add feature to fetch PRs across forks
- *(ci)* Use `cargo-udeps`
- *(ci)* Add nix cache action
- *(cli)* Use `trunk()` revset to detect default branch
- *(pr)* End-to-end `pr create` orchestrator
- *(gh)* GitHub API client and PR target resolution
- *(jj)* Read layer for revs, bookmarks, and remotes
- *(config)* Implement configuration and `gh-askpass` functionality
- *(cli)* Initial setup

### Fixed

- *(docs)* Fix `jj` alias in example docs
- *(cli)* Fix boolean argument parsing and config layering
- *(treefmt)* Format `*.gql` files with prettier
- *(graphql)* Use search query to pull PRs more precisely
- *(lints)* Show warnings normally in LSP but deny in flake checks
- *(alias)* Fix how `jj` alias is set up
- *(alias)* Fix how `jj` alias is set up
- *(docs)* Fix `jj` alias docs for manual install
- *(cli)* Fix boolean option handling
- *(cli)* Fix help text
- move graphql-validate script out of nix/ directory
- *(docs)* Fix home-manager module
- *(docs)* Fix home-manager module
- *(nix)* Fix home-manager module definition
- *(docs)* Fix home-manager module docs
- *(template)* Add additional newline
- *(pr)* Fix open PR resolution w.r.t forks vs. not fork
- *(config)* Use `jj` to resolve canonical config files
- *(config)* Use `[jj-gh]` key for config
- *(ci)* Allow dispatching manually
- *(ci)* Add correct permissions for caching
- *(ci)* Run on correct branch

### Other

- *(pr)* Add utility to lookup PR from number or revision
- *(cli)* Improve `pr` module organization
- *(cli)* Simplify argument handling by using `figment` more
- *(ci)* Automated flake.lock updates
- *(tools)* Set up treefmt.nix
- *(docs)* Document required GitHub token permissions
- *(cli)* Consistently use `tokio::process:Command`
- *(docs)* Document using nix to build
- *(cli)* Use dispatcher pattern for `pr` subcommand
- *(docs)* Add README.md
- *(cli)* Drop dependency on `git` on `$PATH`
- *(ci)* Add GitHub Actions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).