### PR TITLE
feat(pr-log): Show more details CI status breakdown by default

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -175,7 +175,7 @@ The following template aliases are available for use if you pass your own templa
 ###### **Arguments:**
 
 - `<JJ_LOG_ARGS>` — Arguments forwarded verbatim to the underlying `jj log` invocation. Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`. If you pass `-T` / `--template`, the default PR-aware template is not applied; the following per-commit aliases are then available in your own template, each keyed on `commit_id`:
-  - `pr_number`: PR number as a string, or empty for commits without a PR. - `pr_url`: PR URL, or empty. - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty. - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or empty. - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon plus merge status (empty for commits without a PR).
+  - `pr_number`: PR number as a string, or empty for commits without a PR. - `pr_url`: PR URL, or empty. - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty. - `pr_ci_breakdown`: per-bucket counts `(● P / ✗ F / ✓ S)` with labeled colors, or empty when the PR has no CI contexts. - `pr_draft_status`: a colored "draft" label (with a nerdfont icon when enabled), or empty when the PR is not a draft. - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or empty. - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon plus merge status (empty for commits without a PR).
 
 ###### **Options:**
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
   - Intelligently supports stacked PRs by choosing the correct base if the revision has an ancestor bookmark for which an open PR exists
 - Enable auto-merge for a PR by its revision ID, without having to know/find its PR number (e.g. `jj pr auto-merge zqxy`)
 - Create local bookmarks for PRs, including across forks (e.g. `jj pr fetch 1234 && jj new pr-1234/...`, useful for testing PRs to OSS repos)
-- Show PR metadata like number and CI status in commit graph (e.g. `jj pr log`)
+- Show PR metadata like number and CI breakdown counts in commit graph (e.g. `jj pr log`)
+- Re-run failed CI jobs on a PR by revision ID or PR number (e.g. `jj pr retry-failed zqxy`), with `--cancel` to cancel and restart the entire pipeline
 
 all from the comfort of your terminal, without touching GitHub's clunky web UI.
 Works great when combined with the [jj megamerge](https://isaaccorbrey.com/notes/jujutsu-megamerges-for-fun-and-profit) workflow!
@@ -283,9 +284,15 @@ a matching open PR:
 
 - `pr_number`: PR number as a string.
 - `pr_url`: PR URL.
-- `pr_ci_status`: `SUCCESS`, `FAILED`, or `PENDING`.
+- `pr_ci_status`: `SUCCESS`, `FAILED`, or `PENDING` (rolled-up rollup state).
+- `pr_ci_breakdown`: per-bucket check counts `(● P / ✗ F / ✓ S)` with colored
+  labels. Pending and failed chunks are hidden when their count is `0`, so a
+  fully-green PR renders as `(✓ 27)`. Empty when the PR has no CI contexts.
+- `pr_draft_status`: colored `draft` label (with a `` nerdfont icon when
+  enabled), or empty when the PR is not a draft.
 - `pr_merge_status`: merged / in-merge-queue / auto-merge label.
-- `pr_meta`: pre-formatted hyperlinked PR number, colored CI icon, and merge
+- `pr_meta`: pre-formatted hyperlinked PR number, draft indicator, the
+  breakdown counts (or the rolled-up CI icon when no contexts), and merge
   status.
 
 ## PR body template resolution

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -11,7 +11,7 @@ mod reviewer;
 
 pub mod real;
 pub mod remote;
-pub use queries::{CiStatus, PrWithCiStatus};
+pub use queries::{CiCounts, CiStatus, PrWithCiStatus};
 pub use reviewer::Reviewer;
 
 /// Summary of an existing pull request. Just the fields we render.

--- a/src/gh/queries/mod.rs
+++ b/src/gh/queries/mod.rs
@@ -9,6 +9,7 @@ mod find_open_pr;
 mod get_pr;
 mod lookup_base;
 mod mark_ready_for_review;
+mod pr_check_contexts_page;
 mod prs_with_ci_status;
 mod remove_labels;
 mod update_pr;
@@ -36,9 +37,13 @@ pub use lookup_base::{LookupBaseInternal, LookupBaseResponseData, LookupBaseVari
 pub use mark_ready_for_review::{
     MarkReadyForReviewInternal, MarkReadyForReviewResponseData, MarkReadyForReviewVariables,
 };
+pub use pr_check_contexts_page::count_contexts_page;
+pub use pr_check_contexts_page::{
+    PrCheckContextsPageInternal, PrCheckContextsPageResponseData, PrCheckContextsPageVariables,
+};
 pub use prs_with_ci_status::{
-    CiStatus, PrWithCiStatus, PrsWithCiStatusInternal, PrsWithCiStatusResponseData,
-    PrsWithCiStatusVariables,
+    CiCounts, CiStatus, PrWithCiStatus, PrsWithCiStatusInternal, PrsWithCiStatusResponseData,
+    PrsWithCiStatusVariables, extract_pr_partials,
 };
 pub use remove_labels::{RemoveLabelsInternal, RemoveLabelsResponseData, RemoveLabelsVariables};
 pub use update_pr::{UpdatePrInternal, UpdatePrResponseData, UpdatePrVariables};

--- a/src/gh/queries/pr_check_contexts_page.gql
+++ b/src/gh/queries/pr_check_contexts_page.gql
@@ -1,0 +1,25 @@
+query PrCheckContextsPageInternal($prId: ID!, $after: String!) {
+  node(id: $prId) {
+    __typename
+    ... on PullRequest {
+      statusCheckRollup {
+        contexts(first: 100, after: $after) {
+          nodes {
+            __typename
+            ... on CheckRun {
+              status
+              conclusion
+            }
+            ... on StatusContext {
+              state
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/gh/queries/pr_check_contexts_page.rs
+++ b/src/gh/queries/pr_check_contexts_page.rs
@@ -1,0 +1,62 @@
+use super::CiCounts;
+
+#[derive(graphql_client::GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gh/github.graphql",
+    query_path = "src/gh/queries/pr_check_contexts_page.gql"
+)]
+pub struct PrCheckContextsPageInternal;
+
+pub use pr_check_contexts_page_internal::{
+    ResponseData as PrCheckContextsPageResponseData, Variables as PrCheckContextsPageVariables,
+};
+
+/// Count the contexts in one follow-up page and return the next cursor when
+/// more pages exist. Mirrors the first-page counting in
+/// [`super::prs_with_ci_status`].
+#[must_use]
+pub fn count_contexts_page(data: PrCheckContextsPageResponseData) -> (CiCounts, Option<String>) {
+    use pr_check_contexts_page_internal::{
+        CheckConclusionState, CheckStatusState, PrCheckContextsPageInternalNode as Node,
+        PrCheckContextsPageInternalNodeOnPullRequestStatusCheckRollupContextsNodes as CtxNode,
+        StatusState,
+    };
+    let mut counts = CiCounts::default();
+    let Some(Node::PullRequest(pr)) = data.node else {
+        return (counts, None);
+    };
+    let Some(rollup) = pr.status_check_rollup else {
+        return (counts, None);
+    };
+    if let Some(nodes) = rollup.contexts.nodes.as_ref() {
+        for node in nodes.iter().flatten() {
+            match node {
+                CtxNode::CheckRun(check) => match check.status {
+                    CheckStatusState::COMPLETED => match &check.conclusion {
+                        Some(
+                            CheckConclusionState::SUCCESS
+                            | CheckConclusionState::NEUTRAL
+                            | CheckConclusionState::SKIPPED,
+                        ) => counts.passed += 1,
+                        Some(_) => counts.failed += 1,
+                        None => counts.pending += 1,
+                    },
+                    _ => counts.pending += 1,
+                },
+                CtxNode::StatusContext(status) => match status.state {
+                    StatusState::SUCCESS => counts.passed += 1,
+                    StatusState::ERROR | StatusState::FAILURE => counts.failed += 1,
+                    StatusState::EXPECTED | StatusState::PENDING => counts.pending += 1,
+                    StatusState::Other(_) => {}
+                },
+            }
+        }
+    }
+    let next_after = rollup
+        .contexts
+        .page_info
+        .has_next_page
+        .then(|| rollup.contexts.page_info.end_cursor.clone())
+        .flatten();
+    (counts, next_after)
+}

--- a/src/gh/queries/prs_with_ci_status.gql
+++ b/src/gh/queries/prs_with_ci_status.gql
@@ -17,6 +17,22 @@ query PrsWithCiStatusInternal($query: String!) {
         }
         statusCheckRollup {
           state
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun {
+                status
+                conclusion
+              }
+              ... on StatusContext {
+                state
+              }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
         }
       }
     }

--- a/src/gh/queries/prs_with_ci_status.rs
+++ b/src/gh/queries/prs_with_ci_status.rs
@@ -1,5 +1,6 @@
 use crate::logging::ResultExt;
 use anyhow::Context;
+use std::ops::AddAssign;
 
 // required to satisfy GraphQL interfaces for the `PullRequest` type
 type GitObjectID = String;
@@ -31,6 +32,39 @@ pub enum CiStatus {
     None,
 }
 
+/// Per-bucket check counts for a PR's status check rollup. Computed from the
+/// individual `CheckRun` / `StatusContext` entries inside `statusCheckRollup`,
+/// since the API does not expose them aggregated.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CiCounts {
+    /// Checks that are queued, in progress, expected, or otherwise not yet
+    /// concluded.
+    pub pending: u32,
+    /// Checks that finished with a non-success conclusion (failure, error,
+    /// cancelled, timed out, action required, startup failure).
+    pub failed: u32,
+    /// Checks that finished with a success-equivalent conclusion (success,
+    /// neutral, skipped).
+    pub passed: u32,
+}
+
+impl CiCounts {
+    /// Total number of checks in the rollup. Zero means there are no contexts
+    /// (no CI configured).
+    #[must_use]
+    pub fn total(self) -> u32 {
+        self.pending + self.failed + self.passed
+    }
+}
+
+impl AddAssign for CiCounts {
+    fn add_assign(&mut self, rhs: Self) {
+        self.pending += rhs.pending;
+        self.failed += rhs.failed;
+        self.passed += rhs.passed;
+    }
+}
+
 impl From<Option<prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequestStatusCheckRollup>>
     for CiStatus
 {
@@ -50,6 +84,48 @@ impl From<Option<prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodes
     }
 }
 
+fn count_first_page(
+    rollup: &prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequestStatusCheckRollup,
+) -> (CiCounts, Option<String>) {
+    use prs_with_ci_status_internal::{
+        CheckConclusionState, CheckStatusState,
+        PrsWithCiStatusInternalSearchNodesOnPullRequestStatusCheckRollupContextsNodes as Node,
+        StatusState,
+    };
+    let mut counts = CiCounts::default();
+    if let Some(nodes) = rollup.contexts.nodes.as_ref() {
+        for node in nodes.iter().flatten() {
+            match node {
+                Node::CheckRun(check) => match check.status {
+                    CheckStatusState::COMPLETED => match &check.conclusion {
+                        Some(
+                            CheckConclusionState::SUCCESS
+                            | CheckConclusionState::NEUTRAL
+                            | CheckConclusionState::SKIPPED,
+                        ) => counts.passed += 1,
+                        Some(_) => counts.failed += 1,
+                        None => counts.pending += 1,
+                    },
+                    _ => counts.pending += 1,
+                },
+                Node::StatusContext(status) => match status.state {
+                    StatusState::SUCCESS => counts.passed += 1,
+                    StatusState::ERROR | StatusState::FAILURE => counts.failed += 1,
+                    StatusState::EXPECTED | StatusState::PENDING => counts.pending += 1,
+                    StatusState::Other(_) => {}
+                },
+            }
+        }
+    }
+    let next_after = rollup
+        .contexts
+        .page_info
+        .has_next_page
+        .then(|| rollup.contexts.page_info.end_cursor.clone())
+        .flatten();
+    (counts, next_after)
+}
+
 /// Open PR with CI status and head commit SHA. Used by `jj-gh pr log` to map
 /// jj revisions to their PR metadata.
 #[derive(Debug)]
@@ -61,8 +137,6 @@ pub struct PrWithCiStatus {
     pub number: u64,
     /// PR URL.
     pub url: String,
-    /// PR title.
-    pub title: String,
     /// Name of the branch the PR is opened from (the head ref). Used to map
     /// the PR onto the local bookmark with the same name, so the badge
     /// renders on the local commit even when it has diverged from the remote
@@ -81,39 +155,61 @@ pub struct PrWithCiStatus {
     pub is_in_merge_queue: bool,
     /// Rolled-up CI status across all required checks.
     pub ci_status: CiStatus,
+    /// Per-bucket counts of individual check runs and status contexts.
+    /// Empty (all zero) when there are no contexts.
+    pub ci_counts: CiCounts,
     /// Whether auto-merge enabled for this PR
     pub auto_merge_enabled: bool,
 }
 
-impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
-    fn from(value: prs_with_ci_status_internal::ResponseData) -> Self {
-        let Some(nodes) = value.search.nodes else {
-            return vec![];
-        };
-        nodes
-            .into_iter()
-            .filter_map(|n| match n {
-                Some(
-                    prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodes::PullRequest(
-                        pr,
-                    ),
-                ) => Some(pr),
-                _ => None,
-            })
-            .map(
-                |prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequest {
-                     id,
-                     number,
-                     url,
-                     title,
-                     head_ref_name,
-                     head_ref_oid,
-                     is_draft,
-                     merged,
-                     is_in_merge_queue,
-                     status_check_rollup,
-                     auto_merge_request,
-                 }| PrWithCiStatus {
+/// One PR's first page of results, plus a cursor for additional context pages
+/// when the PR has more than 100 checks (GitHub's max `first:` value).
+/// Callers are expected to follow the cursor and accumulate the extra counts
+/// onto [`PrWithCiStatus::ci_counts`].
+#[derive(Debug)]
+pub struct PrPartial {
+    pub pr: PrWithCiStatus,
+    /// `Some(cursor)` when more context pages exist; pass it to the
+    /// `pr_check_contexts_page` query as `after:`. `None` when all contexts
+    /// fit in the first page.
+    pub next_after: Option<String>,
+}
+
+/// Extract per-PR partial state from the search response. Use this instead of
+/// converting straight into `Vec<PrWithCiStatus>` so the caller can follow
+/// any context-page cursors.
+#[must_use]
+pub fn extract_pr_partials(data: prs_with_ci_status_internal::ResponseData) -> Vec<PrPartial> {
+    let Some(nodes) = data.search.nodes else {
+        return vec![];
+    };
+    nodes
+        .into_iter()
+        .filter_map(|n| match n {
+            Some(prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodes::PullRequest(
+                pr,
+            )) => Some(pr),
+            _ => None,
+        })
+        .map(
+            |prs_with_ci_status_internal::PrsWithCiStatusInternalSearchNodesOnPullRequest {
+                 id,
+                 number,
+                 url,
+                 title: _,
+                 head_ref_name,
+                 head_ref_oid,
+                 is_draft,
+                 merged,
+                 is_in_merge_queue,
+                 status_check_rollup,
+                 auto_merge_request,
+             }| {
+                let (ci_counts, next_after) = status_check_rollup
+                    .as_ref()
+                    .map(count_first_page)
+                    .unwrap_or_default();
+                let pr = PrWithCiStatus {
                     id,
                     // PR numbers will always fit in a u64, this is fine.
                     number: number
@@ -122,16 +218,17 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                         .log_err()
                         .unwrap(),
                     url,
-                    title,
-                    merged,
                     is_draft,
+                    merged,
                     is_in_merge_queue,
                     head_ref_name,
                     head_sha: head_ref_oid,
                     ci_status: status_check_rollup.into(),
+                    ci_counts,
                     auto_merge_enabled: auto_merge_request.is_some_and(|r| r.enabled_at.is_some()),
-                },
-            )
-            .collect()
-    }
+                };
+                PrPartial { pr, next_after }
+            },
+        )
+        .collect()
 }

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -15,16 +15,18 @@ use crate::{
         FindOpenPrVariables, GetPrInternal, GetPrInternalRepositoryPullRequest, GetPrResponseData,
         GetPrVariables, LookupBaseInternal, LookupBaseResponseData, LookupBaseVariables,
         MarkReadyForReviewInternal, MarkReadyForReviewResponseData, MarkReadyForReviewVariables,
+        PrCheckContextsPageInternal, PrCheckContextsPageResponseData, PrCheckContextsPageVariables,
         PrWithCiStatus, PrsWithCiStatusInternal, PrsWithCiStatusResponseData,
         PrsWithCiStatusVariables, PullRequestMergeMethod, PullRequestState, RemoveLabelsInternal,
         RemoveLabelsResponseData, RemoveLabelsVariables, RequestedReviewer, UpdatePrInternal,
-        UpdatePrResponseData, UpdatePrVariables,
+        UpdatePrResponseData, UpdatePrVariables, count_contexts_page, extract_pr_partials,
     },
 };
 use anyhow::{Context, Result, anyhow};
 use graphql_client::GraphQLQuery;
 use octocrab::Octocrab;
 use secrecy::{ExposeSecret, SecretString};
+use std::collections::HashMap;
 
 /// Production [`Gh`] impl wrapping an authenticated `octocrab` client.
 pub struct OctocrabGh {
@@ -455,26 +457,90 @@ impl Gh for OctocrabGh {
 
         let mut out: Vec<PrWithCiStatus> = Vec::new();
         let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        let mut pending_followups: Vec<(String, String)> = Vec::new();
         for search_query in build_search_queries(owner, repo, branches) {
             let vars = PrsWithCiStatusVariables {
                 query: search_query,
             };
             let body = PrsWithCiStatusInternal::build_query(vars);
-            let batch: Vec<PrWithCiStatus> = self
+            let response = self
                 .octo
                 .graphql::<PrsWithCiStatusResponseData>(&body)
                 .await
                 .map_err(humanize)
-                .context("fetching local PRs")?
-                .into();
-            for pr in batch {
-                if seen.insert(pr.number) {
-                    out.push(pr);
+                .context("fetching local PRs")?;
+            for partial in extract_pr_partials(response) {
+                if !seen.insert(partial.pr.number) {
+                    continue;
+                }
+                if let Some(cursor) = partial.next_after {
+                    pending_followups.push((partial.pr.id.clone(), cursor));
+                }
+                out.push(partial.pr);
+            }
+        }
+
+        if !pending_followups.is_empty() {
+            let extra = fetch_remaining_contexts(&self.octo, owner, repo, pending_followups)
+                .await
+                .context("paginating PR check contexts")?;
+            let index_by_id: HashMap<String, usize> = out
+                .iter()
+                .enumerate()
+                .map(|(i, pr)| (pr.id.clone(), i))
+                .collect();
+            for (pr_id, counts) in extra {
+                if let Some(&i) = index_by_id.get(&pr_id) {
+                    out[i].ci_counts += counts;
                 }
             }
         }
         Ok(out)
     }
+}
+
+/// Follow each PR's context-page cursor to exhaustion, in parallel via
+/// `JoinSet`. Returns `(pr_node_id, extra_counts)` for every PR that had
+/// more than one page of contexts.
+async fn fetch_remaining_contexts(
+    octo: &Octocrab,
+    owner: &str,
+    repo: &str,
+    cursors: Vec<(String, String)>,
+) -> Result<Vec<(String, super::CiCounts)>> {
+    let mut set = tokio::task::JoinSet::new();
+    for (pr_id, first_cursor) in cursors {
+        let octo = octo.clone();
+        let owner = owner.to_string();
+        let repo = repo.to_string();
+        set.spawn(async move {
+            let mut total = super::CiCounts::default();
+            let mut cursor = Some(first_cursor);
+            while let Some(after) = cursor.take() {
+                let vars = PrCheckContextsPageVariables {
+                    after,
+                    pr_id: pr_id.clone(),
+                };
+                let body = PrCheckContextsPageInternal::build_query(vars);
+                let response = octo
+                    .graphql::<PrCheckContextsPageResponseData>(&body)
+                    .await
+                    .map_err(humanize)
+                    .with_context(|| {
+                        format!("fetching contexts page for {owner}/{repo} pr {pr_id}")
+                    })?;
+                let (counts, next) = count_contexts_page(response);
+                total += counts;
+                cursor = next;
+            }
+            Ok::<_, anyhow::Error>((pr_id, total))
+        });
+    }
+    let mut out = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        out.push(joined.context("contexts pagination task panicked")??);
+    }
+    Ok(out)
 }
 
 /// Split reviewers into `(user_logins, team_names)` as the REST review-request

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -210,6 +210,10 @@ impl Jj for JjCli {
         // `normal_target.commit_id()` is the local commit (which may diverge
         // from the remote target, e.g. local rebase without push).
         //
+        // `-r '~trunk()'` restricts to bookmarks whose target is not the
+        // trunk commit, so callers (e.g. `pr log`) never burn a GitHub PR
+        // search slot on `main`/`master`.
+        //
         // Emit NDJSON: one `PushedBookmark` per line, parsed via serde so
         // bookmark names with unusual characters round-trip safely.
         let record = json_object_template(&[
@@ -223,6 +227,8 @@ impl Jj for JjCli {
             "--tracked",
             "--remote",
             remote,
+            "-r",
+            "~trunk()",
             "-T",
             &template,
         ])

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -11,12 +11,13 @@
 
 use crate::{
     config::Config,
-    gh::{CiStatus, Gh, PrWithCiStatus},
+    gh::{CiCounts, CiStatus, Gh, PrWithCiStatus},
     git,
     jj::{
         Jj,
         inject::{TemplateAliases, escape_jj_string},
     },
+    ui::Spinner,
 };
 use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
@@ -30,6 +31,7 @@ const COLOR_CI_SUCCESS: &str = "gh-ci-success";
 const COLOR_CI_FAILED: &str = "gh-ci-failed";
 const COLOR_CI_PENDING: &str = "gh-ci-pending";
 const COLOR_PR_MERGE_STATUS: &str = "gh-pr-merge-status";
+const COLOR_PR_DRAFT: &str = "gh-pr-draft";
 
 /// Default `pr_log` template applied when the user did not pass their own
 /// `-T` / `--template`. References the `pr_meta` alias so spacing only appears
@@ -69,6 +71,10 @@ pub struct PrLogArgs {
     ///   PR.
     /// - `pr_url`: PR URL, or empty.
     /// - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty.
+    /// - `pr_ci_breakdown`: per-bucket counts `(● P / ✗ F / ✓ S)` with
+    ///   labeled colors, or empty when the PR has no CI contexts.
+    /// - `pr_draft_status`: a colored "draft" label (with a nerdfont icon
+    ///   when enabled), or empty when the PR is not a draft.
     /// - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or
     ///   empty.
     /// - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon
@@ -107,7 +113,13 @@ pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) 
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))
         .collect();
     let names = bookmarks.into_iter().map(|b| b.name).collect::<Vec<_>>();
-    let prs = gh.local_pulls(&owner, &repo, &names).await?;
+    let spinner = Spinner::start(format!(
+        "resolving PRs for {} local bookmark(s)",
+        names.len()
+    ));
+    let prs_result = gh.local_pulls(&owner, &repo, &names).await;
+    spinner.stop().await;
+    let prs = prs_result?;
 
     let aliases = build_aliases(&prs, &branch_to_local, config);
     let tmp = aliases.write_temp_config()?;
@@ -161,6 +173,12 @@ fn build_aliases(
     let status = if_chain_alias(prs, branch_to_local, |pr| {
         format!(r#""{}""#, ci_status_str(pr.ci_status))
     });
+    let breakdown = if_chain_alias(prs, branch_to_local, |pr| {
+        ci_breakdown_body(pr.ci_counts).unwrap_or_else(|| r#""""#.to_string())
+    });
+    let draft_status = if_chain_alias(prs, branch_to_local, |pr| {
+        draft_status_body(pr, config).unwrap_or_else(|| r#""""#.to_string())
+    });
     let merge_status = if_chain_alias(prs, branch_to_local, |pr| {
         format!(r#""{}""#, merge_status(pr, config).unwrap_or_default())
     });
@@ -170,6 +188,8 @@ fn build_aliases(
         .alias("pr_number", number)
         .alias("pr_url", url)
         .alias("pr_ci_status", status)
+        .alias("pr_ci_breakdown", breakdown)
+        .alias("pr_draft_status", draft_status)
         .alias("pr_meta", meta)
         .alias("pr_merge_status", merge_status)
         .alias("pr_log", PR_LOG_TEMPLATE)
@@ -177,6 +197,7 @@ fn build_aliases(
         .color(COLOR_CI_FAILED, "red")
         .color(COLOR_CI_PENDING, "yellow")
         .color(COLOR_PR_MERGE_STATUS, "bright black")
+        .color(COLOR_PR_DRAFT, "bright black")
 }
 
 /// Render the body of a single `pr_meta` if-chain arm: the full template
@@ -189,8 +210,14 @@ fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
         n = pr.number
     );
 
-    template = match ci_status_icon_label(pr) {
-        Some(icon) => format!(r#"{template} ++ " " ++ {icon}"#),
+    template = match draft_status_body(pr, config) {
+        Some(frag) => format!(r#"{template} ++ " " ++ {frag}"#),
+        None => template,
+    };
+
+    let ci_fragment = ci_breakdown_body(pr.ci_counts).or_else(|| ci_status_icon_label(pr));
+    template = match ci_fragment {
+        Some(frag) => format!(r#"{template} ++ " " ++ {frag}"#),
         None => template,
     };
 
@@ -227,6 +254,17 @@ fn merge_status(pr: &PrWithCiStatus, config: &Config) -> Option<String> {
     }
 }
 
+/// Render the per-PR draft indicator: a pencil nerdfont icon (when enabled)
+/// plus a `draft` label, colored. Returns `None` when the PR is not a draft
+/// so the template emits nothing.
+fn draft_status_body(pr: &PrWithCiStatus, config: &Config) -> Option<String> {
+    if !pr.is_draft {
+        return None;
+    }
+    let icon = if config.nerdfonts { " " } else { "" };
+    Some(format!(r#"label("{COLOR_PR_DRAFT}", "{icon}draft")"#))
+}
+
 fn ci_status_icon_label(pr: &PrWithCiStatus) -> Option<String> {
     Some(match pr.ci_status {
         CiStatus::Success => format!(r#"label("{COLOR_CI_SUCCESS}", "✓")"#),
@@ -234,6 +272,38 @@ fn ci_status_icon_label(pr: &PrWithCiStatus) -> Option<String> {
         CiStatus::Pending => format!(r#"label("{COLOR_CI_PENDING}", "●")"#),
         CiStatus::None => return None,
     })
+}
+
+/// Per-bucket counts fragment `(● P / ✗ F / ✓ S)` with colored labels.
+/// Returns `None` when the PR has no contexts (matches `ci_status_icon_label`'s
+/// `CiStatus::None` behavior, so the default template renders nothing).
+///
+/// `pending` and `failed` chunks are omitted when their count is `0`; the
+/// `passed` chunk is always shown (it carries the "this PR has CI configured"
+/// signal even when nothing has failed). Separators are emitted only between
+/// visible chunks so a passing PR renders cleanly as `(✓ 27)`.
+fn ci_breakdown_body(counts: CiCounts) -> Option<String> {
+    if counts.total() == 0 {
+        return None;
+    }
+    let CiCounts {
+        pending,
+        failed,
+        passed,
+    } = counts;
+    let sep = format!(r#"label("{COLOR_PR_MERGE_STATUS}", " / ")"#);
+    let mut chunks = Vec::new();
+    if pending > 0 {
+        chunks.push(format!(r#"label("{COLOR_CI_PENDING}", "● {pending}")"#));
+    }
+    if failed > 0 {
+        chunks.push(format!(r#"label("{COLOR_CI_FAILED}", "✗ {failed}")"#));
+    }
+    chunks.push(format!(r#"label("{COLOR_CI_SUCCESS}", "✓ {passed}")"#));
+    let inner = chunks.join(&format!(" ++ {sep} ++ "));
+    Some(format!(
+        r#"label("{COLOR_PR_MERGE_STATUS}", "(") ++ {inner} ++ label("{COLOR_PR_MERGE_STATUS}", ")")"#
+    ))
 }
 
 /// Build a nested `if(commit_id.short(40) == "<sha>", <body>, ...)` chain that
@@ -285,12 +355,12 @@ mod tests {
             id: format!("ID{number}"),
             number,
             url: format!("https://github.com/o/r/pull/{number}"),
-            title: format!("PR {number}"),
             head_ref_name: format!("branch-{number}"),
             head_sha: sha.into(),
             is_draft: false,
             is_in_merge_queue: false,
             ci_status: status,
+            ci_counts: CiCounts::default(),
             merged: false,
             auto_merge_enabled: false,
         }
@@ -306,11 +376,11 @@ mod tests {
             id: format!("ID{number}"),
             number,
             url: format!("https://github.com/o/r/pull/{number}"),
-            title: format!("PR {number}"),
             head_ref_name: format!("branch-{number}"),
             head_sha: number.to_string(),
             is_draft: false,
             ci_status: CiStatus::Success,
+            ci_counts: CiCounts::default(),
             auto_merge_enabled,
             is_in_merge_queue,
             merged,
@@ -445,6 +515,194 @@ mod tests {
         let map = local_map_from(&prs);
         let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
         assert!(cfg.contains("󰾨 auto-merge enabled"));
+    }
+
+    fn pr_with_counts(sha: &str, number: u64, counts: CiCounts) -> PrWithCiStatus {
+        let mut p = pr(sha, number, CiStatus::Pending);
+        p.ci_counts = counts;
+        p
+    }
+
+    #[test]
+    fn breakdown_body_none_when_no_contexts() {
+        assert!(ci_breakdown_body(CiCounts::default()).is_none());
+    }
+
+    #[test]
+    fn breakdown_body_renders_counts_with_color_labels() {
+        let body = ci_breakdown_body(CiCounts {
+            pending: 7,
+            failed: 3,
+            passed: 27,
+        })
+        .unwrap();
+        assert!(body.contains(r#"label("gh-ci-pending", "● 7")"#), "{body}");
+        assert!(body.contains(r#"label("gh-ci-failed", "✗ 3")"#), "{body}");
+        assert!(body.contains(r#"label("gh-ci-success", "✓ 27")"#), "{body}");
+        assert!(
+            body.contains(r#"label("gh-pr-merge-status", "(")"#),
+            "{body}"
+        );
+        assert!(
+            body.contains(r#"label("gh-pr-merge-status", ")")"#),
+            "{body}"
+        );
+    }
+
+    #[test]
+    fn config_includes_pr_ci_breakdown_alias_with_counts() {
+        let prs = vec![pr_with_counts(
+            &"a".repeat(40),
+            42,
+            CiCounts {
+                pending: 1,
+                failed: 2,
+                passed: 5,
+            },
+        )];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        assert!(cfg.contains("pr_ci_breakdown"), "{cfg}");
+        assert!(cfg.contains(r#""● 1""#), "{cfg}");
+        assert!(cfg.contains(r#""✗ 2""#), "{cfg}");
+        assert!(cfg.contains(r#""✓ 5""#), "{cfg}");
+    }
+
+    #[test]
+    fn breakdown_body_hides_zero_pending_and_failed_chunks() {
+        // Only `passed` is non-zero -> just `(✓ 27)`, no separators, no
+        // pending/failed chunks.
+        let body = ci_breakdown_body(CiCounts {
+            pending: 0,
+            failed: 0,
+            passed: 27,
+        })
+        .unwrap();
+        assert!(body.contains(r#"label("gh-ci-success", "✓ 27")"#), "{body}");
+        assert!(!body.contains("● 0"), "{body}");
+        assert!(!body.contains("✗ 0"), "{body}");
+        assert!(!body.contains(" / "), "{body}");
+    }
+
+    #[test]
+    fn breakdown_body_keeps_separator_only_between_visible_chunks() {
+        // pending=0 hides the pending chunk and its separator: `(✗ 3 / ✓ 27)`.
+        let body = ci_breakdown_body(CiCounts {
+            pending: 0,
+            failed: 3,
+            passed: 27,
+        })
+        .unwrap();
+        assert!(!body.contains("● 0"), "{body}");
+        assert!(body.contains(r#"label("gh-ci-failed", "✗ 3")"#), "{body}");
+        assert!(body.contains(r#"label("gh-ci-success", "✓ 27")"#), "{body}");
+        // Exactly one separator between the two visible chunks.
+        assert_eq!(
+            body.matches(r#"label("gh-pr-merge-status", " / ")"#)
+                .count(),
+            1,
+            "{body}"
+        );
+    }
+
+    #[test]
+    fn pr_meta_uses_breakdown_when_counts_present() {
+        let prs = vec![pr_with_counts(
+            &"b".repeat(40),
+            1,
+            CiCounts {
+                pending: 0,
+                failed: 1,
+                passed: 4,
+            },
+        )];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        assert!(cfg.contains(r#""✗ 1""#), "{cfg}");
+        assert!(cfg.contains(r#""✓ 4""#), "{cfg}");
+        assert!(!cfg.contains(r#""● 0""#), "{cfg}");
+    }
+
+    #[test]
+    fn pr_meta_falls_back_to_single_icon_when_no_counts() {
+        let prs = vec![pr(&"c".repeat(40), 2, CiStatus::Failed)];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        assert!(cfg.contains(r#"label("gh-ci-failed", "✗")"#), "{cfg}");
+        // No breakdown counts emitted.
+        assert!(!cfg.contains(r#""● 0""#), "{cfg}");
+    }
+
+    #[test]
+    fn draft_status_body_none_when_not_draft() {
+        let p = pr(&"a".repeat(40), 1, CiStatus::Success);
+        assert!(draft_status_body(&p, &Config::default()).is_none());
+    }
+
+    #[test]
+    fn draft_status_body_renders_nerdfont_icon_when_enabled() {
+        let mut p = pr(&"a".repeat(40), 1, CiStatus::Success);
+        p.is_draft = true;
+        let cfg = Config {
+            nerdfonts: true,
+            ..Config::default()
+        };
+        let body = draft_status_body(&p, &cfg).unwrap();
+        assert!(body.contains(""), "{body}");
+        assert!(body.contains("draft"), "{body}");
+        assert!(body.contains(r#"label("gh-pr-draft""#), "{body}");
+    }
+
+    #[test]
+    fn draft_status_body_falls_back_to_plain_label_without_nerdfonts() {
+        let mut p = pr(&"a".repeat(40), 1, CiStatus::Success);
+        p.is_draft = true;
+        let cfg = Config {
+            nerdfonts: false,
+            ..Config::default()
+        };
+        let body = draft_status_body(&p, &cfg).unwrap();
+        assert!(!body.contains(""), "{body}");
+        assert!(body.contains("draft"), "{body}");
+    }
+
+    #[test]
+    fn config_includes_pr_draft_status_alias_for_draft_pr() {
+        let mut p = pr(&"a".repeat(40), 42, CiStatus::Success);
+        p.is_draft = true;
+        let prs = vec![p];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        assert!(cfg.contains("pr_draft_status"), "{cfg}");
+        assert!(cfg.contains("draft"), "{cfg}");
+    }
+
+    #[test]
+    fn pr_meta_includes_draft_label_for_draft_pr() {
+        let mut p = pr(&"a".repeat(40), 1, CiStatus::Success);
+        p.is_draft = true;
+        let prs = vec![p];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        assert!(cfg.contains(r#"label("gh-pr-draft""#), "{cfg}");
+    }
+
+    #[test]
+    fn pr_meta_omits_draft_label_for_non_draft_pr() {
+        let prs = vec![pr(&"a".repeat(40), 1, CiStatus::Success)];
+        let map = local_map_from(&prs);
+        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        // pr_draft_status alias exists but resolves to an empty string for
+        // this PR; check the rendered meta does not include the draft label.
+        // The if-chain for that PR's sha must not embed the draft label call.
+        let sha_arm = format!(r#"commit_id.short(40) == "{}""#, "a".repeat(40));
+        let start = cfg.find(&sha_arm).expect("arm present");
+        // Slice through the next ~400 chars looking for a draft label in this arm.
+        let window: &str = &cfg[start..(start + 800).min(cfg.len())];
+        assert!(
+            !window.contains(r#"label("gh-pr-draft""#),
+            "draft label leaked into non-draft arm: {window}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Changes `jj pr log` to show breakdown of `(pending/failed/succeeded)` CI jobs by default.
