### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.1...jj-gh-v0.2.2) - 2026-06-01
+
+### Fixed
+
+- *(pr)* Fix GraphQL query and vendor schema
+
 ## [0.2.1](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.0...jj-gh-v0.2.1) - 2026-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.2.1"
+version = "0.2.2"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",


### PR DESCRIPTION



## 🤖 New release

* `jj-gh`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.1...jj-gh-v0.2.2) - 2026-06-01

### Fixed

- *(pr)* Fix GraphQL query and vendor schema
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).