### PR TITLE
fix(remotes): Make remotes configurable

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -36,6 +36,8 @@ Opinionated `jj` tools for working with GitHub from your terminal
 - `-v`, `--verbose` — Increase log verbosity (repeat for more, e.g. `-vv`)
 - `-q`, `--quiet` — Drop log level to `ERROR`
 - `--log-level <LEVEL>` — Set log level explicitly, overrides `-v` and `-q`
+- `--remote <NAME>` — Git remote used for the user's own pushes and PR head lookups. Overrides config `default_remote` (default: `origin`)
+- `--upstream-remote <NAME>` — Git remote used as the PR target in fork workflows. Overrides config `upstream_remote` (default: `upstream`)
 
 ## `jj-gh pr`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,19 +17,34 @@ pub struct Cli {
     pub command: Command,
 }
 
-#[derive(Debug, clap::Args)]
+#[derive(Debug, clap::Args, Serialize)]
 pub struct GlobalOpts {
     /// Increase log verbosity (repeat for more, e.g. `-vv`).
     #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
+    #[serde(skip)]
     pub verbose: u8,
 
     /// Drop log level to `ERROR`.
     #[arg(short = 'q', long = "quiet", global = true, conflicts_with = "verbose")]
+    #[serde(skip)]
     pub quiet: bool,
 
     /// Set log level explicitly, overrides `-v` and `-q`.
     #[arg(long = "log-level", value_name = "LEVEL", global = true)]
+    #[serde(skip)]
     pub log_level: Option<LevelFilter>,
+
+    /// Git remote used for the user's own pushes and PR head lookups.
+    /// Overrides config `default_remote` (default: `origin`).
+    #[arg(long = "remote", value_name = "NAME", global = true)]
+    #[serde(rename = "default_remote", skip_serializing_if = "Option::is_none")]
+    pub remote: Option<String>,
+
+    /// Git remote used as the PR target in fork workflows. Overrides config
+    /// `upstream_remote` (default: `upstream`).
+    #[arg(long = "upstream-remote", value_name = "NAME", global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_remote: Option<String>,
 }
 
 impl GlobalOpts {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub askpass_timeout_secs: u64,
     pub gh_token: Option<SecretString>,
     pub default_base_branch: String,
+    pub default_remote: String,
+    pub upstream_remote: String,
     pub template_path: Option<PathBuf>,
     pub draft: bool,
     pub auto_merge: bool,
@@ -46,6 +48,8 @@ impl Default for Config {
             askpass_timeout_secs: 20,
             gh_token: None,
             default_base_branch: "master".into(),
+            default_remote: "origin".into(),
+            upstream_remote: "upstream".into(),
             template_path: None,
             draft: false,
             auto_merge: false,
@@ -78,18 +82,6 @@ pub fn load_figment() -> Figment {
         fig = fig.merge(JjConfProvider::from_file(path));
     }
     fig.merge(Serialized::defaults(EnvOverlay::from_env()))
-}
-
-/// Discover config layers and merge them into a [`Config`].
-///
-/// # Errors
-///
-/// Returns an error if any layer is malformed or fails serde extraction, or if
-/// `pr_fetch_bookmark_template` references an unknown placeholder.
-pub fn debug_load() -> Result<Config> {
-    let config: Config = extract(&load_figment())?;
-    validate(&config)?;
-    Ok(config)
 }
 
 /// Validate cross-field invariants on a merged [`Config`].
@@ -267,6 +259,8 @@ fn extract_jj_gh_subtree(contents: &str) -> Result<Option<toml::Table>, SourceEr
 struct DefaultsOverlay {
     askpass_timeout_secs: u64,
     default_base_branch: String,
+    default_remote: String,
+    upstream_remote: String,
     draft: bool,
     auto_merge: bool,
     auto_merge_method: AutoMergeMethod,
@@ -280,6 +274,8 @@ impl DefaultsOverlay {
             auto_merge,
             auto_merge_method,
             default_base_branch,
+            default_remote,
+            upstream_remote,
             draft,
             nerdfonts,
             editor: _,
@@ -291,6 +287,8 @@ impl DefaultsOverlay {
         Self {
             askpass_timeout_secs,
             default_base_branch,
+            default_remote,
+            upstream_remote,
             draft,
             auto_merge,
             auto_merge_method,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,14 +2,15 @@
 
 use crate::{
     auth,
-    cli::DebugAction,
-    config,
+    cli::{DebugAction, GlobalOpts},
+    config::{self, Config},
     gh::{Gh, real::OctocrabGh},
     git::url::parse_owner_repo,
     jj::{self, CommitInfo, Jj, real::JjCli},
     pr,
 };
 use anyhow::Result;
+use figment::providers::Serialized;
 
 /// Dispatch a `jj-gh debug` invocation.
 ///
@@ -17,29 +18,37 @@ use anyhow::Result;
 ///
 /// Returns an error from the underlying operation; for `auth` this means token
 /// resolution failed, for `rev`/`pr-lookup` the jj or GH read failed.
-pub async fn dispatch(action: DebugAction) -> Result<()> {
+pub async fn dispatch(global: &GlobalOpts, action: DebugAction) -> Result<()> {
     match action {
-        DebugAction::Config => print_config(),
-        DebugAction::Auth => check_auth().await,
-        DebugAction::Rev { rev } => print_rev(&rev).await,
-        DebugAction::PrLookup { rev } => print_pr_lookup(&rev).await,
+        DebugAction::Config => print_config(global),
+        DebugAction::Auth => check_auth(global).await,
+        DebugAction::Rev { rev } => print_rev(global, &rev).await,
+        DebugAction::PrLookup { rev } => print_pr_lookup(global, &rev).await,
     }
 }
 
-fn print_config() -> Result<()> {
-    let config = config::debug_load()?;
+fn load_config(global: &GlobalOpts) -> Result<Config> {
+    let fig = config::load_figment().merge(Serialized::defaults(global));
+    let config = config::extract(&fig)?;
+    config::validate(&config)?;
+    Ok(config)
+}
+
+fn print_config(global: &GlobalOpts) -> Result<()> {
+    let config = load_config(global)?;
     println!("{config:#?}");
     Ok(())
 }
 
-async fn check_auth() -> Result<()> {
-    let config = config::debug_load()?;
+async fn check_auth(global: &GlobalOpts) -> Result<()> {
+    let config = load_config(global)?;
     auth::resolve_token(&config).await?;
     println!("ok");
     Ok(())
 }
 
-async fn print_rev(rev: &str) -> Result<()> {
+async fn print_rev(global: &GlobalOpts, rev: &str) -> Result<()> {
+    let config = load_config(global)?;
     let jj = JjCli::new().await?;
 
     let CommitInfo {
@@ -52,11 +61,14 @@ async fn print_rev(rev: &str) -> Result<()> {
     let title_revset = jj::title_base_revset(rev, ancestor.as_deref());
     let default_title = jj.first_commit_description(&title_revset).await?;
 
-    let origin_url = jj.remote_url("origin").await?;
-    let upstream_url = jj.remote_url("upstream").await?;
+    let origin_url = jj.remote_url(&config.default_remote).await?;
+    let upstream_url = jj.remote_url(&config.upstream_remote).await?;
     let default_branch = jj.trunk_branch().await?;
     let default_branch_sha = match &default_branch {
-        Some(branch) => jj.remote_bookmark_sha(branch, "origin").await?,
+        Some(branch) => {
+            jj.remote_bookmark_sha(branch, &config.default_remote)
+                .await?
+        }
         None => None,
     };
 
@@ -81,13 +93,13 @@ async fn print_rev(rev: &str) -> Result<()> {
     Ok(())
 }
 
-async fn print_pr_lookup(rev: &str) -> Result<()> {
+async fn print_pr_lookup(global: &GlobalOpts, rev: &str) -> Result<()> {
+    let config = load_config(global)?;
     let jj = JjCli::new().await?;
-    let config = config::debug_load()?;
     let token = auth::resolve_token(&config).await?;
     let gh = OctocrabGh::new(&token)?;
 
-    let lookup = pr::resolve_pr_for_rev(&jj, &gh, rev).await?;
+    let lookup = pr::resolve_pr_for_rev(&jj, &gh, &config, rev).await?;
     let base = gh
         .lookup_base(
             &lookup.target.owner,

--- a/src/git/real.rs
+++ b/src/git/real.rs
@@ -10,12 +10,12 @@ pub trait GitOps {
     /// Propagates gix failures.
     async fn local_bookmark_exists(&self, name: &str) -> Result<bool>;
 
-    /// Fetch `refs/pull/<pr>/head` from `origin` into `refs/heads/<bookmark>`.
+    /// Fetch `refs/pull/<pr>/head` from `remote` into `refs/heads/<bookmark>`.
     ///
     /// # Errors
     ///
     /// Propagates gix failures.
-    async fn fetch_pr(&self, pr: u64, bookmark: &str, force: bool) -> Result<()>;
+    async fn fetch_pr(&self, remote: &str, pr: u64, bookmark: &str, force: bool) -> Result<()>;
 }
 
 /// Production [`GitOps`] backed by a shared `gix::Repository` discovered
@@ -37,12 +37,12 @@ impl GitOps for RealGit {
         Ok(self.repo.try_find_reference(full.as_str())?.is_some())
     }
 
-    async fn fetch_pr(&self, pr: u64, bookmark: &str, force: bool) -> Result<()> {
+    async fn fetch_pr(&self, remote: &str, pr: u64, bookmark: &str, force: bool) -> Result<()> {
         let prefix = if force { "+" } else { "" };
         let refspec = format!("{prefix}refs/pull/{pr}/head:refs/heads/{bookmark}");
         let remote = self
             .repo
-            .find_remote("origin")?
+            .find_remote(remote)?
             .with_refspecs([refspec.as_bytes()], gix::remote::Direction::Fetch)?;
         let conn = remote.connect(gix::remote::Direction::Fetch)?;
         let prep = conn.prepare_fetch(

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -97,17 +97,17 @@ pub trait Jj {
     /// Propagates jj failures.
     async fn git_import(&self) -> Result<()>;
 
-    /// Bookmarks that have a tracking branch on the `origin` remote, paired
-    /// with the commit id the *local* bookmark currently targets. Used to
-    /// scope GitHub PR lookups to branches the user has actually pushed and
-    /// to render PR badges against the local commit (even when the local
-    /// bookmark has diverged from the remote — e.g. local rebase without
-    /// push). Sorted by name, deduped.
+    /// Bookmarks that have a tracking branch on `remote`, paired with the
+    /// commit id the *local* bookmark currently targets. Used to scope GitHub
+    /// PR lookups to branches the user has actually pushed and to render PR
+    /// badges against the local commit (even when the local bookmark has
+    /// diverged from the remote — e.g. local rebase without push). Sorted by
+    /// name, deduped.
     ///
     /// # Errors
     ///
     /// Propagates jj errors.
-    async fn pushed_bookmarks(&self) -> Result<Vec<PushedBookmark>>;
+    async fn pushed_bookmarks(&self, remote: &str) -> Result<Vec<PushedBookmark>>;
 }
 
 /// Compose the revset used to compute the default PR title.

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -192,8 +192,8 @@ impl Jj for JjCli {
         Ok(())
     }
 
-    async fn pushed_bookmarks(&self) -> Result<Vec<PushedBookmark>> {
-        // `jj bookmark list --tracked --remote origin` emits one entry per
+    async fn pushed_bookmarks(&self, remote: &str) -> Result<Vec<PushedBookmark>> {
+        // `jj bookmark list --tracked --remote <remote>` emits one entry per
         // local/remote side of each tracked bookmark; filtering on
         // `if(remote, ...)` keeps only the local-side row, whose
         // `normal_target.commit_id()` is the local commit (which may diverge
@@ -211,7 +211,7 @@ impl Jj for JjCli {
             "list",
             "--tracked",
             "--remote",
-            "origin",
+            remote,
             "-T",
             &template,
         ])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,10 @@ pub async fn dispatch(bin_name: &str) -> anyhow::Result<()> {
 
     let args = Cli::parse();
     let _logger = logging::init(args.global.resolve_log_level())?;
+    let global = args.global;
     match args.command {
-        Command::Pr { action } => pr::dispatch(action).await?,
-        Command::Debug { action } => debug::dispatch(action).await?,
+        Command::Pr { action } => pr::dispatch(&global, action).await?,
+        Command::Debug { action } => debug::dispatch(&global, action).await?,
         Command::Completions {
             shell,
             jj_alias,

--- a/src/pr/auto_merge.rs
+++ b/src/pr/auto_merge.rs
@@ -37,7 +37,7 @@ where
         method: _,
         auth: _,
     } = args;
-    let pr = pr::get_pr(jj, gh, number_or_rev).await?;
+    let pr = pr::get_pr(jj, gh, config, number_or_rev).await?;
 
     gh.enable_auto_merge(
         &pr.graphql_node_id,

--- a/src/pr/create.rs
+++ b/src/pr/create.rs
@@ -112,10 +112,10 @@ where
     let existing_branch = info.bookmarks.first().cloned();
 
     let origin_url = jj
-        .remote_url("origin")
+        .remote_url(&config.default_remote)
         .await?
-        .ok_or_else(|| anyhow!("origin remote is not configured"))?;
-    let upstream_url = jj.remote_url("upstream").await?;
+        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+    let upstream_url = jj.remote_url(&config.upstream_remote).await?;
     let target = remote::target(&origin_url, upstream_url.as_deref())?;
 
     // Pre-flight only when we already have a bookmark; an unpushed rev can't have

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -90,9 +90,9 @@ pub async fn run_with<J: Jj, G: Gh, GO: GitOps>(
     ensure_colocated(workspace_root)?;
 
     let origin_url = jj
-        .remote_url("origin")
+        .remote_url(&config.default_remote)
         .await?
-        .ok_or_else(|| anyhow!("origin remote is not configured"))?;
+        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
     let (owner, repo) = parse_owner_repo(&origin_url)?;
 
     let pr = gh.get_pr(&owner, &repo, args.pr).await?;
@@ -114,7 +114,8 @@ pub async fn run_with<J: Jj, G: Gh, GO: GitOps>(
         ));
     }
 
-    git.fetch_pr(args.pr, &bookmark, args.force).await?;
+    git.fetch_pr(&config.default_remote, args.pr, &bookmark, args.force)
+        .await?;
     jj.git_import().await?;
 
     log::info!("PR #{}: {}", pr.number, pr.title);
@@ -138,6 +139,7 @@ mod tests {
     struct FakeJj {
         workspace_root: PathBuf,
         origin: Option<String>,
+        expected_remote: String,
         import_calls: Mutex<u32>,
     }
 
@@ -152,7 +154,7 @@ mod tests {
             unimplemented!("fetch does not call first_commit_description")
         }
         async fn remote_url(&self, name: &str) -> Result<Option<String>> {
-            assert_eq!(name, "origin");
+            assert_eq!(name, self.expected_remote);
             Ok(self.origin.clone())
         }
         async fn remote_bookmark_sha(&self, _: &str, _: &str) -> Result<Option<String>> {
@@ -171,7 +173,7 @@ mod tests {
             *self.import_calls.lock().unwrap() += 1;
             Ok(())
         }
-        async fn pushed_bookmarks(&self) -> Result<Vec<crate::jj::PushedBookmark>> {
+        async fn pushed_bookmarks(&self, _remote: &str) -> Result<Vec<crate::jj::PushedBookmark>> {
             unimplemented!("fetch does not call pushed_bookmarks")
         }
     }
@@ -236,6 +238,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct FetchCall {
+        remote: String,
         pr: u64,
         bookmark: String,
         force: bool,
@@ -250,8 +253,9 @@ mod tests {
         async fn local_bookmark_exists(&self, _name: &str) -> Result<bool> {
             Ok(self.exists)
         }
-        async fn fetch_pr(&self, pr: u64, bookmark: &str, force: bool) -> Result<()> {
+        async fn fetch_pr(&self, remote: &str, pr: u64, bookmark: &str, force: bool) -> Result<()> {
             self.fetches.borrow_mut().push(FetchCall {
+                remote: remote.to_string(),
                 pr,
                 bookmark: bookmark.to_string(),
                 force,
@@ -296,6 +300,7 @@ mod tests {
         FakeJj {
             workspace_root: dir.path().to_path_buf(),
             origin: origin.map(str::to_string),
+            expected_remote: "origin".into(),
             import_calls: Mutex::new(0),
         }
     }
@@ -322,10 +327,34 @@ mod tests {
 
         let calls = git.fetches.borrow();
         assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].remote, "origin");
         assert_eq!(calls[0].pr, 1234);
         assert_eq!(calls[0].bookmark, "pr-1234/feature/foo");
         assert!(!calls[0].force);
         assert_eq!(*jj.import_calls.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn config_default_remote_propagates_to_jj_and_git() {
+        let dir = colocated_workspace();
+        let mut jj = jj_for(&dir, Some("git@github.com:o/r.git"));
+        jj.expected_remote = "fork".into();
+        let gh = gh_for(details(), "o", "r");
+        let git = FakeGit {
+            exists: false,
+            fetches: RefCell::new(vec![]),
+        };
+        let config = Config {
+            default_remote: "fork".into(),
+            ..Config::default()
+        };
+
+        run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+            .await
+            .unwrap();
+
+        let calls = git.fetches.borrow();
+        assert_eq!(calls[0].remote, "fork");
     }
 
     #[tokio::test]
@@ -445,7 +474,8 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            err.to_string().contains("origin remote is not configured"),
+            err.to_string()
+                .contains("`origin` remote is not configured"),
             "msg: {err}"
         );
     }

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -11,6 +11,7 @@ mod validation;
 
 use crate::{
     auth,
+    cli::GlobalOpts,
     config::{self, Config},
     fs::RealFs,
     gh::{self, Gh, PrDetails, PrSummary, remote},
@@ -75,8 +76,8 @@ pub enum PrAction {
 /// Propagates errors from config loading, auth resolution, jj/GitHub API
 /// calls, the editor round-trip, or any sub-handler (`create`, `fetch`,
 /// `auto-merge`).
-pub async fn dispatch(action: PrAction) -> Result<()> {
-    let mut fig = config::load_figment();
+pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
+    let mut fig = config::load_figment().merge(Serialized::defaults(global));
     fig = match &action {
         PrAction::Create(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Fetch(a) => fig.merge(Serialized::defaults(a)),
@@ -99,7 +100,6 @@ pub async fn dispatch(action: PrAction) -> Result<()> {
         PrAction::AutoMerge(args) => auto_merge::run(&jj, &gh, &config, &args).await?,
         PrAction::Log(args) => pr_log::run(&args, &config, &gh, &jj).await?,
     }
-
     Ok(())
 }
 
@@ -121,19 +121,25 @@ pub struct PrLookup {
 ///
 /// # Errors
 ///
-/// Returns an error if `rev` has no local bookmark, if `origin` is unset, if
-/// `trunk()` is empty, or if any underlying jj/GH call fails.
-pub async fn get_pr<J: Jj, G: Gh>(jj: &J, gh: &G, number_or_rev: &str) -> Result<PrDetails> {
+/// Returns an error if `rev` has no local bookmark, if the configured
+/// `default_remote` is unset, if `trunk()` is empty, or if any underlying
+/// jj/GH call fails.
+pub async fn get_pr<J: Jj, G: Gh>(
+    jj: &J,
+    gh: &G,
+    config: &Config,
+    number_or_rev: &str,
+) -> Result<PrDetails> {
     if let Ok(num) = number_or_rev.parse::<u64>() {
         let origin_url = jj
-            .remote_url("origin")
+            .remote_url(&config.default_remote)
             .await?
-            .ok_or_else(|| anyhow!("origin remote is not configured"))?;
-        let upstream_url = jj.remote_url("upstream").await?;
+            .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+        let upstream_url = jj.remote_url(&config.upstream_remote).await?;
         let target = remote::target(&origin_url, upstream_url.as_deref())?;
         gh.get_pr(&target.owner, &target.repo, num).await
     } else {
-        let lookup = resolve_pr_for_rev(jj, gh, number_or_rev).await?;
+        let lookup = resolve_pr_for_rev(jj, gh, config, number_or_rev).await?;
         let summary = lookup.summary.ok_or_else(|| {
             anyhow!(
                 "no open PR for revision `{number_or_rev}` (head `{}`)",
@@ -150,9 +156,15 @@ pub async fn get_pr<J: Jj, G: Gh>(jj: &J, gh: &G, number_or_rev: &str) -> Result
 ///
 /// # Errors
 ///
-/// Returns an error if `rev` has no local bookmark, if `origin` is unset, if
-/// `trunk()` is empty, or if any underlying jj/GH call fails.
-pub async fn resolve_pr_for_rev<J: Jj, G: Gh>(jj: &J, gh: &G, rev: &str) -> Result<PrLookup> {
+/// Returns an error if `rev` has no local bookmark, if the configured
+/// `default_remote` is unset, if `trunk()` is empty, or if any underlying
+/// jj/GH call fails.
+pub async fn resolve_pr_for_rev<J: Jj, G: Gh>(
+    jj: &J,
+    gh: &G,
+    config: &Config,
+    rev: &str,
+) -> Result<PrLookup> {
     let info = jj.resolve_rev(rev).await?;
     let branch = info
         .bookmarks
@@ -161,10 +173,10 @@ pub async fn resolve_pr_for_rev<J: Jj, G: Gh>(jj: &J, gh: &G, rev: &str) -> Resu
         .ok_or_else(|| anyhow!("no local bookmark on `{rev}`; nothing to look up"))?;
 
     let origin_url = jj
-        .remote_url("origin")
+        .remote_url(&config.default_remote)
         .await?
-        .ok_or_else(|| anyhow!("origin remote is not configured"))?;
-    let upstream_url = jj.remote_url("upstream").await?;
+        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+    let upstream_url = jj.remote_url(&config.upstream_remote).await?;
     let target = remote::target(&origin_url, upstream_url.as_deref())?;
     let head_spec = target.head_spec(&branch);
 
@@ -465,5 +477,66 @@ mod tests {
             Some(&["cli-askpass".to_string()][..])
         );
         assert_eq!(c.askpass_timeout_secs, 99);
+    }
+
+    #[test]
+    fn global_remote_overrides_default_remote_config() {
+        use crate::cli::GlobalOpts;
+        use clap::Parser;
+
+        #[derive(clap::Parser, Debug)]
+        #[command(no_binary_name = true)]
+        struct GlobalParser {
+            #[command(flatten)]
+            opts: GlobalOpts,
+        }
+
+        let global =
+            GlobalParser::try_parse_from(["--remote", "fork", "--upstream-remote", "canonical"])
+                .unwrap()
+                .opts;
+        let fig = config::defaults_figment()
+            .merge(config::JjConfProvider::from_memory(
+                "test",
+                r#"
+                [jj-gh]
+                default_remote = "cfg-origin"
+                upstream_remote = "cfg-upstream"
+                "#,
+            ))
+            .merge(Serialized::defaults(&global));
+        let c = config::extract(&fig).unwrap();
+        assert_eq!(c.default_remote, "fork");
+        assert_eq!(c.upstream_remote, "canonical");
+    }
+
+    #[test]
+    fn config_remote_used_when_global_not_set() {
+        use crate::cli::GlobalOpts;
+        use clap::Parser;
+
+        #[derive(clap::Parser, Debug)]
+        #[command(no_binary_name = true)]
+        struct GlobalParser {
+            #[command(flatten)]
+            opts: GlobalOpts,
+        }
+
+        let global = GlobalParser::try_parse_from::<[&str; 0], _>([])
+            .unwrap()
+            .opts;
+        let fig = config::defaults_figment()
+            .merge(config::JjConfProvider::from_memory(
+                "test",
+                r#"
+                [jj-gh]
+                default_remote = "cfg-origin"
+                upstream_remote = "cfg-upstream"
+                "#,
+            ))
+            .merge(Serialized::defaults(&global));
+        let c = config::extract(&fig).unwrap();
+        assert_eq!(c.default_remote, "cfg-origin");
+        assert_eq!(c.upstream_remote, "cfg-upstream");
     }
 }

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -60,11 +60,11 @@ pub struct PrLogArgs {
 
 pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
     let origin_url = jj
-        .remote_url("origin")
+        .remote_url(&config.default_remote)
         .await?
-        .ok_or_else(|| anyhow!("origin remote is not configured"))?;
+        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
     let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
-    let bookmarks = jj.pushed_bookmarks().await?;
+    let bookmarks = jj.pushed_bookmarks(&config.default_remote).await?;
     let branch_to_local: HashMap<String, String> = bookmarks
         .iter()
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))


### PR DESCRIPTION
Don't hard code "origin" and "upstream" remotes. Make them configurable, with those values as the defaults.

Fixes #80
