### PR TITLE
fix(dev): Remove `release-plz` from Nix `devShell`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,6 @@
             pkgs.cargo-semver-checks
             pkgs.cargo-udeps
             pkgs.jujutsu
-            pkgs.release-plz
             pkgs.rust-analyzer
             treefmtEval.config.build.wrapper
           ];


### PR DESCRIPTION
The Nix `devShell` does not activate on macOS because `release-plz` is marked broken on Darwin in `nixpkgs`.

We don't ever use it locally anyway, I just had it there to test with while I was initially setting it up. `release-plz` should only ever be called from CI, the crates.io side will only accept trusted publishing from GitHub Actions anyway.
