### PR TITLE
refactor(jj): Extract reusable template-alias config injection

### DIFF
--- a/src/jj/inject.rs
+++ b/src/jj/inject.rs
@@ -1,0 +1,178 @@
+//! Reusable builder for the `jj --config-file <tmp>` template-alias injection trick.
+//!
+//! Callers build a [`TemplateAliases`] via the builder API, write it to a
+//! tempfile, then pass that path to `jj`. You can use the full `jj` template
+//! language.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::io::Write as _;
+use tempfile::NamedTempFile;
+
+/// Builder for the `[template-aliases]` and `[colors]` sections of a jj
+/// config file.
+///
+/// Iteration over a `BTreeMap` is sorted, so [`to_toml`](Self::to_toml) emits
+/// a deterministic byte sequence. This keeps snapshot tests stable and makes
+/// debugging diffs of the temp config easier.
+#[derive(Debug, Default, Serialize)]
+pub struct TemplateAliases {
+    #[serde(
+        rename = "template-aliases",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    aliases: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    colors: BTreeMap<String, String>,
+}
+
+impl TemplateAliases {
+    #[must_use]
+    pub fn builder() -> Self {
+        Self::default()
+    }
+
+    /// Add a `[template-aliases]` entry. `expr` is a jj template expression
+    /// inserted as the alias body.
+    #[must_use]
+    pub fn alias(mut self, name: impl Into<String>, expr: impl Into<String>) -> Self {
+        self.aliases.insert(name.into(), expr.into());
+        self
+    }
+
+    /// Add a `[colors]` entry. `value` is a jj color string such as `green`,
+    /// `bright black`, or `#aabbcc`. Validation is deferred to jj at runtime.
+    #[must_use]
+    pub fn color(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
+        self.colors.insert(label.into(), value.into());
+        self
+    }
+
+    /// Render the configured sections as TOML via the [`toml`] crate.
+    #[must_use]
+    pub fn to_toml(&self) -> String {
+        toml::to_string(self).expect("TemplateAliases is always TOML-serializable")
+    }
+
+    /// Write the rendered TOML to a new tempfile. The returned [`NamedTempFile`]
+    /// owns the file; the caller must keep it alive across the `jj` invocation
+    /// that reads its path.
+    ///
+    /// # Errors
+    ///
+    /// Propagates filesystem errors creating or writing the tempfile.
+    pub fn write_temp_config(&self) -> Result<NamedTempFile> {
+        let mut tmp = NamedTempFile::with_suffix(".toml").context("creating temp config file")?;
+        tmp.write_all(self.to_toml().as_bytes())
+            .context("writing template-alias config")?;
+        Ok(tmp)
+    }
+}
+
+/// Escape a string for embedding inside a jj template double-quoted string
+/// literal. Handles `\` and `"`; we never embed control characters here.
+#[must_use]
+pub fn escape_jj_string(s: &str) -> String {
+    s.replace('\\', r"\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_builder_renders_empty_toml() {
+        let toml = TemplateAliases::builder().to_toml();
+        assert_eq!(toml, "");
+    }
+
+    #[test]
+    fn aliases_render_sorted_under_template_aliases() {
+        let toml = TemplateAliases::builder()
+            .alias("zeta", r#""z""#)
+            .alias("alpha", r#""a""#)
+            .to_toml();
+        let parsed: toml::Table = toml::from_str(&toml).unwrap();
+        let aliases = parsed["template-aliases"].as_table().unwrap();
+        let keys: Vec<&str> = aliases.keys().map(String::as_str).collect();
+        assert_eq!(keys, vec!["alpha", "zeta"]);
+        assert_eq!(aliases["alpha"].as_str(), Some(r#""a""#));
+        assert_eq!(aliases["zeta"].as_str(), Some(r#""z""#));
+    }
+
+    #[test]
+    fn colors_render_sorted_under_colors() {
+        let toml = TemplateAliases::builder()
+            .color("zz-label", "yellow")
+            .color("aa-label", "green")
+            .to_toml();
+        let parsed: toml::Table = toml::from_str(&toml).unwrap();
+        let colors = parsed["colors"].as_table().unwrap();
+        let keys: Vec<&str> = colors.keys().map(String::as_str).collect();
+        assert_eq!(keys, vec!["aa-label", "zz-label"]);
+    }
+
+    #[test]
+    fn aliases_and_colors_both_present() {
+        let toml = TemplateAliases::builder()
+            .alias("a", r#""x""#)
+            .color("c", "red")
+            .to_toml();
+        let parsed: toml::Table = toml::from_str(&toml).unwrap();
+        assert!(parsed.contains_key("template-aliases"));
+        assert!(parsed.contains_key("colors"));
+    }
+
+    #[test]
+    fn color_value_with_quote_round_trips() {
+        let toml = TemplateAliases::builder()
+            .color("c", r#"weird"name"#)
+            .to_toml();
+        let parsed: toml::Table = toml::from_str(&toml).unwrap();
+        assert_eq!(parsed["colors"]["c"].as_str(), Some(r#"weird"name"#));
+    }
+
+    #[test]
+    fn alias_body_with_quote_round_trips() {
+        let body = r#""https://example.com/""#;
+        let toml = TemplateAliases::builder().alias("u", body).to_toml();
+        let parsed: toml::Table = toml::from_str(&toml).unwrap();
+        assert_eq!(parsed["template-aliases"]["u"].as_str(), Some(body));
+    }
+
+    #[test]
+    fn write_temp_config_persists_to_disk() {
+        let aliases = TemplateAliases::builder().alias("pr_number", r#""42""#);
+        let tmp = aliases.write_temp_config().unwrap();
+        let on_disk = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(on_disk, aliases.to_toml());
+    }
+
+    #[test]
+    fn write_temp_config_uses_toml_suffix() {
+        let tmp = TemplateAliases::builder().write_temp_config().unwrap();
+        assert!(
+            tmp.path()
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("toml")),
+            "expected .toml suffix, got: {}",
+            tmp.path().display()
+        );
+    }
+
+    #[test]
+    fn escape_jj_string_handles_backslash_and_quote() {
+        assert_eq!(escape_jj_string(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+
+    #[test]
+    fn alias_overwrites_existing_key() {
+        let toml = TemplateAliases::builder()
+            .alias("a", r#""1""#)
+            .alias("a", r#""2""#)
+            .to_toml();
+        let parsed: toml::Table = toml::from_str(&toml).unwrap();
+        assert_eq!(parsed["template-aliases"]["a"].as_str(), Some(r#""2""#));
+    }
+}

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -6,8 +6,9 @@
 
 use anyhow::Result;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+pub mod inject;
 pub mod real;
 
 /// What we read about a single revision.
@@ -101,13 +102,39 @@ pub trait Jj {
     /// commit id the *local* bookmark currently targets. Used to scope GitHub
     /// PR lookups to branches the user has actually pushed and to render PR
     /// badges against the local commit (even when the local bookmark has
-    /// diverged from the remote — e.g. local rebase without push). Sorted by
+    /// diverged from the remote, e.g. local rebase without push). Sorted by
     /// name, deduped.
     ///
     /// # Errors
     ///
     /// Propagates jj errors.
     async fn pushed_bookmarks(&self, remote: &str) -> Result<Vec<PushedBookmark>>;
+
+    /// Render `template` by invoking `jj log` against `revset`. When
+    /// `config_file` is `Some`, jj is given `--config-file <path>` so the
+    /// template can reference aliases or colors defined there (typically built
+    /// via [`inject::TemplateAliases`]).
+    ///
+    /// Returns raw stdout. Callers trim or otherwise normalize the result
+    /// based on what they expect (a bookmark name versus a multi-line PR
+    /// body).
+    ///
+    /// `reversed` sets the `--reversed` flag so multi-commit revsets render oldest
+    /// first (chronological order).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if jj exits non-zero (template parse failures land
+    /// here with jj's own error in the message). Callers should add their own
+    /// context via [`anyhow::Context`].
+    #[expect(dead_code, reason = "callers added in PR 2")]
+    async fn eval_template(
+        &self,
+        revset: &str,
+        template: &str,
+        config_file: Option<&Path>,
+        reversed: bool,
+    ) -> Result<String>;
 }
 
 /// Compose the revset used to compute the default PR title.

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -6,7 +6,7 @@
 
 use super::{CommitInfo, Jj, PushedBookmark};
 use anyhow::{Context, Result, anyhow};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 
 /// Build a jj template that emits a JSON object: each `(key, expr)` becomes
@@ -192,6 +192,17 @@ impl Jj for JjCli {
         Ok(())
     }
 
+    async fn eval_template(
+        &self,
+        revset: &str,
+        template: &str,
+        config_file: Option<&Path>,
+        reversed: bool,
+    ) -> Result<String> {
+        let args = eval_template_argv(revset, template, config_file, reversed);
+        String::from_utf8(run_jj_strs(&args).await?).context("jj log output is not UTF-8")
+    }
+
     async fn pushed_bookmarks(&self, remote: &str) -> Result<Vec<PushedBookmark>> {
         // `jj bookmark list --tracked --remote <remote>` emits one entry per
         // local/remote side of each tracked bookmark; filtering on
@@ -254,4 +265,90 @@ async fn run_jj(args: &[&str]) -> Result<Vec<u8>> {
         return Err(anyhow!("`jj {}` failed: {}", args.join(" "), stderr.trim()));
     }
     Ok(output.stdout)
+}
+
+async fn run_jj_strs(args: &[String]) -> Result<Vec<u8>> {
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_jj(&refs).await
+}
+
+/// Build the argv passed to `run_jj` for [`Jj::eval_template`]. Pure so it
+/// can be unit tested without spawning.
+fn eval_template_argv(
+    revset: &str,
+    template: &str,
+    config_file: Option<&Path>,
+    reversed: bool,
+) -> Vec<String> {
+    let mut argv: Vec<String> = Vec::with_capacity(10);
+    if let Some(path) = config_file {
+        argv.push("--config-file".into());
+        argv.push(path.to_string_lossy().into_owned());
+    }
+    argv.push("log".into());
+    argv.push("-r".into());
+    argv.push(revset.into());
+    argv.push("--no-graph".into());
+    argv.push("--color=never".into());
+    if reversed {
+        argv.push("--reversed".into());
+    }
+    argv.push("-T".into());
+    argv.push(template.into());
+    argv
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eval_template_argv_minimal() {
+        let argv = eval_template_argv("@", "description", None, false);
+        assert_eq!(
+            argv,
+            vec![
+                "log",
+                "-r",
+                "@",
+                "--no-graph",
+                "--color=never",
+                "-T",
+                "description"
+            ]
+        );
+    }
+
+    #[test]
+    fn eval_template_argv_with_config_file_and_reversed() {
+        let argv = eval_template_argv(
+            "trunk()..@",
+            "description.first_line()",
+            Some(Path::new("/tmp/x.toml")),
+            true,
+        );
+        assert_eq!(
+            argv,
+            vec![
+                "--config-file",
+                "/tmp/x.toml",
+                "log",
+                "-r",
+                "trunk()..@",
+                "--no-graph",
+                "--color=never",
+                "--reversed",
+                "-T",
+                "description.first_line()",
+            ]
+        );
+    }
+
+    #[test]
+    fn eval_template_argv_config_file_precedes_subcommand() {
+        let argv = eval_template_argv("@", "x", Some(Path::new("/c.toml")), false);
+        let log_idx = argv.iter().position(|s| s == "log").unwrap();
+        let cfg_idx = argv.iter().position(|s| s == "--config-file").unwrap();
+        assert!(cfg_idx < log_idx, "--config-file must precede `log`");
+    }
 }

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -176,6 +176,15 @@ mod tests {
         async fn pushed_bookmarks(&self, _remote: &str) -> Result<Vec<crate::jj::PushedBookmark>> {
             unimplemented!("fetch does not call pushed_bookmarks")
         }
+        async fn eval_template(
+            &self,
+            _revset: &str,
+            _template: &str,
+            _config_file: Option<&std::path::Path>,
+            _reversed: bool,
+        ) -> Result<String> {
+            unimplemented!("fetch does not call eval_template")
+        }
     }
 
     struct FakeGh {

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -14,14 +14,49 @@ use crate::{
     config::Config,
     gh::{CiStatus, Gh, PrWithCiStatus},
     git,
-    jj::Jj,
+    jj::{
+        Jj,
+        inject::{TemplateAliases, escape_jj_string},
+    },
 };
 use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::io::Write;
-use tempfile::NamedTempFile;
 use tokio::process::Command;
+
+/// jj `label(...)` keys for which we ship default colors in the injected
+/// config. Templates reference them by name so users can override the colors
+/// in their own jj config.
+const COLOR_CI_SUCCESS: &str = "gh-ci-success";
+const COLOR_CI_FAILED: &str = "gh-ci-failed";
+const COLOR_CI_PENDING: &str = "gh-ci-pending";
+const COLOR_PR_MERGE_STATUS: &str = "gh-pr-merge-status";
+
+/// Default `pr_log` template applied when the user did not pass their own
+/// `-T` / `--template`. References the `pr_meta` alias so spacing only appears
+/// for commits that actually have a PR.
+const PR_LOG_TEMPLATE: &str = r#"
+if(root,
+  format_root_commit(self),
+  label(
+    separate(" ",
+      if(current_working_copy, "working_copy"),
+      if(immutable, "immutable", "mutable"),
+      if(conflict, "conflicted"),
+    ),
+    concat(
+      format_short_commit_header(self)  ++ surround(" ", "", pr_meta) ++ "\n",
+      separate(" ",
+        if(empty, empty_commit_marker),
+        if(description,
+          description.first_line(),
+          label(if(empty, "empty"), description_placeholder),
+        ),
+      ) ++ "\n",
+    ),
+  )
+)
+"#;
 
 #[derive(Debug, clap::Args, Serialize)]
 pub struct PrLogArgs {
@@ -69,17 +104,14 @@ pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) 
         .iter()
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))
         .collect();
-    let names: Vec<String> = bookmarks.into_iter().map(|b| b.name).collect();
+    let names = bookmarks.into_iter().map(|b| b.name).collect::<Vec<_>>();
     let prs = gh.local_pulls(&owner, &repo, &names).await?;
 
-    let config_toml = render_config(&prs, &branch_to_local, config);
-    let mut tmp = NamedTempFile::with_suffix(".toml").context("creating temp config file")?;
-    tmp.write_all(config_toml.as_bytes())
-        .context("writing template-alias config")?;
-    let tmp = tmp.into_temp_path();
+    let aliases = build_aliases(&prs, &branch_to_local, config);
+    let tmp = aliases.write_temp_config()?;
 
     let mut cmd = Command::new("jj");
-    cmd.arg("--config-file").arg(&tmp).arg("log");
+    cmd.arg("--config-file").arg(tmp.path()).arg("log");
     if !user_set_template(&args.jj_log_args) {
         cmd.args(["-T", "pr_log"]);
     }
@@ -102,27 +134,27 @@ fn user_set_template(args: &[String]) -> bool {
     })
 }
 
-/// Build the TOML config that defines our `pr_*` template aliases, default
-/// colors, and the `pr_log` template.
+/// Build the [`TemplateAliases`] that define our `pr_*` aliases, the
+/// `pr_log` default template, and the colors it labels.
 ///
 /// jj template aliases lose static type info when called from another alias
 /// (their return type becomes `Any`), which breaks `if(pr_x, ...)` and
-/// `pr_x == ""` in nested aliases. To sidestep this we render the *entire*
-/// inline PR fragment (hyperlinked number + colored CI icon) as a single
-/// `pr_meta` alias whose body is a per-commit if-chain; the default `pr_log`
-/// template then wraps it with `surround(" ", "", pr_meta)` so spacing only
-/// appears for commits that actually have a PR. We still expose `pr_number` /
-/// `pr_url` / `pr_ci_status` as raw String aliases for users who want to
-/// build custom templates — they work in direct contexts even if they can't
-/// be re-chained through `if()`.
-fn render_config(
+/// `pr_x == ""` in nested aliases. To sidestep this we render the entire
+/// inline PR fragment (hyperlinked number, colored CI icon, merge status) as
+/// a single `pr_meta` alias whose body is a per-commit if-chain; the default
+/// `pr_log` template then wraps it with `surround(" ", "", pr_meta)` so
+/// spacing only appears for commits that actually have a PR. We still expose
+/// `pr_number`, `pr_url`, and `pr_ci_status` as raw `String` aliases for
+/// users who want to build custom templates; they work in direct contexts
+/// even if they cannot be re-chained through `if()`.
+fn build_aliases(
     prs: &[PrWithCiStatus],
     branch_to_local: &HashMap<String, String>,
     config: &Config,
-) -> String {
+) -> TemplateAliases {
     let number = if_chain_alias(prs, branch_to_local, |pr| format!(r#""{}""#, pr.number));
     let url = if_chain_alias(prs, branch_to_local, |pr| {
-        format!(r#""{}""#, escape_toml_dq(&pr.url))
+        format!(r#""{}""#, escape_jj_string(&pr.url))
     });
     let status = if_chain_alias(prs, branch_to_local, |pr| {
         format!(r#""{}""#, ci_status_str(pr.ci_status))
@@ -132,50 +164,24 @@ fn render_config(
     });
     let meta = if_chain_alias(prs, branch_to_local, |pr| render_pr_meta_body(pr, config));
 
-    format!(
-        r#"[template-aliases]
-pr_number = '''{number}'''
-pr_url = '''{url}'''
-pr_ci_status = '''{status}'''
-pr_meta = '''{meta}'''
-pr_merge_status = '''{merge_status}'''
-pr_log = '''
-if(root,
-  format_root_commit(self),
-  label(
-    separate(" ",
-      if(current_working_copy, "working_copy"),
-      if(immutable, "immutable", "mutable"),
-      if(conflict, "conflicted"),
-    ),
-    concat(
-      format_short_commit_header(self)  ++ surround(" ", "", pr_meta) ++ "\n",
-      separate(" ",
-        if(empty, empty_commit_marker),
-        if(description,
-          description.first_line(),
-          label(if(empty, "empty"), description_placeholder),
-        ),
-      ) ++ "\n",
-    ),
-  )
-)
-'''
-
-[colors]
-gh-ci-success = "green"
-gh-ci-failed = "red"
-gh-ci-pending = "yellow"
-gh-pr-merge-status = "bright black"
-"#
-    )
+    TemplateAliases::builder()
+        .alias("pr_number", number)
+        .alias("pr_url", url)
+        .alias("pr_ci_status", status)
+        .alias("pr_meta", meta)
+        .alias("pr_merge_status", merge_status)
+        .alias("pr_log", PR_LOG_TEMPLATE)
+        .color(COLOR_CI_SUCCESS, "green")
+        .color(COLOR_CI_FAILED, "red")
+        .color(COLOR_CI_PENDING, "yellow")
+        .color(COLOR_PR_MERGE_STATUS, "bright black")
 }
 
 /// Render the body of a single `pr_meta` if-chain arm: the full template
 /// fragment for one PR (hyperlinked number plus colored CI-status icon).
 fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
     let github_icon = if config.nerdfonts { " " } else { "" };
-    let url = escape_toml_dq(&pr.url);
+    let url = escape_jj_string(&pr.url);
     let mut template = format!(
         r##""{github_icon}" ++ hyperlink("{url}", "#{n}")"##,
         n = pr.number
@@ -189,7 +195,7 @@ fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
     template = match merge_status(pr, config) {
         Some(metadata) => {
             format!(
-                r#"{template} ++ " " ++ label("gh-pr-merge-status", "(") ++ {metadata} ++ label("gh-pr-merge-status", ")")"#
+                r#"{template} ++ " " ++ label("{COLOR_PR_MERGE_STATUS}", "(") ++ {metadata} ++ label("{COLOR_PR_MERGE_STATUS}", ")")"#
             )
         }
         None => template,
@@ -201,27 +207,29 @@ fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
 fn merge_status(pr: &PrWithCiStatus, config: &Config) -> Option<String> {
     if pr.merged {
         let icon = if config.nerdfonts { " " } else { "" };
-        Some(format!(r#"label("gh-pr-merge-status", "{icon}merged")"#))
+        Some(format!(
+            r#"label("{COLOR_PR_MERGE_STATUS}", "{icon}merged")"#
+        ))
     } else if pr.is_in_merge_queue {
         let icon = if config.nerdfonts { " " } else { "" };
         Some(format!(
-            r#"label("gh-pr-merge-status", "{icon}in merge queue")"#
+            r#"label("{COLOR_PR_MERGE_STATUS}", "{icon}in merge queue")"#
         ))
     } else if pr.auto_merge_enabled {
         let icon = if config.nerdfonts { "󰾨 " } else { "" };
         Some(format!(
-            r#"label("gh-pr-merge-status", "{icon}auto-merge enabled")"#
+            r#"label("{COLOR_PR_MERGE_STATUS}", "{icon}auto-merge enabled")"#
         ))
     } else {
         None
     }
 }
 
-fn ci_status_icon_label(pr: &PrWithCiStatus) -> Option<&'static str> {
+fn ci_status_icon_label(pr: &PrWithCiStatus) -> Option<String> {
     Some(match pr.ci_status {
-        CiStatus::Success => r#"label("gh-ci-success", "✓")"#,
-        CiStatus::Failed => r#"label("gh-ci-failed", "✗")"#,
-        CiStatus::Pending => r#"label("gh-ci-pending", "●")"#,
+        CiStatus::Success => format!(r#"label("{COLOR_CI_SUCCESS}", "✓")"#),
+        CiStatus::Failed => format!(r#"label("{COLOR_CI_FAILED}", "✗")"#),
+        CiStatus::Pending => format!(r#"label("{COLOR_CI_PENDING}", "●")"#),
         CiStatus::None => return None,
     })
 }
@@ -264,13 +272,6 @@ fn ci_status_str(status: CiStatus) -> &'static str {
         CiStatus::Pending => "PENDING",
         CiStatus::None => "",
     }
-}
-
-/// Escape a value for embedding in a TOML double-quoted string. We only ever
-/// embed PR URLs and SHAs (no control chars), so handling `\` and `"` is
-/// sufficient.
-fn escape_toml_dq(s: &str) -> String {
-    s.replace('\\', r"\\").replace('"', "\\\"")
 }
 
 #[cfg(test)]
@@ -416,7 +417,7 @@ mod tests {
     fn config_contains_alias_for_each_pr() {
         let prs = vec![pr("a".repeat(40).as_str(), 42, CiStatus::Success)];
         let map = local_map_from(&prs);
-        let cfg = render_config(&prs, &map, &Config::default());
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
         assert!(
             cfg.contains(r#"commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""#)
         );
@@ -430,22 +431,28 @@ mod tests {
     fn default_template_shows_merge_metadata() {
         let prs = vec![pr_merge_status(1, true, false, false)];
         let map = local_map_from(&prs);
-        let cfg = render_config(&prs, &map, &Config::default());
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
         assert!(cfg.contains(" merged"));
 
         let prs = vec![pr_merge_status(2, false, true, false)];
         let map = local_map_from(&prs);
-        let cfg = render_config(&prs, &map, &Config::default());
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
         assert!(cfg.contains(" in merge queue"), "{}", cfg);
 
         let prs = vec![pr_merge_status(3, false, false, true)];
         let map = local_map_from(&prs);
-        let cfg = render_config(&prs, &map, &Config::default());
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
         assert!(cfg.contains("󰾨 auto-merge enabled"));
     }
 
     #[test]
-    fn escape_toml_dq_handles_backslash_and_quote() {
-        assert_eq!(escape_toml_dq(r#"a"b\c"#), r#"a\"b\\c"#);
+    fn merge_status_labels_use_pr_merge_color_const() {
+        let prs = vec![pr_merge_status(1, true, false, false)];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        assert!(
+            cfg.contains(r#"label("gh-pr-merge-status""#),
+            "expected gh-pr-merge-status color label, got: {cfg}"
+        );
     }
 }


### PR DESCRIPTION
Extracts a reusable template alias builder API; this will be used in upcoming PRs for #112
