### PR TITLE
fix(cli): Add completions when invoked as `jj` alias

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -191,15 +191,24 @@ Pre-flight lookup for a PR: resolve the target, check if a PR is already open fo
 
 ## `jj-gh completions`
 
-Generate completions (on stdout) for the specified shell
+Generate completions (on stdout) for the specified shell.
 
-**Usage:** `jj-gh completions <SHELL>`
+Without flags, emits a standalone completion script for the `jj-gh` binary. With `--jj-alias <NAME> --subcommand <NAME>` (both required together), emits an overlay that adds completions for `jj <jj-alias> <tab>` on top of jj's own completion script (source the overlay _after_ `jj util completion <shell>`).
+
+**Usage:** `jj-gh completions [OPTIONS] <SHELL>`
 
 ###### **Arguments:**
 
 - `<SHELL>`
 
   Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
+###### **Options:**
+
+- `--jj-alias <NAME>` — Emit an overlay for `jj <NAME> <tab>` instead of the standalone `jj-gh` script. Pass the jj alias name (e.g. `pr`). Must be paired with `--subcommand`
+- `--subcommand <NAME>` — jj-gh top-level subcommand whose tree the overlay describes (e.g. `pr`). Must be paired with `--jj-alias`
+
+  Possible values: `pr`
 
 <hr/>
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ You can either use the overlay directly, or use the `home-manager` module.
   # home-manager
   imports = [ jj-gh.homeManagerModules.default ];
   programs.jujutsu.gh = {
-    # this will set up some jj aliases like
-    # pr = ["util", "exec", "--", "jj-gh", "pr"]
     enable = true;
+    # Map of `jj` alias name -> `jj-gh` subcommand. Each entry installs the
+    # alias *and* drops a completion overlay for `jj <name> <tab>` into any
+    # shell home-manager has enabled (fish/bash/zsh).
+    # aliases = { pr = "pr"; };
     settings = {
       gh_askpass = [
         "op"
@@ -111,6 +113,28 @@ pr = ["util", "exec", "--", "jj-gh", "pr"]
 
 Now `jj pr create <rev>` (and the alias `jj pr c <rev>`) and `jj pr fetch <pr-num>` (alias `jj pr f <pr-num>`) work like any other `jj`
 subcommand.
+
+### Shell completions
+
+`jj-gh completions <shell>` prints a standard completion script for the `jj-gh` binary. For the more common case where you invoke `jj-gh` through a `jj` alias (e.g. `jj pr <tab>`), pass `--jj-alias <NAME> --subcommand <NAME>` (both required together) to emit an overlay that adds completions for the alias on top of jj's own completion script.
+
+```sh
+# fish
+jj util completion fish | source
+jj-gh completions fish --jj-alias pr --subcommand pr | source
+
+# bash
+eval "$(jj util completion bash)"
+eval "$(jj-gh completions bash --jj-alias pr --subcommand pr)"
+
+# zsh (after compinit)
+source <(jj util completion zsh)
+source <(jj-gh completions zsh --jj-alias pr --subcommand pr)
+```
+
+The overlay must be sourced _after_ `jj util completion <shell>` so it can chain to jj's completer when the alias is not the one being completed.
+
+If you use the `home-manager` module with `programs.fish.enable` / `programs.bash.enable` / `programs.zsh.enable` set, the matching overlay is wired up automatically for every entry in `programs.jujutsu.gh.aliases`. You only need the manual steps above when installing via `cargo install` or from source.
 
 ## Config
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -29,6 +29,22 @@ let
       pr_fetch_bookmark_template
       ;
   };
+
+  mkJjAliasArgv = subcmd: [
+    "util"
+    "exec"
+    "--"
+    "${cfg.package}/bin/jj-gh"
+    subcmd
+  ];
+
+  mkOverlay =
+    shell: aliasName: subcmd:
+    pkgs.runCommand "jj-gh-${shell}-${aliasName}-overlay" { } ''
+      ${cfg.package}/bin/jj-gh completions ${shell} \
+        --jj-alias ${aliasName} \
+        --subcommand ${subcmd} > $out
+    '';
 in
 {
   options.programs.jujutsu.gh = {
@@ -39,6 +55,24 @@ in
       default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
       defaultText = lib.literalExpression "jj-gh.packages.\${system}.default";
       description = "The jj-gh package to install.";
+    };
+
+    aliases = mkOption {
+      type = types.attrsOf types.str;
+      default = {
+        pr = "pr";
+      };
+      example = {
+        pr = "pr";
+      };
+      description = ''
+        Map of `jj` alias name -> `jj-gh` subcommand. Each entry:
+
+        - Installs `programs.jujutsu.settings.aliases.<name>` dispatching to
+          `jj-gh <subcommand>` (so e.g. `jj pr create` runs `jj-gh pr create`).
+        - Drops a shell completion overlay for `jj <name> <tab>` into each
+          enabled shell (fish/bash/zsh), so completions work out of the box.
+      '';
     };
 
     settings = {
@@ -107,19 +141,47 @@ in
     };
   };
 
-  config = mkIf (cfg.enable && config.programs.jujutsu.enable) {
-    home.packages = [ cfg.package ];
-    programs.jujutsu.settings = mkMerge [
-      {
-        aliases.pr = lib.mkDefault [
-          "util"
-          "exec"
-          "--"
-          "${cfg.package}/bin/jj-gh"
-          "pr"
-        ];
-      }
-      (optionalAttrs (jjGhTable != { }) { "jj-gh" = jjGhTable; })
-    ];
-  };
+  config = mkIf (cfg.enable && config.programs.jujutsu.enable) (mkMerge [
+    {
+      home.packages = [ cfg.package ];
+      programs.jujutsu.settings = mkMerge [
+        {
+          aliases = lib.mapAttrs (_: subcmd: lib.mkDefault (mkJjAliasArgv subcmd)) cfg.aliases;
+        }
+        (optionalAttrs (jjGhTable != { }) { "jj-gh" = jjGhTable; })
+      ];
+    }
+
+    # fish: source overlays from interactiveShellInit. Fish autoloads
+    # completion files by filename match (`<cmd>.fish`), so dropping
+    # `jj-gh-<alias>-overlay.fish` into `completions/` would never fire on
+    # `jj <tab>`. Sourcing from interactive init registers the rules
+    # against `jj` directly; fish then unions them with jj's own.
+    (mkIf (config.programs.fish.enable && cfg.aliases != { }) {
+      programs.fish.interactiveShellInit = lib.concatMapStringsSep "\n" (n: ''
+        source ${mkOverlay "fish" n cfg.aliases.${n}}
+      '') (lib.attrNames cfg.aliases);
+    })
+
+    # bash: source overlays from initExtra. The overlays self-bootstrap —
+    # each one calls bash-completion's dynamic loader to force jj's own
+    # completion to load before snapshotting the prior `complete -F`
+    # handler, so we don't need to `eval "$(jj util completion bash)"`
+    # here.
+    (mkIf (config.programs.bash.enable && cfg.aliases != { }) {
+      programs.bash.initExtra = lib.concatMapStringsSep "\n" (n: ''
+        source ${mkOverlay "bash" n cfg.aliases.${n}}
+      '') (lib.attrNames cfg.aliases);
+    })
+
+    # zsh: source overlays from initExtra. initExtra runs after compinit
+    # in home-manager's .zshrc, so `_comps[jj]` is already populated from
+    # `_jj` in fpath (nixpkgs jujutsu ships it under
+    # share/zsh/site-functions) and the overlays can snapshot it directly.
+    (mkIf (config.programs.zsh.enable && cfg.aliases != { }) {
+      programs.zsh.initExtra = lib.concatMapStringsSep "\n" (n: ''
+        source ${mkOverlay "zsh" n cfg.aliases.${n}}
+      '') (lib.attrNames cfg.aliases);
+    })
+  ]);
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 //! CLI arg parser
 
-use crate::pr::PrAction;
+use crate::{completions::SubcommandStr, pr::PrAction};
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 use log::LevelFilter;
@@ -68,8 +68,25 @@ pub enum Command {
         #[command(subcommand)]
         action: DebugAction,
     },
-    /// Generate completions (on stdout) for the specified shell
-    Completions { shell: Shell },
+    /// Generate completions (on stdout) for the specified shell.
+    ///
+    /// Without flags, emits a standalone completion script for the `jj-gh`
+    /// binary. With `--jj-alias <NAME> --subcommand <NAME>` (both required
+    /// together), emits an overlay that adds completions for
+    /// `jj <jj-alias> <tab>` on top of jj's own completion script (source
+    /// the overlay *after* `jj util completion <shell>`).
+    Completions {
+        shell: Shell,
+        /// Emit an overlay for `jj <NAME> <tab>` instead of the standalone
+        /// `jj-gh` script. Pass the jj alias name (e.g. `pr`). Must be
+        /// paired with `--subcommand`.
+        #[arg(long = "jj-alias", value_name = "NAME", requires = "jj_gh_subcommand")]
+        jj_alias: Option<String>,
+        /// jj-gh top-level subcommand whose tree the overlay describes
+        /// (e.g. `pr`). Must be paired with `--jj-alias`.
+        #[arg(long = "subcommand", value_name = "NAME", requires = "jj_alias")]
+        jj_gh_subcommand: Option<SubcommandStr>,
+    },
 }
 
 #[derive(Debug, clap::Args, Serialize)]

--- a/src/completions/bash.rs
+++ b/src/completions/bash.rs
@@ -1,0 +1,144 @@
+use super::{ArgInfo, SubInfo, collect_subs};
+use anyhow::Result;
+use clap::Command;
+use core::fmt::Write as _;
+use std::io::Write;
+
+pub(super) fn emit<W: Write>(cmd: &Command, alias: &str, out: &mut W) -> Result<()> {
+    let subs = collect_subs(cmd);
+    writeln!(
+        out,
+        "# jj-gh: completion overlay for `jj {alias} <tab>` (do not edit)\n\
+         # Safe to source any time after bash-completion is initialised; the\n\
+         # overlay triggers jj's own lazy completion load before snapshotting."
+    )?;
+    write!(out, "{}", wrapper(alias, &subs))?;
+    Ok(())
+}
+
+fn wrapper(alias: &str, subs: &[SubInfo]) -> String {
+    let sub_names: Vec<String> = subs
+        .iter()
+        .flat_map(|s| {
+            std::iter::once(s.name.to_string()).chain(s.aliases.iter().map(ToString::to_string))
+        })
+        .collect();
+    let sub_list = sub_names.join(" ");
+    let per_sub_cases = build_cases(subs);
+
+    format!(
+        r#"if ! declare -F _jj_gh_alias_wrapper_{alias} >/dev/null 2>&1; then
+    _jj_gh_alias_inner_{alias}() {{
+        local cur sub
+        cur="${{COMP_WORDS[COMP_CWORD]}}"
+        sub="${{COMP_WORDS[2]:-}}"
+        if [[ "$COMP_CWORD" -le 2 ]]; then
+            COMPREPLY=( $(compgen -W "{sub_list}" -- "$cur") )
+            return 0
+        fi
+        case "$sub" in
+{per_sub_cases}        esac
+        COMPREPLY=()
+        return 0
+    }}
+
+    # nixpkgs `jujutsu` ships jj's bash completion at
+    # share/bash-completion/completions/jj, which bash-completion only
+    # sources on the first `jj <tab>`. Force-load it now so the snapshot
+    # below finds a real handler instead of an empty `complete -p jj`.
+    if ! complete -p jj >/dev/null 2>&1; then
+        if declare -F _comp_load >/dev/null 2>&1; then
+            _comp_load jj 2>/dev/null || true
+        elif declare -F _completion_loader >/dev/null 2>&1; then
+            _completion_loader jj 2>/dev/null || true
+        fi
+    fi
+
+    # Capture the prior `jj` completer (jj's own, or another alias overlay
+    # sourced earlier) so we can delegate when the user is not invoking
+    # `jj {alias}`. Parse with awk so we only pick up the function name
+    # after `-F`; any other `complete` form (`-W`, `-C`, ...) leaves the
+    # variable empty and the delegate path is skipped.
+    declare -g _jj_gh_alias_prior_{alias}
+    _jj_gh_alias_prior_{alias}=$(complete -p jj 2>/dev/null \
+        | awk '{{ for (i = 1; i < NF; i++) if ($i == "-F") {{ print $(i + 1); exit }} }}')
+
+    _jj_gh_alias_wrapper_{alias}() {{
+        if [[ "${{COMP_WORDS[1]:-}}" == "{alias}" ]]; then
+            _jj_gh_alias_inner_{alias} "$@"
+            return $?
+        fi
+        if [[ -n "$_jj_gh_alias_prior_{alias}" ]] \
+            && [[ "$_jj_gh_alias_prior_{alias}" != "_jj_gh_alias_wrapper_{alias}" ]] \
+            && declare -F "$_jj_gh_alias_prior_{alias}" >/dev/null 2>&1; then
+            "$_jj_gh_alias_prior_{alias}" "$@"
+            return $?
+        fi
+        COMPREPLY=()
+    }}
+
+    complete -F _jj_gh_alias_wrapper_{alias} jj
+fi
+"#
+    )
+}
+
+fn build_cases(subs: &[SubInfo]) -> String {
+    let mut out = String::new();
+    for sub in subs {
+        let names: Vec<&str> = std::iter::once(sub.name)
+            .chain(sub.aliases.iter().copied())
+            .collect();
+        let pattern = names.join("|");
+        let flags = flag_list(&sub.args);
+        writeln!(
+            out,
+            r#"            {pattern})
+                COMPREPLY=( $(compgen -W "{flags}" -- "$cur") )
+                return 0
+                ;;"#
+        )
+        .expect("writing to String never fails");
+    }
+    out
+}
+
+fn flag_list(args: &[ArgInfo]) -> String {
+    let mut flags: Vec<String> = Vec::new();
+    for a in args {
+        if let Some(long) = a.long {
+            flags.push(format!("--{long}"));
+        }
+        if let Some(short) = a.short {
+            flags.push(format!("-{short}"));
+        }
+    }
+    flags.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completions::fake_pr_command;
+
+    #[test]
+    fn wraps_and_chains() {
+        let mut out: Vec<u8> = Vec::new();
+        emit(&fake_pr_command(), "pr", &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+
+        assert!(s.contains("_jj_gh_alias_wrapper_pr"));
+        assert!(s.contains("_jj_gh_alias_inner_pr"));
+        assert!(s.contains("complete -F _jj_gh_alias_wrapper_pr jj"));
+        assert!(s.contains("compgen -W \"create c fetch\""));
+        assert!(s.contains("create|c)"));
+        assert!(s.contains("--draft"));
+        assert!(s.contains("--base"));
+        assert!(s.contains("\"${COMP_WORDS[1]:-}\" == \"pr\""));
+        assert!(s.contains("_jj_gh_alias_prior_pr"));
+        assert!(s.contains("declare -g _jj_gh_alias_prior_pr"));
+        assert!(s.contains("awk"));
+        assert!(s.contains("_comp_load jj"));
+        assert!(s.contains("_completion_loader jj"));
+    }
+}

--- a/src/completions/fish.rs
+++ b/src/completions/fish.rs
@@ -1,0 +1,119 @@
+use super::{ArgInfo, collect_subs, first_help_line};
+use anyhow::Result;
+use clap::Command;
+use std::io::Write;
+
+pub(super) fn emit<W: Write>(cmd: &Command, alias: &str, out: &mut W) -> Result<()> {
+    let subs = collect_subs(cmd);
+    writeln!(
+        out,
+        "# jj-gh: completion overlay for `jj {alias} <tab>` (do not edit)\n\
+         # Source *after* `jj util completion fish`."
+    )?;
+    writeln!(out, "{}", helpers())?;
+
+    for sub in &subs {
+        let names: Vec<&str> = std::iter::once(sub.name)
+            .chain(sub.aliases.iter().copied())
+            .collect();
+        for n in &names {
+            let line = match &sub.about {
+                Some(about) => format!(
+                    "complete -c jj -n '__jj_gh_alias_no_subcommand {alias}' -f -a '{n}' -d '{}'",
+                    escape(&first_help_line(about))
+                ),
+                None => {
+                    format!("complete -c jj -n '__jj_gh_alias_no_subcommand {alias}' -f -a '{n}'")
+                }
+            };
+            writeln!(out, "{line}")?;
+        }
+        let pred = sub_predicate(alias, &names);
+        for arg in &sub.args {
+            writeln!(out, "{}", arg_line(&pred, arg))?;
+        }
+    }
+    Ok(())
+}
+
+fn helpers() -> &'static str {
+    // Guarded so multiple sourcings (e.g. across nested fish shells, or
+    // overlays for several aliases) are idempotent. `commandline -opc`
+    // gives the tokens before the cursor; `$cmd[1]` is `jj`,
+    // `$cmd[2]` should equal the alias name we were emitted for.
+    "if not functions -q __jj_gh_alias_no_subcommand
+    function __jj_gh_alias_no_subcommand -a alias
+        set -l cmd (commandline -opc)
+        test (count $cmd) -eq 2
+        and test \"$cmd[2]\" = $alias
+    end
+    function __jj_gh_alias_at_subcommand
+        set -l alias $argv[1]
+        set -l names $argv[2..]
+        set -l cmd (commandline -opc)
+        test (count $cmd) -ge 3
+        and test \"$cmd[2]\" = $alias
+        and contains -- \"$cmd[3]\" $names
+    end
+end"
+}
+
+fn sub_predicate(alias: &str, names: &[&str]) -> String {
+    let names_str = names.join(" ");
+    format!("__jj_gh_alias_at_subcommand {alias} {names_str}")
+}
+
+fn arg_line(predicate: &str, arg: &ArgInfo) -> String {
+    let mut parts = vec![format!("complete -c jj -n '{predicate}'")];
+    if let Some(short) = arg.short {
+        parts.push(format!("-s {short}"));
+    }
+    if let Some(long) = arg.long {
+        parts.push(format!("-l {long}"));
+    }
+    if arg.takes_value {
+        parts.push("-r".into());
+    } else {
+        parts.push("-f".into());
+    }
+    if let Some(about) = &arg.about {
+        parts.push(format!("-d '{}'", escape(&first_help_line(about))));
+    }
+    parts.join(" ")
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completions::fake_pr_command;
+
+    #[test]
+    fn registers_against_jj_and_gates_on_alias() {
+        let mut out: Vec<u8> = Vec::new();
+        emit(&fake_pr_command(), "pr", &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+
+        assert!(s.contains("function __jj_gh_alias_no_subcommand"));
+        assert!(s.contains("complete -c jj -n '__jj_gh_alias_no_subcommand pr' -f -a 'create'"));
+        assert!(s.contains("complete -c jj -n '__jj_gh_alias_no_subcommand pr' -f -a 'c'"));
+        assert!(s.contains("complete -c jj -n '__jj_gh_alias_no_subcommand pr' -f -a 'fetch'"));
+        assert!(s.contains("__jj_gh_alias_at_subcommand pr create c"));
+        assert!(s.contains("-l draft"));
+        assert!(s.contains("-l base"));
+
+        let base_line = s
+            .lines()
+            .find(|l| l.contains("-l base"))
+            .expect("base line");
+        assert!(base_line.contains(" -r"));
+        let draft_line = s
+            .lines()
+            .find(|l| l.contains("-l draft") && !l.contains("no-draft"))
+            .expect("draft line");
+        assert!(draft_line.contains(" -f"));
+    }
+}

--- a/src/completions/mod.rs
+++ b/src/completions/mod.rs
@@ -1,0 +1,228 @@
+//! Shell completion overlay for `jj <alias> <tab>`.
+//!
+//! jj's static completion script (`jj util completion <shell>`) does not
+//! know about user-defined aliases. When a user aliases `pr` to
+//! `["util", "exec", "--", "jj-gh", "pr"]`, typing `jj pr <tab>` produces
+//! nothing because jj's script sees `pr` as an unknown subcommand.
+//!
+//! This module emits a *supplementary* completion fragment that registers
+//! against the `jj` binary but is predicated on the alias token being
+//! present in the command line. Sourced after jj's own script, it adds
+//! completion for the aliased subcommand tree. Multiple overlays (for
+//! different aliases) chain: each captures the prior `jj` completer at
+//! source time and delegates to it when the alias does not match.
+//!
+//! Inventory (subcommands, flags) is read from clap's `Command`
+//! introspection at runtime rather than duplicated by hand.
+
+mod bash;
+mod fish;
+mod zsh;
+
+use crate::pr::PrAction;
+use anyhow::{Result, bail};
+use clap::{Arg, Command, Subcommand};
+use std::{fmt::Display, io::Write};
+
+/// Shells for which an overlay can be emitted. Sibling to
+/// `clap_complete::Shell`, but narrower: only shells whose programmable
+/// completion model supports the layering we need (predicate-gated rules
+/// or wrapper functions) get a dedicated variant. Anything else lands in
+/// `Other` so the dispatch can produce a clear error referencing the name
+/// the user actually passed.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum Shell {
+    /// Bash.
+    Bash,
+    /// Fish.
+    Fish,
+    /// Zsh.
+    Zsh,
+    /// Any shell name we don't have an overlay implementation for. The
+    /// inner string is whatever the user passed (e.g. `"powershell"`,
+    /// `"elvish"`).
+    Other(String),
+}
+
+impl From<clap_complete::Shell> for Shell {
+    fn from(shell: clap_complete::Shell) -> Self {
+        match shell {
+            clap_complete::Shell::Bash => Self::Bash,
+            clap_complete::Shell::Fish => Self::Fish,
+            clap_complete::Shell::Zsh => Self::Zsh,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, clap::ValueEnum, Clone, Copy)]
+pub enum SubcommandStr {
+    Pr,
+}
+
+impl Display for SubcommandStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SubcommandStr::Pr => "pr",
+        })
+    }
+}
+
+// this is never actually used, but it gives us compiler errors when new subcommands are added
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+fn _ensure_subcmds_handled(cmd: crate::cli::Command) {
+    let _ = match cmd {
+        crate::Command::Pr { .. } => SubcommandStr::Pr,
+        subcmd @ (crate::Command::Debug { .. } | crate::Command::Completions { .. }) => {
+            unreachable!("{subcmd:?} is not supported in this position");
+        }
+    };
+}
+
+/// Emit a completion overlay for `jj <alias> <tab>` to `out`.
+pub fn run<W: Write>(
+    shell: Shell,
+    alias: &str,
+    subcommand: SubcommandStr,
+    out: &mut W,
+) -> Result<()> {
+    let cmd = match subcommand {
+        SubcommandStr::Pr => PrAction::augment_subcommands(Command::new("pr")),
+    };
+    match shell {
+        Shell::Fish => fish::emit(&cmd, alias, out)?,
+        Shell::Bash => bash::emit(&cmd, alias, out)?,
+        Shell::Zsh => zsh::emit(&cmd, alias, out)?,
+        Shell::Other(name) => bail!("--jj-alias overlay not supported for shell `{name}`"),
+    }
+    Ok(())
+}
+
+pub(super) struct SubInfo<'a> {
+    pub(super) name: &'a str,
+    pub(super) aliases: Vec<&'a str>,
+    pub(super) about: Option<String>,
+    pub(super) args: Vec<ArgInfo<'a>>,
+}
+
+pub(super) struct ArgInfo<'a> {
+    pub(super) long: Option<&'a str>,
+    pub(super) short: Option<char>,
+    pub(super) about: Option<String>,
+    pub(super) takes_value: bool,
+}
+
+pub(super) fn collect_subs(cmd: &Command) -> Vec<SubInfo<'_>> {
+    cmd.get_subcommands()
+        .filter(|s| !s.is_hide_set())
+        .map(|s| SubInfo {
+            name: s.get_name(),
+            aliases: s.get_visible_aliases().collect(),
+            about: s.get_about().map(ToString::to_string),
+            args: collect_args(s),
+        })
+        .collect()
+}
+
+fn collect_args(cmd: &Command) -> Vec<ArgInfo<'_>> {
+    cmd.get_arguments()
+        .filter(|a| !a.is_hide_set() && !a.is_positional())
+        .map(|a: &Arg| ArgInfo {
+            long: a.get_long(),
+            short: a.get_short(),
+            about: a.get_help().map(ToString::to_string),
+            takes_value: arg_takes_value(a),
+        })
+        .collect()
+}
+
+fn arg_takes_value(arg: &Arg) -> bool {
+    // Explicit `num_args` (e.g. `num_args = 0` on `Option<bool>` flags) wins
+    // over the action's default, since the action may report "Set" for an
+    // Option-typed field that's used as a presence flag.
+    arg.get_num_args()
+        .map_or_else(|| arg.get_action().takes_values(), |r| r.takes_values())
+}
+
+pub(super) fn first_help_line(text: &str) -> String {
+    text.lines().next().unwrap_or("").trim().to_string()
+}
+
+#[cfg(test)]
+pub(super) fn fake_pr_command() -> Command {
+    #[derive(Debug, clap::Args)]
+    #[allow(dead_code)]
+    struct FakeCreateArgs {
+        /// Open as draft.
+        #[arg(long)]
+        draft: bool,
+        /// Base bookmark.
+        #[arg(long, value_name = "BRANCH")]
+        base: Option<String>,
+    }
+
+    #[derive(Debug, Subcommand)]
+    #[allow(dead_code)]
+    enum FakeAction {
+        /// Create a thing.
+        #[command(visible_alias = "c")]
+        Create(FakeCreateArgs),
+        /// Fetch a thing.
+        Fetch,
+    }
+
+    let cmd = Command::new("pr");
+    FakeAction::augment_subcommands(cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn emit_real(shell: Shell) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        run(shell, "pr", SubcommandStr::Pr, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn real_pr_action_covers_all_visible_subcommands() {
+        // Catches regressions when adding/renaming subcommands or visible
+        // aliases on `PrAction` — fake_pr_command is too narrow to notice.
+        let bash = emit_real(Shell::Bash);
+        for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
+            assert!(bash.contains(name), "bash overlay missing `{name}`");
+        }
+        assert!(bash.contains("complete -F _jj_gh_alias_wrapper_pr jj"));
+
+        let zsh = emit_real(Shell::Zsh);
+        for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
+            assert!(zsh.contains(name), "zsh overlay missing `{name}`");
+        }
+        assert!(zsh.contains("compdef _jj_gh_alias_pr jj"));
+
+        let fish = emit_real(Shell::Fish);
+        for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
+            assert!(
+                fish.contains(&format!("-a '{name}'")),
+                "fish overlay missing `-a '{name}'`"
+            );
+        }
+        assert!(fish.contains("__jj_gh_alias_no_subcommand pr"));
+    }
+
+    #[test]
+    fn unsupported_shell_errors_with_name() {
+        let mut buf: Vec<u8> = Vec::new();
+        let err = run(
+            Shell::Other("powershell".into()),
+            "pr",
+            SubcommandStr::Pr,
+            &mut buf,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("powershell"));
+    }
+}

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -1,0 +1,160 @@
+use super::{ArgInfo, SubInfo, collect_subs, first_help_line};
+use anyhow::Result;
+use clap::Command;
+use core::fmt::Write as _;
+use std::io::Write;
+
+pub(super) fn emit<W: Write>(cmd: &Command, alias: &str, out: &mut W) -> Result<()> {
+    let subs = collect_subs(cmd);
+    writeln!(
+        out,
+        "# jj-gh: completion overlay for `jj {alias} <tab>` (do not edit)\n\
+         # Safe to source any time after `compinit`; the overlay forces an\n\
+         # autoload of `_jj` if compinit hasn't registered it yet."
+    )?;
+    write!(out, "{}", wrapper(alias, &subs))?;
+    Ok(())
+}
+
+fn wrapper(alias: &str, subs: &[SubInfo]) -> String {
+    let mut sub_lines: Vec<String> = Vec::new();
+    for sub in subs {
+        let desc = sub
+            .about
+            .as_deref()
+            .map(first_help_line)
+            .unwrap_or_default();
+        for n in std::iter::once(sub.name).chain(sub.aliases.iter().copied()) {
+            sub_lines.push(format!("            '{n}:{}'", escape(&desc)));
+        }
+    }
+    let sub_block = sub_lines.join(" \\\n");
+    let per_sub_cases = build_cases(subs);
+
+    format!(
+        r#"if (( ! ${{+functions[_jj_gh_alias_{alias}]}} )); then
+    _jj_gh_alias_{alias}_inner() {{
+        if (( CURRENT <= 3 )); then
+            _values "subcommand" \
+{sub_block}
+            return
+        fi
+        local sub="${{words[3]}}"
+        case "$sub" in
+{per_sub_cases}        esac
+    }}
+
+    # nixpkgs `jujutsu` drops `_jj` into `$fpath` via
+    # share/zsh/site-functions; compinit registers `_comps[jj]=_jj` from
+    # the `#compdef jj` header. If compinit hasn't run yet (rare, but
+    # possible if the user sources this from a non-interactive context),
+    # force-resolve `_jj` so the snapshot below picks it up.
+    if (( ! ${{+_comps[jj]}} )); then
+        autoload -Uz +X _jj 2>/dev/null
+    fi
+
+    # Capture the prior `jj` completer (jj's own, or another alias overlay
+    # sourced earlier) so we can delegate when not handling our alias.
+    if (( ${{+_comps[jj]}} )); then
+        functions[_jj_gh_alias_prior_{alias}]=$functions[${{_comps[jj]}}]
+    fi
+
+    _jj_gh_alias_{alias}() {{
+        if [[ "${{words[2]:-}}" == "{alias}" ]]; then
+            _jj_gh_alias_{alias}_inner
+            return
+        fi
+        if (( ${{+functions[_jj_gh_alias_prior_{alias}]}} )); then
+            _jj_gh_alias_prior_{alias}
+        fi
+    }}
+    compdef _jj_gh_alias_{alias} jj
+fi
+"#
+    )
+}
+
+fn build_cases(subs: &[SubInfo]) -> String {
+    let mut out = String::new();
+    for sub in subs {
+        let names: Vec<&str> = std::iter::once(sub.name)
+            .chain(sub.aliases.iter().copied())
+            .collect();
+        let pattern = names.join("|");
+        let args = arg_spec_lines(&sub.args);
+        if args.is_empty() {
+            #[expect(clippy::needless_raw_string_hashes)]
+            writeln!(
+                out,
+                r#"            ({pattern})
+                _arguments
+                ;;"#
+            )
+            .expect("writing to String never fails");
+        } else {
+            #[expect(clippy::needless_raw_string_hashes)]
+            writeln!(
+                out,
+                r#"            ({pattern})
+                _arguments \
+{args}
+                ;;"#
+            )
+            .expect("writing to String never fails");
+        }
+    }
+    out
+}
+
+fn arg_spec_lines(args: &[ArgInfo]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for a in args {
+        let desc = a.about.as_deref().map(first_help_line).unwrap_or_default();
+        let value_suffix = if a.takes_value { "=" } else { "" };
+        // `_arguments` syntax:
+        //   long-only/short-only: `'--flag[desc]'`
+        //   both:                 `'(-s --long)'{-s,--long}'[desc]'`
+        // (the brace expansion is unquoted; each surrounding piece carries
+        // its own quoting.)
+        let spec = match (a.short, a.long) {
+            (Some(s), Some(l)) => format!(
+                "'(-{s} --{l})'{{-{s},--{l}{value_suffix}}}'[{}]'",
+                escape(&desc)
+            ),
+            (Some(s), None) => format!("'-{s}{value_suffix}[{}]'", escape(&desc)),
+            (None, Some(l)) => format!("'--{l}{value_suffix}[{}]'", escape(&desc)),
+            (None, None) => continue,
+        };
+        lines.push(format!("                    {spec}"));
+    }
+    lines.join(" \\\n")
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completions::fake_pr_command;
+
+    #[test]
+    fn compdef_and_chains() {
+        let mut out: Vec<u8> = Vec::new();
+        emit(&fake_pr_command(), "pr", &mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+
+        assert!(s.contains("_jj_gh_alias_pr"));
+        assert!(s.contains("compdef _jj_gh_alias_pr jj"));
+        // clap strips the trailing period from doc-comment short help.
+        assert!(s.contains("'create:Create a thing'"));
+        assert!(s.contains("'c:Create a thing'"));
+        assert!(s.contains("'fetch:Fetch a thing'"));
+        assert!(s.contains("(create|c)"));
+        assert!(s.contains("--draft"));
+        assert!(s.contains("--base="));
+        assert!(s.contains("_jj_gh_alias_prior_pr"));
+        assert!(s.contains("autoload -Uz +X _jj"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use clap::CommandFactory as _;
 
 mod auth;
 mod cli;
+mod completions;
 mod config;
 mod debug;
 mod fs;
@@ -27,9 +28,23 @@ pub async fn dispatch(bin_name: &str) -> anyhow::Result<()> {
     match args.command {
         Command::Pr { action } => pr::dispatch(action).await?,
         Command::Debug { action } => debug::dispatch(action).await?,
-        Command::Completions { shell } => {
-            clap_complete::generate(shell, &mut Cli::command(), bin_name, &mut std::io::stdout());
-        }
+        Command::Completions {
+            shell,
+            jj_alias,
+            jj_gh_subcommand,
+        } => match (jj_alias, jj_gh_subcommand) {
+            (Some(alias), Some(subcommand)) => {
+                completions::run(shell.into(), &alias, subcommand, &mut std::io::stdout())?;
+            }
+            _ => {
+                clap_complete::generate(
+                    shell,
+                    &mut Cli::command(),
+                    bin_name,
+                    &mut std::io::stdout(),
+                );
+            }
+        },
     }
     Ok(())
 }


### PR DESCRIPTION
Wires up completion to work when the CLI is invoked as a `jj` alias.

There is some additional manual configuration for users who don't use `home-manager` (but completions require manual config in that case anyway).

Closes #28 