### PR TITLE
fix(pr-log): Fix missing PRs for locally diverged bookmarks

### DIFF
--- a/src/gh/prs_with_ci_status.gql
+++ b/src/gh/prs_with_ci_status.gql
@@ -7,6 +7,7 @@ query PrsWithCiStatusInternal($query: String!) {
         number
         url
         title
+        headRefName
         headRefOid
         isDraft
         merged

--- a/src/gh/prs_with_ci_status.rs
+++ b/src/gh/prs_with_ci_status.rs
@@ -62,8 +62,15 @@ pub struct PrWithCiStatus {
     pub url: String,
     /// PR title.
     pub title: String,
-    /// SHA of the commit at the head of the PR's branch. Matches a jj
-    /// `commit_id` in colocated repos.
+    /// Name of the branch the PR is opened from (the head ref). Used to map
+    /// the PR onto the local bookmark with the same name, so the badge
+    /// renders on the local commit even when it has diverged from the remote
+    /// head SHA.
+    pub head_ref_name: String,
+    /// SHA of the commit at the head of the PR's branch on the remote. May
+    /// not match the local bookmark target if the local bookmark has diverged
+    /// from the remote PR head (e.g. if you rebase the PR on `trunk()` but have
+    /// not pushed it to the remote yet).
     pub head_sha: String,
     /// Whether the PR is a draft.
     pub is_draft: bool,
@@ -98,6 +105,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                      number,
                      url,
                      title,
+                     head_ref_name,
                      head_ref_oid,
                      is_draft,
                      merged,
@@ -117,6 +125,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                     merged,
                     is_draft,
                     is_in_merge_queue,
+                    head_ref_name,
                     head_sha: head_ref_oid,
                     ci_status: status_check_rollup.into(),
                     auto_merge_enabled: auto_merge_request.is_some_and(|r| r.enabled_at.is_some()),

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -19,6 +19,16 @@ pub struct CommitInfo {
     pub bookmarks: Vec<String>,
 }
 
+/// A local bookmark tracked on the `origin` remote, paired with the commit
+/// the *local* side currently points at. The local commit may diverge from
+/// the remote target (e.g. user rebased without pushing).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct PushedBookmark {
+    pub name: String,
+    /// 40-char hex commit id of the local bookmark target.
+    pub local_commit_id: String,
+}
+
 pub trait Jj {
     /// Resolve a single revision into commit metadata.
     ///
@@ -87,14 +97,17 @@ pub trait Jj {
     /// Propagates jj failures.
     async fn git_import(&self) -> Result<()>;
 
-    /// Names of bookmarks that have a tracking branch on the `origin` remote.
-    /// Used to scope GitHub PR lookups to branches the user has actually
-    /// pushed. Sorted, deduped, with empty entries removed.
+    /// Bookmarks that have a tracking branch on the `origin` remote, paired
+    /// with the commit id the *local* bookmark currently targets. Used to
+    /// scope GitHub PR lookups to branches the user has actually pushed and
+    /// to render PR badges against the local commit (even when the local
+    /// bookmark has diverged from the remote — e.g. local rebase without
+    /// push). Sorted by name, deduped.
     ///
     /// # Errors
     ///
     /// Propagates jj errors.
-    async fn pushed_bookmarks(&self) -> Result<Vec<String>>;
+    async fn pushed_bookmarks(&self) -> Result<Vec<PushedBookmark>>;
 }
 
 /// Compose the revset used to compute the default PR title.

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -4,7 +4,7 @@
 //! [`parse_remote_url`]), which works in both colocated and pure-jj repos
 //! without a `git` binary on `PATH`.
 
-use super::{CommitInfo, Jj};
+use super::{CommitInfo, Jj, PushedBookmark};
 use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
 use tokio::process::Command;
@@ -167,26 +167,41 @@ impl Jj for JjCli {
         Ok(())
     }
 
-    async fn pushed_bookmarks(&self) -> Result<Vec<String>> {
+    async fn pushed_bookmarks(&self) -> Result<Vec<PushedBookmark>> {
+        // `jj bookmark list --tracked --remote origin` emits one entry per
+        // local/remote side of each tracked bookmark; filtering on
+        // `if(remote, ...)` keeps only the local-side row, whose
+        // `normal_target.commit_id()` is the local commit (which may diverge
+        // from the remote target — e.g. local rebase without push).
+        //
+        // Emit NDJSON: one `PushedBookmark` per line, parsed via serde so
+        // bookmark names with unusual characters round-trip safely.
+        let record = json_object_template(&[
+            ("name", "name"),
+            ("local_commit_id", "normal_target.commit_id()"),
+        ]);
+        let template = format!(r#"if(remote, "", {record} ++ "\n")"#);
         let stdout = run_jj(&[
-            "log",
-            "--no-graph",
-            "-r",
-            r#"bookmarks() & remote_bookmarks(remote=exact:"origin")"#,
+            "bookmark",
+            "list",
+            "--tracked",
+            "--remote",
+            "origin",
             "-T",
-            r#"bookmarks.map(|b| b.name() ++ "\n")"#,
+            &template,
         ])
         .await?;
-        let mut names: Vec<String> = std::str::from_utf8(&stdout)
-            .context("jj log output is not UTF-8")?
+        let mut bookmarks: Vec<PushedBookmark> = std::str::from_utf8(&stdout)
+            .context("jj bookmark list output is not UTF-8")?
             .lines()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-            .collect();
-        names.sort();
-        names.dedup();
-        Ok(names)
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                serde_json::from_str(l).with_context(|| format!("parsing bookmark record `{l}`"))
+            })
+            .collect::<Result<_>>()?;
+        bookmarks.sort_by(|a, b| a.name.cmp(&b.name));
+        bookmarks.dedup_by(|a, b| a.name == b.name);
+        Ok(bookmarks)
     }
 }
 

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -235,7 +235,7 @@ mod tests {
             *self.import_calls.lock().unwrap() += 1;
             Ok(())
         }
-        async fn pushed_bookmarks(&self) -> Result<Vec<String>> {
+        async fn pushed_bookmarks(&self) -> Result<Vec<crate::jj::PushedBookmark>> {
             unimplemented!("fetch does not call pushed_bookmarks")
         }
     }

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::io::Write;
 use tempfile::NamedTempFile;
 use tokio::process::Command;
@@ -63,10 +64,15 @@ pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) 
         .await?
         .ok_or_else(|| anyhow!("origin remote is not configured"))?;
     let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
-    let branches = jj.pushed_bookmarks().await?;
-    let prs = gh.local_pulls(&owner, &repo, &branches).await?;
+    let bookmarks = jj.pushed_bookmarks().await?;
+    let branch_to_local: HashMap<String, String> = bookmarks
+        .iter()
+        .map(|b| (b.name.clone(), b.local_commit_id.clone()))
+        .collect();
+    let names: Vec<String> = bookmarks.into_iter().map(|b| b.name).collect();
+    let prs = gh.local_pulls(&owner, &repo, &names).await?;
 
-    let config_toml = render_config(&prs, config);
+    let config_toml = render_config(&prs, &branch_to_local, config);
     let mut tmp = NamedTempFile::with_suffix(".toml").context("creating temp config file")?;
     tmp.write_all(config_toml.as_bytes())
         .context("writing template-alias config")?;
@@ -109,14 +115,22 @@ fn user_set_template(args: &[String]) -> bool {
 /// `pr_url` / `pr_ci_status` as raw String aliases for users who want to
 /// build custom templates — they work in direct contexts even if they can't
 /// be re-chained through `if()`.
-fn render_config(prs: &[PrWithCiStatus], config: &Config) -> String {
-    let number = if_chain_alias(prs, |pr| format!(r#""{}""#, pr.number));
-    let url = if_chain_alias(prs, |pr| format!(r#""{}""#, escape_toml_dq(&pr.url)));
-    let status = if_chain_alias(prs, |pr| format!(r#""{}""#, ci_status_str(pr.ci_status)));
-    let merge_status = if_chain_alias(prs, |pr| {
+fn render_config(
+    prs: &[PrWithCiStatus],
+    branch_to_local: &HashMap<String, String>,
+    config: &Config,
+) -> String {
+    let number = if_chain_alias(prs, branch_to_local, |pr| format!(r#""{}""#, pr.number));
+    let url = if_chain_alias(prs, branch_to_local, |pr| {
+        format!(r#""{}""#, escape_toml_dq(&pr.url))
+    });
+    let status = if_chain_alias(prs, branch_to_local, |pr| {
+        format!(r#""{}""#, ci_status_str(pr.ci_status))
+    });
+    let merge_status = if_chain_alias(prs, branch_to_local, |pr| {
         format!(r#""{}""#, merge_status(pr, config).unwrap_or_default())
     });
-    let meta = if_chain_alias(prs, |pr| render_pr_meta_body(pr, config));
+    let meta = if_chain_alias(prs, branch_to_local, |pr| render_pr_meta_body(pr, config));
 
     format!(
         r#"[template-aliases]
@@ -214,15 +228,29 @@ fn ci_status_icon_label(pr: &PrWithCiStatus) -> Option<&'static str> {
 
 /// Build a nested `if(commit_id.short(40) == "<sha>", <body>, ...)` chain that
 /// terminates in the empty string. Generated PR SHAs are 40-char hex (SHA-1).
-fn if_chain_alias<F>(prs: &[PrWithCiStatus], render: F) -> String
+///
+/// Each arm keys on the **local** bookmark target (from `branch_to_local`)
+/// rather than `pr.head_sha`, so the badge renders on the commit the user
+/// sees locally, even when they've rebased/squashed/etc. without pushing and the local
+/// commit no longer matches the PR's remote head. Falls back to
+/// `pr.head_sha` when no matching local bookmark is found (defensive: this
+/// shouldn't happen since the PR was returned by a branch-name search
+/// scoped to `branch_to_local`'s keys).
+fn if_chain_alias<F>(
+    prs: &[PrWithCiStatus],
+    branch_to_local: &HashMap<String, String>,
+    render: F,
+) -> String
 where
     F: Fn(&PrWithCiStatus) -> String,
 {
     let mut expr = String::from(r#""""#);
     for pr in prs.iter().rev() {
+        let sha = branch_to_local
+            .get(&pr.head_ref_name)
+            .map_or(pr.head_sha.as_str(), String::as_str);
         expr = format!(
             r#"if(commit_id.short(40) == "{sha}", {body}, {expr})"#,
-            sha = pr.head_sha,
             body = render(pr),
         );
     }
@@ -255,6 +283,7 @@ mod tests {
             number,
             url: format!("https://github.com/o/r/pull/{number}"),
             title: format!("PR {number}"),
+            head_ref_name: format!("branch-{number}"),
             head_sha: sha.into(),
             is_draft: false,
             is_in_merge_queue: false,
@@ -275,6 +304,7 @@ mod tests {
             number,
             url: format!("https://github.com/o/r/pull/{number}"),
             title: format!("PR {number}"),
+            head_ref_name: format!("branch-{number}"),
             head_sha: number.to_string(),
             is_draft: false,
             ci_status: CiStatus::Success,
@@ -286,7 +316,8 @@ mod tests {
 
     #[test]
     fn if_chain_empty_returns_empty_string_literal() {
-        let expr = if_chain_alias::<fn(&PrWithCiStatus) -> String>(&[], |_| String::new());
+        let map = HashMap::new();
+        let expr = if_chain_alias::<fn(&PrWithCiStatus) -> String>(&[], &map, |_| String::new());
         assert_eq!(expr, r#""""#);
     }
 
@@ -304,10 +335,53 @@ mod tests {
                 CiStatus::None,
             ),
         ];
-        let expr = if_chain_alias(&prs, |pr| format!(r#""{}""#, pr.number));
+        let map: HashMap<String, String> = prs
+            .iter()
+            .map(|p| (p.head_ref_name.clone(), p.head_sha.clone()))
+            .collect();
+        let expr = if_chain_alias(&prs, &map, |pr| format!(r#""{}""#, pr.number));
         assert_eq!(
             expr,
             r#"if(commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "1", if(commit_id.short(40) == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "2", ""))"#
+        );
+    }
+
+    #[test]
+    fn if_chain_uses_local_sha_when_bookmark_diverges() {
+        // Regression for #74: PR's remote head_sha is stale (pre-rebase);
+        // the local bookmark points at a different commit. The arm must key
+        // on the local commit so the badge appears on the user's current
+        // working state.
+        let pr = pr(
+            "remote_remote_remote_remote_remote_remote",
+            42,
+            CiStatus::Success,
+        );
+        let local_sha = "local0_local0_local0_local0_local0_local0";
+        let mut map = HashMap::new();
+        map.insert(pr.head_ref_name.clone(), local_sha.to_string());
+        let expr = if_chain_alias(&[pr], &map, |pr| format!(r#""{}""#, pr.number));
+        assert!(
+            expr.contains(&format!(r#"commit_id.short(40) == "{local_sha}""#)),
+            "if-chain should key on local sha, got: {expr}"
+        );
+        assert!(
+            !expr.contains("remote_remote_remote_remote_remote_remote"),
+            "if-chain should not reference stale remote sha, got: {expr}"
+        );
+    }
+
+    #[test]
+    fn if_chain_falls_back_to_remote_sha_when_no_local_mapping() {
+        let pr = pr(
+            "cccccccccccccccccccccccccccccccccccccccc",
+            7,
+            CiStatus::None,
+        );
+        let map = HashMap::new();
+        let expr = if_chain_alias(&[pr], &map, |pr| format!(r#""{}""#, pr.number));
+        assert!(
+            expr.contains(r#"commit_id.short(40) == "cccccccccccccccccccccccccccccccccccccccc""#)
         );
     }
 
@@ -332,10 +406,17 @@ mod tests {
         assert!(!user_set_template(&["-r".into(), "@-".into()]));
     }
 
+    fn local_map_from(prs: &[PrWithCiStatus]) -> HashMap<String, String> {
+        prs.iter()
+            .map(|p| (p.head_ref_name.clone(), p.head_sha.clone()))
+            .collect()
+    }
+
     #[test]
     fn config_contains_alias_for_each_pr() {
         let prs = vec![pr("a".repeat(40).as_str(), 42, CiStatus::Success)];
-        let cfg = render_config(&prs, &Config::default());
+        let map = local_map_from(&prs);
+        let cfg = render_config(&prs, &map, &Config::default());
         assert!(
             cfg.contains(r#"commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""#)
         );
@@ -348,15 +429,18 @@ mod tests {
     #[test]
     fn default_template_shows_merge_metadata() {
         let prs = vec![pr_merge_status(1, true, false, false)];
-        let cfg = render_config(&prs, &Config::default());
+        let map = local_map_from(&prs);
+        let cfg = render_config(&prs, &map, &Config::default());
         assert!(cfg.contains(" merged"));
 
         let prs = vec![pr_merge_status(2, false, true, false)];
-        let cfg = render_config(&prs, &Config::default());
+        let map = local_map_from(&prs);
+        let cfg = render_config(&prs, &map, &Config::default());
         assert!(cfg.contains(" in merge queue"), "{}", cfg);
 
         let prs = vec![pr_merge_status(3, false, false, true)];
-        let cfg = render_config(&prs, &Config::default());
+        let map = local_map_from(&prs);
+        let cfg = render_config(&prs, &map, &Config::default());
         assert!(cfg.contains("󰾨 auto-merge enabled"));
     }
 


### PR DESCRIPTION
Fixes an issue where `jj pr log` could be missing PRs if the local bookmark head does not match the remote PR head (for example, if you squashed changes into it, or rebased it on `trunk()` but have not pushed it to the remote yet).
