### PR TITLE
fix(auth): Allow `gh auth token` to be used for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,14 @@ editor = [
 nerdfonts = true
 ```
 
-Config precedence (low to high):
+Config precedence (high to low):
 
-1. built-in defaults
-1. `jj` global config file
-1. `jj` repo-local config file
-1. `$JJ_GH_EXTRA_CONFIG` file
+1. CLI flags
 1. env (`GH_ASKPASS`, `JJ_GH_TEMPLATE`)
-1. CLI flags.
+1. `$JJ_GH_EXTRA_CONFIG` file
+1. `jj` repo-local config file
+1. `jj` global config file
+1. built-in defaults
 
 Token source precedence (high to low):
 
@@ -186,10 +186,12 @@ Token source precedence (high to low):
 1. `$JJ_GH_TOKEN` environment variable
 1. `$GH_TOKEN` environment variable (matches the `gh` CLI convention)
 1. `gh_token` from merged config (plain text, less safe)
+1. Attempting to run `gh auth token`
 
 Env vars override `gh_token` from config, but a configured `gh_askpass` still
 wins. Use `$JJ_GH_TOKEN` when you need a different token for `jj-gh` than for
-the `gh` CLI itself.
+the `gh` CLI itself. You may also run `gh auth login` before running `jj-gh`
+to use the GitHub CLI's authentication.
 
 ## Frontmatter format
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -12,7 +12,7 @@
 //! via [`EnvReader`] so tests can supply canned outcomes without touching the
 //! real process environment or filesystem.
 
-use crate::config::Config;
+use crate::{config::Config, logging::ResultExt};
 use anyhow::{Context, Result, anyhow};
 use secrecy::SecretString;
 use std::time::Duration;
@@ -127,8 +127,27 @@ async fn resolve_token_with<R: ProcessRunner, E: EnvReader>(
         return Ok(token.clone());
     }
 
+    if let Some(token) = Command::new("gh")
+        .args(["auth", "token"])
+        .stdout(std::process::Stdio::piped())
+        .output()
+        .await
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            String::from_utf8(output.stdout)
+                .context("`gh auth token` returned non-UTF8 output")
+                .log_err()
+                .ok()
+        })
+        .map(|output| output.trim().to_string())
+    {
+        return Ok(token.into());
+    }
+
     Err(anyhow!(
-        "no GitHub token available: use `--gh_askpass`, configure `gh_token`, or set `JJ_GH_TOKEN` or `GH_TOKEN` environment variable"
+        "no GitHub token available: use `--gh_askpass`, configure `gh_token`, set `JJ_GH_TOKEN` or \
+        `GH_TOKEN` environment variable, or run `gh auth login`"
     ))
 }
 


### PR DESCRIPTION
Allow `gh auth token` to be used as an authentication source.

Fixes #69
