### PR TITLE
fix(cli): Add completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1072,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "figment",
  "flexi_logger",
  "graphql_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = ["tools/gen-docs"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 figment = { version = "0.10", features = ["toml"] }
 flexi_logger = { version = "0.31", default-features = false, features = [
   "colors",

--- a/DOCS.md
+++ b/DOCS.md
@@ -17,6 +17,7 @@ This document contains the help content for the `jj-gh` command-line program.
 - [`jj-gh debug auth`↴](#jj-gh-debug-auth)
 - [`jj-gh debug rev`↴](#jj-gh-debug-rev)
 - [`jj-gh debug pr-lookup`↴](#jj-gh-debug-pr-lookup)
+- [`jj-gh completions`↴](#jj-gh-completions)
 
 ## `jj-gh`
 
@@ -28,6 +29,7 @@ Opinionated `jj` tools for working with GitHub from your terminal
 
 - `pr` — Commands to work with PRs
 - `debug` — Diagnostic subcommands. Useful for inspecting the resolved config and pre-flight checks
+- `completions` — Generate completions (on stdout) for the specified shell
 
 ###### **Options:**
 
@@ -186,6 +188,18 @@ Pre-flight lookup for a PR: resolve the target, check if a PR is already open fo
 ###### **Arguments:**
 
 - `<REV>`
+
+## `jj-gh completions`
+
+Generate completions (on stdout) for the specified shell
+
+**Usage:** `jj-gh completions <SHELL>`
+
+###### **Arguments:**
+
+- `<SHELL>`
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
 
 <hr/>
 

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,21 @@
           // {
             inherit cargoArtifacts;
             cargoExtraArgs = "--package jj-gh";
+
+            nativeBuildInputs = [
+              pkgs.installShellFiles
+            ];
+
+            postInstall =
+              let
+                jj-gh = "${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} $out/bin/jj-gh";
+              in
+              pkgs.lib.optionalString (pkgs.stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages) ''
+                installShellCompletion --cmd jj-gh \
+                  --bash <(${jj-gh} completions bash) \
+                  --fish <(${jj-gh} completions fish) \
+                  --zsh <(${jj-gh} completions zsh)
+              '';
           }
         );
         gen-docs = craneLib.buildPackage (

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 
 use crate::pr::PrAction;
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 use log::LevelFilter;
 use serde::Serialize;
 use std::io::IsTerminal;
@@ -67,6 +68,8 @@ pub enum Command {
         #[command(subcommand)]
         action: DebugAction,
     },
+    /// Generate completions (on stdout) for the specified shell
+    Completions { shell: Shell },
 }
 
 #[derive(Debug, clap::Args, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use clap::CommandFactory as _;
+
 mod auth;
 mod cli;
 mod config;
@@ -17,7 +19,7 @@ pub use cli::{Cli, Command};
 /// # Errors
 ///
 /// Propagates the errors from each subcommand.
-pub async fn dispatch() -> anyhow::Result<()> {
+pub async fn dispatch(bin_name: &str) -> anyhow::Result<()> {
     use clap::Parser;
 
     let args = Cli::parse();
@@ -25,6 +27,9 @@ pub async fn dispatch() -> anyhow::Result<()> {
     match args.command {
         Command::Pr { action } => pr::dispatch(action).await?,
         Command::Debug { action } => debug::dispatch(action).await?,
+        Command::Completions { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), bin_name, &mut std::io::stdout());
+        }
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,11 @@ use anyhow::Result;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    jj_gh::dispatch().await
+    let bin_name = std::env::current_exe().ok();
+    let bin_name = bin_name
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .and_then(|o| o.to_str())
+        .unwrap_or(env!("CARGO_BIN_NAME"));
+    jj_gh::dispatch(bin_name).await
 }


### PR DESCRIPTION
Adds a subcommand to generate completions for a given shell

The Nix derivation will automatically install generated completions for bash/fish/zsh