### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.0...jj-gh-v0.1.1) - 2026-05-26
+
+### Fixed
+
+- *(cli)* Support tokens from `GH_TOKEN` and `JJ_GH_TOKEN` env vars
+
 ## [0.1.0](https://github.com/mrjones2014/jj-gh/releases/tag/jj-gh-v0.1.0) - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jj-gh"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.1.0"
+version = "0.1.1"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",


### PR DESCRIPTION



## 🤖 New release

* `jj-gh`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.0...jj-gh-v0.1.1) - 2026-05-26

### Fixed

- *(cli)* Support tokens from `GH_TOKEN` and `JJ_GH_TOKEN` env vars
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).