### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.1...jj-gh-v0.1.2) - 2026-05-27
+
+### Added
+
+- *(pr-create)* Add `reviewers` to frontmatter fields
+- *(cli)* Add completions
+- *(cli)* Add completions when invoked as a `jj` alias
+
+### Fixed
+
+- *(git)* Use `gix` crate to resolve git configs and such
+- *(pr-log)* Fix missing PRs for locally diverged bookmarks
+- *(pr)* Remove extraneous newline when opening editor
+
 ## [0.1.1](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.0...jj-gh-v0.1.1) - 2026-05-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.1.1"
+version = "0.1.2"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",


### PR DESCRIPTION



## 🤖 New release

* `jj-gh`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.1...jj-gh-v0.1.2) - 2026-05-27

### Added

- *(pr-create)* Add `reviewers` to frontmatter fields

### Fixed

- *(git)* Use `gix` crate to resolve git configs and such
- *(pr-log)* Fix missing PRs for locally diverged bookmarks

### Other

- Add completions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).