### PR TITLE
fix(changelog): Drop unused `## Unreleased` section from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.1.0](https://github.com/mrjones2014/jj-gh/releases/tag/jj-gh-v0.1.0) - 2026-05-25
 
 ### Added

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,15 @@
 [workspace]
 semver_check = true
 
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+
 [[package]]
 name = "jj-gh"
 changelog_update = true


### PR DESCRIPTION
The way our releases work, `## Unreleased` will always be empty, since `CHANGELOG.md` only gets updated on release.
