### PR TITLE
fix(ci): Use patched version of release-plz

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,11 +113,21 @@
             treefmt --no-cache DOCS.md
           '';
         };
+        # TODO remove when PR merges and nixpkgs updated: https://github.com/release-plz/release-plz/pull/2857
+        release-plz-patched = pkgs.release-plz.overrideAttrs (old: {
+          patches = (old.patches or [ ]) ++ [
+            (pkgs.fetchpatch {
+              name = "walk-all-branches-2857.patch";
+              url = "https://github.com/release-plz/release-plz/commit/0bf9940e70958cb3777dae063bfda2db77d40502.patch";
+              hash = "sha256-ii1SQ64Wg38sbboafTReOJji8brBYOBfaDjKHbe7SoI=";
+            })
+          ];
+        });
         release-app = pkgs.writeShellApplication {
           name = "release";
           runtimeInputs = [
             rustToolchain
-            pkgs.release-plz
+            release-plz-patched
             pkgs.cargo-semver-checks
             pkgs.git
           ];


### PR DESCRIPTION
Fixes an issue where release-plz misses PRs that are siblings to each other and use merge commits to merge.
