### PR TITLE
feat(pr): Add `retry-failed` subcommand (with `rerun` alias)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -13,6 +13,7 @@ This document contains the help content for the `jj-gh` command-line program.
 - [`jj-gh pr auto-merge`↴](#jj-gh-pr-auto-merge)
 - [`jj-gh pr edit`↴](#jj-gh-pr-edit)
 - [`jj-gh pr log`↴](#jj-gh-pr-log)
+- [`jj-gh pr retry-failed`↴](#jj-gh-pr-retry-failed)
 - [`jj-gh debug`↴](#jj-gh-debug)
 - [`jj-gh debug config`↴](#jj-gh-debug-config)
 - [`jj-gh debug auth`↴](#jj-gh-debug-auth)
@@ -55,6 +56,7 @@ Commands to work with PRs
 - `auto-merge` — Enable auto-merge on a PR
 - `edit` — Edit an existing PR's title, body, base, labels, reviewers, draft state, and auto-merge settings via the markdown frontmatter editor flow
 - `log` — Like `jj log`, but injects PR metadata (e.g. number, CI status, URL)
+- `retry-failed` — Re-run failed CI jobs on a PR
 
 ## `jj-gh pr create`
 
@@ -179,6 +181,29 @@ The following template aliases are available for use if you pass your own templa
 
 - `--nerdfonts <NERDFONTS>` — Force enable the use of nerdfont icons in the default `pr log` template. Overrides config. Use `--no-nerdfonts` to disable
 - `--no-nerdfonts` — Force the default `pr log` template not to use nerdfont icons. Overrides config
+
+## `jj-gh pr retry-failed`
+
+Re-run failed CI jobs on a PR.
+
+Resolves the PR from a revision (via its local bookmark) or PR number, then re-runs failed workflow runs on the PR's head commit. By default the command fails if CI has not yet completed, because GitHub refuses to re-run a workflow run until it reaches the `completed` state.
+
+With `--cancel`, in-progress runs are cancelled first; once they finalize, every workflow run is re-run (full pipeline restart).
+
+**Usage:** `jj-gh pr retry-failed [OPTIONS] <PR_NUM|REV>`
+
+**Command Alias:** `rerun`
+
+###### **Arguments:**
+
+- `<PR_NUM|REV>` — PR number, or revision ID to look up a PR from
+
+###### **Options:**
+
+- `--cancel` — Cancel any in-progress runs and restart the entire pipeline. Without this flag, the command fails if CI has not yet completed
+- `--cancel-timeout <SECS>` — Seconds to wait for cancelled runs to finalize before re-running. Only meaningful with --cancel
+
+  Default value: `30`
 
 ## `jj-gh debug`
 

--- a/src/completions/mod.rs
+++ b/src/completions/mod.rs
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn real_pr_action_covers_all_visible_subcommands() {
         // Catches regressions when adding/renaming subcommands or visible
-        // aliases on `PrAction` — fake_pr_command is too narrow to notice.
+        // aliases on `PrAction`; fake_pr_command is too narrow to notice.
         let bash = emit_real(Shell::Bash);
         for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
             assert!(bash.contains(name), "bash overlay missing `{name}`");

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -111,6 +111,61 @@ pub struct PrCreated {
     pub has_merge_queue: bool,
 }
 
+/// Top-level state of a workflow run from the Actions API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowRunStatus {
+    /// Run is queued but has not started.
+    Queued,
+    /// Run is actively executing.
+    InProgress,
+    /// Run finished; [`WorkflowRun::conclusion`] is set.
+    Completed,
+    /// Any state we don't model explicitly (waiting, pending, requested, etc.).
+    /// Treated as "not completed" by retry-failed logic.
+    Other,
+}
+
+/// Final result of a completed workflow run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowRunConclusion {
+    Success,
+    Failure,
+    Cancelled,
+    TimedOut,
+    ActionRequired,
+    Skipped,
+    Neutral,
+    StartupFailure,
+    /// Any other conclusion string from the API.
+    Other,
+}
+
+/// A single workflow run on a commit. Subset of fields needed by
+/// `jj pr retry-failed`.
+#[derive(Debug, Clone)]
+pub struct WorkflowRun {
+    pub id: u64,
+    pub status: WorkflowRunStatus,
+    pub conclusion: Option<WorkflowRunConclusion>,
+}
+
+impl WorkflowRunConclusion {
+    /// True for conclusions that mean the run did not succeed and is worth
+    /// retrying (failure, cancelled, timed out, action required, startup
+    /// failure). `Success`, `Skipped`, `Neutral` are not retried.
+    #[must_use]
+    pub fn is_retryable_failure(self) -> bool {
+        matches!(
+            self,
+            Self::Failure
+                | Self::Cancelled
+                | Self::TimedOut
+                | Self::ActionRequired
+                | Self::StartupFailure
+        )
+    }
+}
+
 pub trait Gh {
     /// First open PR whose `head` matches `head_spec`. Must be `owner:branch`;
     /// GitHub silently ignores the `head` filter without the owner prefix.
@@ -222,7 +277,7 @@ pub trait Gh {
     /// `enablePullRequestAutoMerge` or `enqueuePullRequest` based on
     /// `has_merge_queue` (callers get this from [`PrDetails::has_merge_queue`]
     /// or [`PrCreated::has_merge_queue`]). `method` is ignored when the queue
-    /// path is taken — the queue's own config decides the merge method.
+    /// path is taken; the queue's own config decides the merge method.
     ///
     /// # Errors
     ///
@@ -255,4 +310,41 @@ pub trait Gh {
         repo: &str,
         branches: &[String],
     ) -> Result<Vec<PrWithCiStatus>>;
+
+    /// List GitHub Actions workflow runs whose head commit matches `sha`.
+    /// Returns the subset of fields needed to decide retry/cancel eligibility.
+    ///
+    /// # Errors
+    ///
+    /// Propagates API errors.
+    async fn list_workflow_runs_for_sha(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<Vec<WorkflowRun>>;
+
+    /// Cancel an in-progress workflow run. The API call is fire-and-forget;
+    /// GitHub asynchronously transitions the run to `completed/cancelled`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates API errors.
+    async fn cancel_workflow_run(&self, owner: &str, repo: &str, run_id: u64) -> Result<()>;
+
+    /// Re-run every job in a workflow run. Only valid when the run is
+    /// `completed`; GitHub returns 403 otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Propagates API errors.
+    async fn rerun_workflow_run(&self, owner: &str, repo: &str, run_id: u64) -> Result<()>;
+
+    /// Re-run only the failed jobs in a workflow run. Only valid when the run
+    /// is `completed`; GitHub returns 403 otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Propagates API errors.
+    async fn rerun_failed_jobs(&self, owner: &str, repo: &str, run_id: u64) -> Result<()>;
 }

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -2,6 +2,7 @@
 
 use super::{
     BaseLookup, CreatePrRequest, Gh, Label, PrCreated, PrDetails, PrSummary, Reviewer, UpdatePr,
+    WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus,
 };
 use crate::{
     config::AutoMergeMethod,
@@ -405,6 +406,43 @@ impl Gh for OctocrabGh {
         Ok(())
     }
 
+    async fn list_workflow_runs_for_sha(
+        &self,
+        owner: &str,
+        repo: &str,
+        sha: &str,
+    ) -> Result<Vec<WorkflowRun>> {
+        let page = self
+            .octo
+            .workflows(owner, repo)
+            .list_all_runs()
+            .head_sha(sha.to_string())
+            .per_page(255)
+            .send()
+            .await
+            .map_err(humanize)
+            .with_context(|| format!("listing workflow runs for {owner}/{repo} sha={sha}"))?;
+        Ok(page.items.iter().map(map_workflow_run).collect())
+    }
+
+    async fn cancel_workflow_run(&self, owner: &str, repo: &str, run_id: u64) -> Result<()> {
+        self.octo
+            .actions()
+            .cancel_workflow_run(owner, repo, run_id.into())
+            .await
+            .map_err(humanize)
+            .with_context(|| format!("cancelling workflow run {run_id} on {owner}/{repo}"))?;
+        Ok(())
+    }
+
+    async fn rerun_workflow_run(&self, owner: &str, repo: &str, run_id: u64) -> Result<()> {
+        post_action_run(&self.octo, owner, repo, run_id, "rerun").await
+    }
+
+    async fn rerun_failed_jobs(&self, owner: &str, repo: &str, run_id: u64) -> Result<()> {
+        post_action_run(&self.octo, owner, repo, run_id, "rerun-failed-jobs").await
+    }
+
     async fn local_pulls(
         &self,
         owner: &str,
@@ -484,6 +522,55 @@ fn build_search_queries(owner: &str, repo: &str, branches: &[String]) -> Vec<Str
         queries.push(current);
     }
     queries
+}
+
+/// POST to a workflow-run action endpoint (`rerun` or `rerun-failed-jobs`).
+/// Octocrab has no typed wrapper for these, so we route through `_post` and
+/// reuse `map_github_error` for consistent error handling.
+async fn post_action_run(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    run_id: u64,
+    action: &str,
+) -> Result<()> {
+    let route = format!("/repos/{owner}/{repo}/actions/runs/{run_id}/{action}");
+    let uri = http::Uri::try_from(&route).with_context(|| format!("building URI for {route}"))?;
+    let response = octo
+        ._post(uri, None::<&()>)
+        .await
+        .map_err(humanize)
+        .with_context(|| format!("POST {route}"))?;
+    octocrab::map_github_error(response)
+        .await
+        .map_err(humanize)
+        .with_context(|| format!("POST {route}"))?;
+    Ok(())
+}
+
+fn map_workflow_run(r: &octocrab::models::workflows::Run) -> WorkflowRun {
+    let status = match r.status.as_str() {
+        "queued" => WorkflowRunStatus::Queued,
+        "in_progress" => WorkflowRunStatus::InProgress,
+        "completed" => WorkflowRunStatus::Completed,
+        _ => WorkflowRunStatus::Other,
+    };
+    let conclusion = r.conclusion.as_deref().map(|c| match c {
+        "success" => WorkflowRunConclusion::Success,
+        "failure" => WorkflowRunConclusion::Failure,
+        "cancelled" => WorkflowRunConclusion::Cancelled,
+        "timed_out" => WorkflowRunConclusion::TimedOut,
+        "action_required" => WorkflowRunConclusion::ActionRequired,
+        "skipped" => WorkflowRunConclusion::Skipped,
+        "neutral" => WorkflowRunConclusion::Neutral,
+        "startup_failure" => WorkflowRunConclusion::StartupFailure,
+        _ => WorkflowRunConclusion::Other,
+    });
+    WorkflowRun {
+        id: r.id.into_inner(),
+        status,
+        conclusion,
+    }
 }
 
 /// Map an `octocrab::Error` into an `anyhow::Error` with a human-friendly message

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -208,7 +208,7 @@ impl Jj for JjCli {
         // local/remote side of each tracked bookmark; filtering on
         // `if(remote, ...)` keeps only the local-side row, whose
         // `normal_target.commit_id()` is the local commit (which may diverge
-        // from the remote target — e.g. local rebase without push).
+        // from the remote target, e.g. local rebase without push).
         //
         // Emit NDJSON: one `PushedBookmark` per line, parsed via serde so
         // bookmark names with unusual characters round-trip safely.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod gh;
 mod git;
 mod jj;
 mod pr;
+mod ui;
 
 pub mod logging;
 

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -360,6 +360,23 @@ mod tests {
         ) -> Result<Vec<crate::gh::PrWithCiStatus>> {
             unimplemented!("fetch does not call local_pulls")
         }
+        async fn list_workflow_runs_for_sha(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _sha: &str,
+        ) -> Result<Vec<crate::gh::WorkflowRun>> {
+            unimplemented!("fetch does not call list_workflow_runs_for_sha")
+        }
+        async fn cancel_workflow_run(&self, _: &str, _: &str, _: u64) -> Result<()> {
+            unimplemented!("fetch does not call cancel_workflow_run")
+        }
+        async fn rerun_workflow_run(&self, _: &str, _: &str, _: u64) -> Result<()> {
+            unimplemented!("fetch does not call rerun_workflow_run")
+        }
+        async fn rerun_failed_jobs(&self, _: &str, _: &str, _: u64) -> Result<()> {
+            unimplemented!("fetch does not call rerun_failed_jobs")
+        }
     }
 
     #[derive(Debug, Clone)]

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -5,6 +5,7 @@ mod editor;
 pub mod fetch;
 mod frontmatter;
 mod pr_log;
+mod retry_failed;
 mod template;
 mod validation;
 
@@ -24,6 +25,7 @@ use crate::{
         editor::{TempfileEditor, edit::EditArgs},
         fetch::FetchArgs,
         pr_log::PrLogArgs,
+        retry_failed::RetryFailedArgs,
         template::TemplateSource,
     },
 };
@@ -82,6 +84,18 @@ pub enum PrAction {
     /// containing all PR information).
     #[command(visible_alias = "l")]
     Log(PrLogArgs),
+
+    /// Re-run failed CI jobs on a PR.
+    ///
+    /// Resolves the PR from a revision (via its local bookmark) or PR number,
+    /// then re-runs failed workflow runs on the PR's head commit. By default
+    /// the command fails if CI has not yet completed, because GitHub refuses
+    /// to re-run a workflow run until it reaches the `completed` state.
+    ///
+    /// With `--cancel`, in-progress runs are cancelled first; once they
+    /// finalize, every workflow run is re-run (full pipeline restart).
+    #[command(visible_alias = "rerun")]
+    RetryFailed(RetryFailedArgs),
 }
 
 /// Dispatch the `pr` subcommand to the matching handler.
@@ -99,6 +113,7 @@ pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
         PrAction::AutoMerge(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Edit(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Log(a) => fig.merge(Serialized::defaults(a)),
+        PrAction::RetryFailed(a) => fig.merge(Serialized::defaults(a)),
     };
     let config = config::extract(&fig)?;
 
@@ -119,6 +134,7 @@ pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
             editor::edit::run(&jj, &gh, &OsEnv, &editor, &config, &args).await?;
         }
         PrAction::Log(args) => pr_log::run(&args, &config, &gh, &jj).await?,
+        PrAction::RetryFailed(args) => retry_failed::run(&jj, &gh, &config, &args).await?,
     }
     Ok(())
 }
@@ -151,6 +167,25 @@ pub async fn get_pr<J: Jj, G: Gh>(
     number_or_rev: &str,
     body: bool,
 ) -> Result<PrDetails> {
+    Ok(resolve_pr_with_target(jj, gh, config, number_or_rev, body)
+        .await?
+        .0)
+}
+
+/// Same as [`get_pr`] but also returns the resolved [`remote::Target`] so
+/// callers that need the owner/repo for further API calls don't have to
+/// re-derive it from the remote URL.
+///
+/// # Errors
+///
+/// See [`get_pr`].
+pub async fn resolve_pr_with_target<J: Jj, G: Gh>(
+    jj: &J,
+    gh: &G,
+    config: &Config,
+    number_or_rev: &str,
+    body: bool,
+) -> Result<(PrDetails, remote::Target)> {
     if let Ok(num) = number_or_rev.parse::<u64>() {
         let origin_url = jj
             .remote_url(&config.default_remote)
@@ -158,7 +193,8 @@ pub async fn get_pr<J: Jj, G: Gh>(
             .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
         let upstream_url = jj.remote_url(&config.upstream_remote).await?;
         let target = remote::target(&origin_url, upstream_url.as_deref())?;
-        gh.get_pr(&target.owner, &target.repo, num, body).await
+        let pr = gh.get_pr(&target.owner, &target.repo, num, body).await?;
+        Ok((pr, target))
     } else {
         let lookup = resolve_pr_for_rev(jj, gh, config, number_or_rev).await?;
         let summary = lookup.summary.ok_or_else(|| {
@@ -167,13 +203,15 @@ pub async fn get_pr<J: Jj, G: Gh>(
                 lookup.head_spec,
             )
         })?;
-        gh.get_pr(
-            &lookup.target.owner,
-            &lookup.target.repo,
-            summary.number,
-            body,
-        )
-        .await
+        let pr = gh
+            .get_pr(
+                &lookup.target.owner,
+                &lookup.target.repo,
+                summary.number,
+                body,
+            )
+            .await?;
+        Ok((pr, lookup.target))
     }
 }
 

--- a/src/pr/retry_failed.rs
+++ b/src/pr/retry_failed.rs
@@ -1,0 +1,720 @@
+//! `jj-gh pr retry-failed`: re-run failed CI on a PR's head commit.
+//!
+//! Default: refuses to act if any workflow run is still in progress, because
+//! GitHub will reject `rerun-failed-jobs` until the run is `completed`.
+//!
+//! `--cancel`: cancels in-progress runs, waits for them to finalize, then
+//! re-runs every workflow run (full pipeline restart).
+
+use crate::{
+    config::Config,
+    gh::{Gh, WorkflowRun, WorkflowRunStatus},
+    jj::Jj,
+    pr,
+    ui::Spinner,
+};
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, clap::Args, Serialize)]
+pub struct RetryFailedArgs {
+    /// PR number, or revision ID to look up a PR from.
+    #[arg(value_name = "PR_NUM|REV")]
+    #[serde(skip)]
+    pub number_or_rev: String,
+
+    /// Cancel any in-progress runs and restart the entire pipeline.
+    /// Without this flag, the command fails if CI has not yet completed.
+    #[arg(long)]
+    #[serde(skip)]
+    pub cancel: bool,
+
+    /// Seconds to wait for cancelled runs to finalize before re-running.
+    /// Only meaningful with --cancel.
+    #[arg(long, value_name = "SECS", default_value_t = 30, requires = "cancel")]
+    #[serde(skip)]
+    pub cancel_timeout: u64,
+}
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+pub async fn run<J, G>(jj: &J, gh: &G, config: &Config, args: &RetryFailedArgs) -> Result<()>
+where
+    J: Jj,
+    G: Gh,
+{
+    run_with(jj, gh, config, args, DEFAULT_POLL_INTERVAL).await
+}
+
+async fn run_with<J, G>(
+    jj: &J,
+    gh: &G,
+    config: &Config,
+    args: &RetryFailedArgs,
+    poll_interval: Duration,
+) -> Result<()>
+where
+    J: Jj,
+    G: Gh,
+{
+    let RetryFailedArgs {
+        number_or_rev,
+        cancel,
+        cancel_timeout,
+    } = args;
+
+    let (pr, target) = pr::resolve_pr_with_target(jj, gh, config, number_or_rev, false).await?;
+    let owner = &target.owner;
+    let repo = &target.repo;
+
+    let runs = gh
+        .list_workflow_runs_for_sha(owner, repo, &pr.head_sha)
+        .await
+        .with_context(|| format!("listing workflow runs for PR #{}", pr.number))?;
+
+    let in_progress: Vec<&WorkflowRun> = runs
+        .iter()
+        .filter(|r| r.status != WorkflowRunStatus::Completed)
+        .collect();
+
+    if *cancel {
+        if !in_progress.is_empty() {
+            let spinner = Spinner::start(format!(
+                "cancelling {} in-progress workflow run(s)",
+                in_progress.len()
+            ));
+            let cancel_result = cancel_each(gh, owner, repo, pr.number, &in_progress).await;
+            if let Err(e) = cancel_result {
+                spinner.stop().await;
+                return Err(e);
+            }
+            let poll_result = poll_until_completed(
+                gh,
+                owner,
+                repo,
+                &pr.head_sha,
+                Duration::from_secs(*cancel_timeout),
+                poll_interval,
+            )
+            .await;
+            spinner.stop().await;
+            poll_result?;
+        }
+
+        let final_runs = gh
+            .list_workflow_runs_for_sha(owner, repo, &pr.head_sha)
+            .await
+            .with_context(|| format!("re-listing workflow runs for PR #{}", pr.number))?;
+
+        if final_runs.is_empty() {
+            log::info!("No workflow runs found for PR #{}", pr.number);
+        } else {
+            let spinner =
+                Spinner::start(format!("restarting {} workflow run(s)", final_runs.len()));
+            let result = rerun_each(gh, owner, repo, pr.number, &final_runs).await;
+            spinner.stop().await;
+            result?;
+
+            log::info!(
+                "Cancelled {} run(s) and restarted {} workflow run(s) for PR #{}",
+                in_progress.len(),
+                final_runs.len(),
+                pr.number
+            );
+        }
+    } else {
+        if !in_progress.is_empty() {
+            bail!(
+                "CI still in progress for PR #{} ({} run(s) not yet completed). \
+                Pass --cancel to cancel and restart the pipeline. \
+                This is a GitHub limitation; it does not let you retry jobs \
+                while jobs are still in progress.",
+                pr.number,
+                in_progress.len()
+            );
+        }
+        retry_failed_jobs(gh, owner, repo, pr.number, &runs).await?;
+    }
+
+    println!("{}", pr.html_url);
+    Ok(())
+}
+
+async fn retry_failed_jobs<G: Gh>(
+    gh: &G,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    runs: &[WorkflowRun],
+) -> Result<()> {
+    let failed: Vec<&WorkflowRun> = runs
+        .iter()
+        .filter(|r| {
+            r.conclusion
+                .is_some_and(super::super::gh::WorkflowRunConclusion::is_retryable_failure)
+        })
+        .collect();
+
+    if failed.is_empty() {
+        log::info!("No failed workflow runs to retry on PR #{pr_number}");
+        return Ok(());
+    }
+
+    let spinner = Spinner::start(format!(
+        "retrying failed jobs on {} workflow run(s)",
+        failed.len()
+    ));
+    let result = retry_each(gh, owner, repo, pr_number, &failed).await;
+    spinner.stop().await;
+    result?;
+
+    log::info!(
+        "Retried failed jobs on {} workflow run(s) for PR #{pr_number}",
+        failed.len()
+    );
+    Ok(())
+}
+
+async fn retry_each<G: Gh>(
+    gh: &G,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    failed: &[&WorkflowRun],
+) -> Result<()> {
+    for r in failed {
+        gh.rerun_failed_jobs(owner, repo, r.id)
+            .await
+            .with_context(|| {
+                format!(
+                    "re-running failed jobs on workflow run {} for PR #{pr_number}",
+                    r.id
+                )
+            })?;
+    }
+    Ok(())
+}
+
+async fn cancel_each<G: Gh>(
+    gh: &G,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    in_progress: &[&WorkflowRun],
+) -> Result<()> {
+    for r in in_progress {
+        gh.cancel_workflow_run(owner, repo, r.id)
+            .await
+            .with_context(|| format!("cancelling workflow run {} on PR #{pr_number}", r.id))?;
+    }
+    Ok(())
+}
+
+async fn rerun_each<G: Gh>(
+    gh: &G,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    runs: &[WorkflowRun],
+) -> Result<()> {
+    for r in runs {
+        gh.rerun_workflow_run(owner, repo, r.id)
+            .await
+            .with_context(|| format!("re-running workflow run {} on PR #{pr_number}", r.id))?;
+    }
+    Ok(())
+}
+
+async fn poll_until_completed<G: Gh>(
+    gh: &G,
+    owner: &str,
+    repo: &str,
+    head_sha: &str,
+    timeout: Duration,
+    interval: Duration,
+) -> Result<()> {
+    let start = Instant::now();
+    loop {
+        let runs = gh.list_workflow_runs_for_sha(owner, repo, head_sha).await?;
+        if runs
+            .iter()
+            .all(|r| r.status == WorkflowRunStatus::Completed)
+        {
+            return Ok(());
+        }
+        if start.elapsed() >= timeout {
+            bail!(
+                "workflow runs did not finish cancelling within {}s; re-run \
+                 `jj pr retry-failed --cancel` once they settle",
+                timeout.as_secs()
+            );
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{self, Config},
+        gh::{
+            BaseLookup, CreatePrRequest, Label, PrCreated, PrDetails, PrSummary, PrWithCiStatus,
+            UpdatePr, WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus,
+        },
+        jj::{CommitInfo, PushedBookmark},
+    };
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    fn default_config() -> Config {
+        let fig = config::defaults_figment();
+        config::extract(&fig).unwrap()
+    }
+
+    fn pr_details(number: u64, sha: &str) -> PrDetails {
+        PrDetails {
+            is_draft: false,
+            auto_merge: false,
+            auto_merge_method: None,
+            number,
+            title: "t".into(),
+            html_url: format!("https://github.com/o/r/pull/{number}"),
+            head_ref: "feat".into(),
+            head_sha: sha.into(),
+            head_user_login: Some("o".into()),
+            head_repo_name: Some("r".into()),
+            graphql_node_id: "node".into(),
+            in_merge_queue: false,
+            labels: Vec::<Label>::new(),
+            reviewers: vec![],
+            body: None,
+        }
+    }
+
+    fn wr(
+        id: u64,
+        status: WorkflowRunStatus,
+        conclusion: Option<WorkflowRunConclusion>,
+    ) -> WorkflowRun {
+        WorkflowRun {
+            id,
+            status,
+            conclusion,
+        }
+    }
+
+    struct FakeJj {
+        workspace_root: PathBuf,
+    }
+
+    impl FakeJj {
+        fn new() -> Self {
+            Self {
+                workspace_root: PathBuf::from("/tmp"),
+            }
+        }
+    }
+
+    impl crate::jj::Jj for FakeJj {
+        async fn resolve_rev(&self, _rev: &str) -> Result<CommitInfo> {
+            unimplemented!("retry-failed tests pass PR numbers, not revs")
+        }
+        async fn stacked_ancestor_bookmark(&self, _rev: &str) -> Result<Option<String>> {
+            unimplemented!()
+        }
+        async fn first_commit_description(&self, _revset: &str) -> Result<String> {
+            unimplemented!()
+        }
+        async fn remote_url(&self, name: &str) -> Result<Option<String>> {
+            // resolve_pr_with_target asks for default + upstream remote URLs.
+            if name == "origin" {
+                Ok(Some("git@github.com:o/r.git".into()))
+            } else {
+                Ok(None)
+            }
+        }
+        async fn remote_bookmark_sha(&self, _: &str, _: &str) -> Result<Option<String>> {
+            unimplemented!()
+        }
+        async fn push(&self, _rev: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn trunk_branch(&self) -> Result<Option<String>> {
+            unimplemented!()
+        }
+        async fn workspace_root(&self) -> Result<&PathBuf> {
+            Ok(&self.workspace_root)
+        }
+        async fn git_import(&self) -> Result<()> {
+            unimplemented!()
+        }
+        async fn pushed_bookmarks(&self, _remote: &str) -> Result<Vec<PushedBookmark>> {
+            unimplemented!()
+        }
+        async fn eval_template(
+            &self,
+            _revset: &str,
+            _template: &str,
+            _config_file: Option<&Path>,
+            _reversed: bool,
+        ) -> Result<String> {
+            unimplemented!()
+        }
+    }
+
+    #[derive(Default)]
+    struct Calls {
+        cancelled: Vec<u64>,
+        rerun: Vec<u64>,
+        rerun_failed: Vec<u64>,
+    }
+
+    struct FakeGh {
+        pr: PrDetails,
+        /// Successive responses to `list_workflow_runs_for_sha`. Last entry
+        /// repeats once exhausted.
+        list_responses: Mutex<Vec<Vec<WorkflowRun>>>,
+        calls: Mutex<Calls>,
+    }
+
+    impl FakeGh {
+        fn new(pr: PrDetails, responses: Vec<Vec<WorkflowRun>>) -> Self {
+            Self {
+                pr,
+                list_responses: Mutex::new(responses),
+                calls: Mutex::new(Calls::default()),
+            }
+        }
+    }
+
+    impl Gh for FakeGh {
+        async fn find_open_pr(&self, _o: &str, _r: &str, _h: &str) -> Result<Option<PrSummary>> {
+            unimplemented!()
+        }
+        async fn lookup_base(&self, _: &str, _: &str, _: &str) -> Result<BaseLookup> {
+            unimplemented!()
+        }
+        async fn create_pr(&self, _req: CreatePrRequest) -> Result<PrCreated> {
+            unimplemented!()
+        }
+        async fn add_reviewers(
+            &self,
+            _o: &str,
+            _r: &str,
+            _p: u64,
+            _: Vec<crate::gh::Reviewer>,
+        ) -> Result<()> {
+            unimplemented!()
+        }
+        async fn remove_reviewers(
+            &self,
+            _o: &str,
+            _r: &str,
+            _p: u64,
+            _: Vec<crate::gh::Reviewer>,
+        ) -> Result<()> {
+            unimplemented!()
+        }
+        async fn add_labels(&self, _: &str, _: &str, _: u64, _: &[String]) -> Result<()> {
+            unimplemented!()
+        }
+        async fn remove_labels(&self, _: &str, _: &[String]) -> Result<()> {
+            unimplemented!()
+        }
+        async fn update_pr(&self, _req: UpdatePr) -> Result<()> {
+            unimplemented!()
+        }
+        async fn set_draft(&self, _id: &str, _d: bool) -> Result<()> {
+            unimplemented!()
+        }
+        async fn disable_auto_merge(&self, _id: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn get_pr(&self, _o: &str, _r: &str, _n: u64, _b: bool) -> Result<PrDetails> {
+            Ok(self.pr.clone())
+        }
+        async fn enable_auto_merge(
+            &self,
+            _id: &str,
+            _q: bool,
+            _m: crate::config::AutoMergeMethod,
+        ) -> Result<()> {
+            unimplemented!()
+        }
+        async fn local_pulls(
+            &self,
+            _o: &str,
+            _r: &str,
+            _b: &[String],
+        ) -> Result<Vec<PrWithCiStatus>> {
+            unimplemented!()
+        }
+        async fn list_workflow_runs_for_sha(
+            &self,
+            _o: &str,
+            _r: &str,
+            _sha: &str,
+        ) -> Result<Vec<WorkflowRun>> {
+            let mut q = self.list_responses.lock().unwrap();
+            if q.len() > 1 {
+                Ok(q.remove(0))
+            } else {
+                Ok(q.first().cloned().unwrap_or_default())
+            }
+        }
+        async fn cancel_workflow_run(&self, _o: &str, _r: &str, id: u64) -> Result<()> {
+            self.calls.lock().unwrap().cancelled.push(id);
+            Ok(())
+        }
+        async fn rerun_workflow_run(&self, _o: &str, _r: &str, id: u64) -> Result<()> {
+            self.calls.lock().unwrap().rerun.push(id);
+            Ok(())
+        }
+        async fn rerun_failed_jobs(&self, _o: &str, _r: &str, id: u64) -> Result<()> {
+            self.calls.lock().unwrap().rerun_failed.push(id);
+            Ok(())
+        }
+    }
+
+    fn args(number: &str, cancel: bool, timeout: u64) -> RetryFailedArgs {
+        RetryFailedArgs {
+            number_or_rev: number.into(),
+            cancel,
+            cancel_timeout: timeout,
+        }
+    }
+
+    #[tokio::test]
+    async fn default_retries_only_failed_completed_runs() {
+        let pr = pr_details(42, "deadbeef");
+        let runs = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Success),
+            ),
+            wr(
+                2,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Failure),
+            ),
+            wr(
+                3,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::TimedOut),
+            ),
+            wr(
+                4,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Skipped),
+            ),
+        ];
+        let gh = FakeGh::new(pr, vec![runs]);
+        let jj = FakeJj::new();
+
+        run_with(
+            &jj,
+            &gh,
+            &default_config(),
+            &args("42", false, 30),
+            Duration::from_millis(5),
+        )
+        .await
+        .expect("default path should succeed");
+
+        let calls = gh.calls.lock().unwrap();
+        assert_eq!(calls.rerun_failed, vec![2, 3]);
+        assert!(calls.cancelled.is_empty());
+        assert!(calls.rerun.is_empty());
+    }
+
+    #[tokio::test]
+    async fn default_errors_when_runs_in_progress() {
+        let pr = pr_details(7, "abc");
+        let runs = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Failure),
+            ),
+            wr(2, WorkflowRunStatus::InProgress, None),
+        ];
+        let gh = FakeGh::new(pr, vec![runs]);
+        let jj = FakeJj::new();
+
+        let err = run_with(
+            &jj,
+            &gh,
+            &default_config(),
+            &args("7", false, 30),
+            Duration::from_millis(5),
+        )
+        .await
+        .expect_err("should refuse while CI in progress");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("still in progress"), "msg: {msg}");
+
+        let calls = gh.calls.lock().unwrap();
+        assert!(calls.cancelled.is_empty());
+        assert!(calls.rerun.is_empty());
+        assert!(calls.rerun_failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn default_all_success_does_nothing() {
+        let pr = pr_details(9, "sha");
+        let runs = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Success),
+            ),
+            wr(
+                2,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Success),
+            ),
+        ];
+        let gh = FakeGh::new(pr, vec![runs]);
+        let jj = FakeJj::new();
+
+        run_with(
+            &jj,
+            &gh,
+            &default_config(),
+            &args("9", false, 30),
+            Duration::from_millis(5),
+        )
+        .await
+        .unwrap();
+
+        let calls = gh.calls.lock().unwrap();
+        assert!(calls.rerun_failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_path_cancels_then_reruns_all_after_settle() {
+        let pr = pr_details(11, "sha");
+        let initial = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Failure),
+            ),
+            wr(2, WorkflowRunStatus::InProgress, None),
+            wr(3, WorkflowRunStatus::Queued, None),
+        ];
+        // Second list call (poll): still in progress.
+        let still_running = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Failure),
+            ),
+            wr(2, WorkflowRunStatus::InProgress, None),
+            wr(
+                3,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Cancelled),
+            ),
+        ];
+        // Third list call (poll): all completed.
+        let all_done = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Failure),
+            ),
+            wr(
+                2,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Cancelled),
+            ),
+            wr(
+                3,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Cancelled),
+            ),
+        ];
+        // Fourth: same all-done state for the post-poll re-list before rerun.
+        let post_poll = all_done.clone();
+        let gh = FakeGh::new(pr, vec![initial, still_running, all_done, post_poll]);
+        let jj = FakeJj::new();
+
+        run_with(
+            &jj,
+            &gh,
+            &default_config(),
+            &args("11", true, 5),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("cancel path should succeed once runs settle");
+
+        let calls = gh.calls.lock().unwrap();
+        assert_eq!(calls.cancelled, vec![2, 3]);
+        assert_eq!(calls.rerun, vec![1, 2, 3]);
+        assert!(calls.rerun_failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_path_times_out_if_runs_never_settle() {
+        let pr = pr_details(13, "sha");
+        let stuck = vec![wr(1, WorkflowRunStatus::InProgress, None)];
+        let gh = FakeGh::new(pr, vec![stuck]);
+        let jj = FakeJj::new();
+
+        let err = run_with(
+            &jj,
+            &gh,
+            &default_config(),
+            // 0s timeout: the very first poll iteration sees elapsed >= timeout and errors.
+            &args("13", true, 0),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect_err("should time out");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("did not finish"), "msg: {msg}");
+
+        let calls = gh.calls.lock().unwrap();
+        assert_eq!(calls.cancelled, vec![1]);
+        assert!(calls.rerun.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_path_with_no_in_progress_just_reruns_all() {
+        let pr = pr_details(21, "sha");
+        let runs = vec![
+            wr(
+                1,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Success),
+            ),
+            wr(
+                2,
+                WorkflowRunStatus::Completed,
+                Some(WorkflowRunConclusion::Failure),
+            ),
+        ];
+        // Same list returned for both the initial and re-list before rerun.
+        let gh = FakeGh::new(pr, vec![runs.clone(), runs]);
+        let jj = FakeJj::new();
+
+        run_with(
+            &jj,
+            &gh,
+            &default_config(),
+            &args("21", true, 30),
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+
+        let calls = gh.calls.lock().unwrap();
+        assert!(calls.cancelled.is_empty());
+        assert_eq!(calls.rerun, vec![1, 2]);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,6 @@
+//! Terminal UI helpers (spinners etc.). All output goes to stderr so it
+//! doesn't pollute stdout pipelines.
+
+pub mod spinner;
+
+pub use spinner::Spinner;

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -1,0 +1,72 @@
+//! Tiny braille spinner for stderr. No-op when stderr is not a TTY (CI, piped
+//! output) so logs stay clean.
+//!
+//! Uses `anstyle` for the dim color escape and `tokio::time` for the tick
+//! loop.
+
+use std::io::{IsTerminal, Write};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const TICK: Duration = Duration::from_millis(100);
+
+/// Animated spinner that runs on a background tokio task. Dropping without
+/// calling [`Spinner::stop`] is safe (the task exits on the next tick) but
+/// the final cleared line is best-effort in that case.
+pub struct Spinner {
+    handle: Option<JoinHandle<()>>,
+    stop_tx: Option<oneshot::Sender<()>>,
+}
+
+impl Spinner {
+    /// Start a spinner with `msg`. When stderr is not a terminal, returns a
+    /// no-op spinner so callers can use it unconditionally.
+    pub fn start(msg: impl Into<String>) -> Self {
+        if !std::io::stderr().is_terminal() {
+            return Self {
+                handle: None,
+                stop_tx: None,
+            };
+        }
+        let msg = msg.into();
+        let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            let dim = anstyle::Style::new().dimmed();
+            let mut interval = tokio::time::interval(TICK);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut frame = 0usize;
+            loop {
+                tokio::select! {
+                    _ = &mut stop_rx => break,
+                    _ = interval.tick() => {
+                        let glyph = FRAMES[frame % FRAMES.len()];
+                        frame = frame.wrapping_add(1);
+                        let mut err = std::io::stderr().lock();
+                        let _ = write!(err, "\r{dim}{glyph} {msg}{dim:#}");
+                        let _ = err.flush();
+                    }
+                }
+            }
+            let mut err = std::io::stderr().lock();
+            let _ = write!(err, "\r\x1b[2K");
+            let _ = err.flush();
+        });
+        Self {
+            handle: Some(handle),
+            stop_tx: Some(stop_tx),
+        }
+    }
+
+    /// Stop the spinner and clear its line. Awaiting ensures the cleared line
+    /// is flushed before subsequent output.
+    pub async fn stop(mut self) {
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.handle.take() {
+            let _ = h.await;
+        }
+    }
+}


### PR DESCRIPTION
Adds a subcommand to retry failed GitHub Actions runs by PR number or revision ID.

Fixes #44
