### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.2...jj-gh-v0.1.3) - 2026-05-28
+
+### Fixed
+
+- *(api)* Use GraphQL for finding open PR for revision
+- *(docs)* Update permissions section
+- *(changelog)* Make release-plz consider `hm-module.nix`
+- *(auth)* Use test abstractions to avoid running real process in tests
+- *(remotes)* Make remotes configurable
+- *(auth)* Allow `gh auth token` to be used for authentication
+- *(completions)* Split comments so completions have concise description
+- *(auto-merge)* Fix auto-merge failing when merge queues are enabled
+
+### Other
+
+- *(deps)* Update serde_yml
+- *(graphql)* Organize queries and make code more consistent
+
 ## [0.1.2](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.1...jj-gh-v0.1.2) - 2026-05-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.1.2"
+version = "0.1.3"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",


### PR DESCRIPTION



## 🤖 New release

* `jj-gh`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.2...jj-gh-v0.1.3) - 2026-05-28

### Fixed

- *(api)* Use GraphQL for finding open PR for revision
- *(docs)* Update permissions section
- *(changelog)* Make release-plz consider `hm-module.nix`
- *(auth)* Use test abstractions to avoid running real process in tests
- *(remotes)* Make remotes configurable
- *(auth)* Allow `gh auth token` to be used for authentication
- *(completions)* Split comments so completions have concise description
- *(auto-merge)* Fix auto-merge failing when merge queues are enabled

### Other

- *(deps)* Update serde_yml
- *(graphql)* Organize queries and make code more consistent
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).