### PR TITLE
fix(template): Add a way to add static content to PR body template

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -80,7 +80,7 @@ Opens your editor to a markdown file where you can write the PR description, and
 - `-T`, `--template <TEMPLATE>` — jj template string used to render the PR body. Evaluated against the revset being PR'd in chronological order (`--reversed`), so a multi-commit stack renders bottom-up.
 
   All standard jj template builtins are available (`description`, `commit_id`, `author`, etc.). The following string aliases are also injected:
-  - `pr_title`: default title (first-line description of the oldest commit on the stack). - `pr_base`: resolved base branch. - `pr_head_branch`: existing local bookmark on the rev, or empty if the rev is unpushed.
+  - `pr_title`: default title (first-line description of the oldest commit on the stack). - `pr_base`: resolved base branch. - `pr_head_branch`: existing local bookmark on the rev, or empty if the rev is unpushed. - `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in the revset. Because the template runs once per commit in the revset, static content like a fixed PR header would otherwise be duplicated N times for an N-commit stack. Comparing `commit_id.short(40) == pr_oldest_rev_id` lets the template emit such content exactly once, at the bottom-most commit (which lands at the top of the output thanks to `--reversed`).
 
   Mutually exclusive with `--template-file` and `--no-template`.
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,19 @@ work (`description`, `commit_id`, `author`, etc.). Injected aliases:
 - `pr_base`: resolved base branch.
 - `pr_head_branch`: existing local bookmark on the rev, or empty if the rev
   is unpushed.
+- `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in the
+  revset. Because the template runs once per commit, static content like a
+  fixed PR header would otherwise be duplicated N times for an N-commit
+  stack. Comparing `commit_id.short(40) == pr_oldest_rev_id` lets the
+  template emit such content exactly once, at the bottom-most commit (which
+  lands at the top of the output thanks to `--reversed`). Example:
+
+```jjtemplate
+if(commit_id.short(40) == pr_oldest_rev_id,
+  "Fixes \n\n",
+  ""
+) ++ "- `" ++ description.first_line() ++ "`\n"
+```
 
 The rendered output seeds the buffer your editor opens; you can still edit
 the body and frontmatter before the PR is submitted.

--- a/src/pr/create.rs
+++ b/src/pr/create.rs
@@ -78,6 +78,13 @@ pub struct CreateArgs {
     /// - `pr_base`: resolved base branch.
     /// - `pr_head_branch`: existing local bookmark on the rev, or empty if
     ///   the rev is unpushed.
+    /// - `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in
+    ///   the revset. Because the template runs once per commit in the
+    ///   revset, static content like a fixed PR header would otherwise be
+    ///   duplicated N times for an N-commit stack. Comparing
+    ///   `commit_id.short(40) == pr_oldest_rev_id` lets the template emit
+    ///   such content exactly once, at the bottom-most commit (which lands
+    ///   at the top of the output thanks to `--reversed`).
     ///
     /// Mutually exclusive with `--template-file` and `--no-template`.
     #[arg(short = 'T', long, value_name = "TEMPLATE", conflicts_with_all = ["template_file", "no_template"])]

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -223,10 +223,19 @@ async fn load_template_for<J: Jj>(
         TemplateSource::None => Ok(None),
         TemplateSource::File(p) => template::load_template_file(&p, &fs),
         TemplateSource::JjTemplate(t) => {
+            let oldest_rev_id = jj
+                .eval_template(title_revset, r#"commit_id.short(40) ++ "\n""#, None, true)
+                .await
+                .context("resolving oldest commit id for `pr_oldest_rev_id` alias")?
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
             let aliases = TemplateAliases::builder()
                 .alias("pr_title", quote_jj(default_title))
                 .alias("pr_base", quote_jj(base))
-                .alias("pr_head_branch", quote_jj(head_branch.unwrap_or("")));
+                .alias("pr_head_branch", quote_jj(head_branch.unwrap_or("")))
+                .alias("pr_oldest_rev_id", quote_jj(&oldest_rev_id));
             let tmp = aliases.write_temp_config()?;
             let body = jj
                 .eval_template(title_revset, &t, Some(tmp.path()), true)


### PR DESCRIPTION
without this there is no way really to add static content to the top of a template
