### PR TITLE
fix(ci): Only run `cargo-udeps` in CI (too slow locally, bad DX)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           purge-created: 0
           purge-primary-key: never
       - run: nix flake check --print-build-logs
+      - run: nix build .#udeps --print-build-logs
   release-plz:
     needs: flake-check
     if: ${{ github.repository_owner == 'mrjones2014' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/master')) }}

--- a/flake.nix
+++ b/flake.nix
@@ -129,8 +129,19 @@
         };
       in
       {
-        packages.default = jj-gh;
-        packages.gen-docs = gen-docs;
+        packages = {
+          default = jj-gh;
+          inherit gen-docs;
+          udeps = craneLibNightly.mkCargoDerivation (
+            commonArgs
+            // {
+              cargoArtifacts = cargoArtifactsNightly;
+              pnameSuffix = "-udeps";
+              buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --locked";
+              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
+            }
+          );
+        };
         apps = {
           default = flake-utils.lib.mkApp { drv = jj-gh; };
           docs = flake-utils.lib.mkApp {
@@ -174,15 +185,6 @@
               cargoNextestExtraArgs = "--workspace";
               partitions = 1;
               partitionType = "count";
-            }
-          );
-          udeps = craneLibNightly.mkCargoDerivation (
-            commonArgs
-            // {
-              cargoArtifacts = cargoArtifactsNightly;
-              pnameSuffix = "-udeps";
-              buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --locked";
-              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
             }
           );
           treefmt = treefmtEval.config.build.check self;


### PR DESCRIPTION
`cargo-udeps` is slow so its a bad DX to run it locally every time you `nix flake check`.

Instead, `ci.yml` just runs `nix build .#udeps` manually.
