### PR TITLE
fix(nix): Validate home-manager module opts against Rust `Config` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2149,7 @@ dependencies = [
  "log",
  "nu-ansi-term",
  "octocrab",
+ "schemars",
  "secrecy",
  "serde",
  "serde_json",
@@ -2683,6 +2690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "print-config-schema"
+version = "0.0.0"
+dependencies = [
+ "jj-gh",
+ "schemars",
+ "serde_json",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,6 +2967,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3077,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ include = [
 ]
 
 [workspace]
-members = ["tools/gen-docs"]
+members = ["tools/gen-docs", "tools/print-config-schema"]
+
+[features]
+schema-validation = ["dep:schemars"]
 
 [dependencies]
 anyhow = "1"
@@ -44,6 +47,7 @@ http = "1"
 log = "0.4"
 nu-ansi-term = "0.50"
 octocrab = "0.51"
+schemars = { version = "0.8", optional = true }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,34 @@
             doCheck = false;
           }
         );
+        schemaArtifacts = craneLib.buildDepsOnly (
+          commonArgs
+          // {
+            pname = "print-config-schema-deps";
+            cargoExtraArgs = "--package print-config-schema";
+          }
+        );
+        print-config-schema = craneLib.buildPackage (
+          commonArgs
+          // {
+            cargoArtifacts = schemaArtifacts;
+            pname = "print-config-schema";
+            cargoExtraArgs = "--package print-config-schema";
+            doCheck = false;
+          }
+        );
+        hmModuleSettingsOptsJson =
+          let
+            mod = (import ./nix/hm-module.nix self) {
+              config = { };
+              inherit (pkgs) lib;
+              inherit pkgs;
+            };
+            names = builtins.attrNames mod.options.programs.jujutsu.gh.settings;
+          in
+          pkgs.writeText "hm-module-settings-opts.json" (
+            builtins.toJSON (builtins.sort builtins.lessThan names)
+          );
         treefmtEval = treefmt-nix.lib.evalModule pkgs (import ./nix/treefmt.nix { inherit rustToolchain; });
         gen-docs-app = pkgs.writeShellApplication {
           name = "gen-docs";
@@ -213,6 +241,30 @@
                   exit 1
                 fi
                 python3 ${./graphql-validate.py} ${github-graphql-schema}/schema.graphql "''${docs[@]}"
+                touch $out
+              '';
+          hm-module-schema =
+            pkgs.runCommand "hm-module-schema"
+              {
+                nativeBuildInputs = [
+                  pkgs.jq
+                  pkgs.delta
+                  pkgs.util-linux
+                ];
+              }
+              ''
+                ${print-config-schema}/bin/print-config-schema > schema.json
+                jq -r '.properties | keys[]' schema.json | sort > rust-fields.txt
+                jq -r '.[]' ${hmModuleSettingsOptsJson} | sort > nix-fields.txt
+                # `script` fakes a TTY so delta emits ANSI colors even though
+                # nix's builder pipes stdout to a log file.
+                if ! script -qec "delta --paging=never rust-fields.txt nix-fields.txt" /dev/null; then
+                  echo "" >&2
+                  echo "ERROR: jj-gh Config struct fields drifted from hm-module.nix settings options." >&2
+                  echo "  left  = Rust Config field names (tools/print-config-schema)" >&2
+                  echo "  right = nix/hm-module.nix settings options" >&2
+                  exit 1
+                fi
                 touch $out
               '';
           docs =

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -21,18 +21,7 @@ let
   # to make sure our completions come after Carapace.
   priority = 3000;
 
-  jjGhTable = lib.filterAttrs (_: v: v != null) {
-    inherit (cfg.settings)
-      gh_askpass
-      askpass_timeout_secs
-      gh_token
-      default_base_branch
-      template_path
-      draft
-      editor
-      pr_fetch_bookmark_template
-      ;
-  };
+  jj_gh_table = lib.filterAttrs (_: v: v != null) cfg.settings;
 
   mkJjAliasArgv = subcmd: [
     "util"
@@ -114,16 +103,49 @@ in
         description = "Fallback base branch when nothing smarter is detected.";
       };
 
+      default_remote = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "origin";
+        description = "Default git remote used for pushes and PR head lookup.";
+      };
+
+      upstream_remote = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "upstream";
+        description = "Default git remote used for cross-fork PR target.";
+      };
+
       template_path = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = "PR template path.";
+        description = "Default PR template path.";
       };
 
       draft = mkOption {
         type = types.nullOr types.bool;
         default = null;
         description = "Open PRs as drafts by default.";
+      };
+
+      auto_merge = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable auto-merge on PRs after creation by default.";
+      };
+
+      auto_merge_method = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "merge"
+            "squash"
+            "rebase"
+          ]
+        );
+        default = null;
+        example = "squash";
+        description = "Default GitHub merge method to use when auto-merge is enabled.";
       };
 
       editor = mkOption {
@@ -142,6 +164,12 @@ in
         example = "pr-{number}/{branch}";
         description = "Bookmark name template for `jj pr fetch`.";
       };
+
+      nerdfonts = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Use nerdfont icons in `jj pr log` output.";
+      };
     };
   };
 
@@ -152,7 +180,7 @@ in
         {
           aliases = lib.mapAttrs (_: subcmd: lib.mkDefault (mkJjAliasArgv subcmd)) cfg.aliases;
         }
-        (optionalAttrs (jjGhTable != { }) { "jj-gh" = jjGhTable; })
+        (optionalAttrs (jj_gh_table != { }) { "jj-gh" = jj_gh_table; })
       ];
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,10 +24,12 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schema-validation", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct Config {
     pub gh_askpass: Option<Vec<String>>,
     pub askpass_timeout_secs: u64,
+    #[cfg_attr(feature = "schema-validation", schemars(with = "Option<String>"))]
     pub gh_token: Option<SecretString>,
     pub default_base_branch: String,
     pub default_remote: String,
@@ -63,6 +65,7 @@ impl Default for Config {
 
 /// GitHub merge method used when enabling auto-merge on a PR.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[cfg_attr(feature = "schema-validation", derive(schemars::JsonSchema))]
 #[serde(rename_all = "lowercase")]
 #[clap(rename_all = "lowercase")]
 pub enum AutoMergeMethod {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use clap::CommandFactory as _;
 mod auth;
 mod cli;
 mod completions;
-mod config;
+pub mod config;
 mod debug;
 mod fs;
 mod gh;

--- a/tools/print-config-schema/Cargo.toml
+++ b/tools/print-config-schema/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "print-config-schema"
+edition = "2024"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+jj-gh = { path = "../..", features = ["schema-validation"] }
+schemars = "0.8"
+serde_json = "1"

--- a/tools/print-config-schema/src/main.rs
+++ b/tools/print-config-schema/src/main.rs
@@ -1,0 +1,13 @@
+//! Prints the JSON schema for [`jj_gh::config::Config`] on stdout. Consumed
+//! by the `hm-module-schema` flake check, which asserts that the schema's
+//! property names match the options exposed by `nix/hm-module.nix`.
+
+use jj_gh::config::Config;
+
+fn main() {
+    let schema = schemars::schema_for!(Config);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&schema).expect("serialize schema")
+    );
+}


### PR DESCRIPTION
Implement validation of options provided by `hm-module.nix` against the Rust `Contig` struct using `schemars` to generate a jsonschema.

I forgot to add some options already so this adds them and ensures I don't forget again.
