### PR TITLE
fix(ci): Omit `CHANGELOG.md` from `treefmt.nix` checks.

### DIFF
--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -12,6 +12,7 @@
         "*.md"
         "*.gql"
       ];
+      excludes = [ "CHANGELOG.md" ];
     };
     taplo.enable = true;
     yamlfmt.enable = true;


### PR DESCRIPTION
Formatting checks otherwise fail because `release-plz` generates opinionated `keep-a-changelog` format `CHANGELOG.md`.
