### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.3...jj-gh-v0.2.0) - 2026-05-29
+
+### Added
+
+- *(pr)* [**breaking**] Use jj templates for `pr fetch` and PR body
+
+### Fixed
+
+- *(nix)* Validate home-manager module opts against Rust `Config` struct
+
+### Other
+
+- *(jj)* Extract reusable template-alias config injection
+- *(docs)* Add note about nerdfont support in pager
+
 ## [0.1.3](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.2...jj-gh-v0.1.3) - 2026-05-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.1.3"
+version = "0.2.0"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",


### PR DESCRIPTION



## 🤖 New release

* `jj-gh`: 0.1.3 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.1.3...jj-gh-v0.2.0) - 2026-05-29

### Added

- *(pr)* [**breaking**] Use jj templates for `pr fetch` and PR body

### Fixed

- *(nix)* Validate home-manager module opts against Rust `Config` struct

### Other

- *(jj)* Extract reusable template-alias config injection
- *(docs)* Add note about nerdfont support in pager
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).