### PR TITLE
feat(pr): Add `restack` subcommand to interactively update PR base refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +402,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -478,6 +514,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +556,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2142,8 +2209,10 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "crossterm",
  "figment",
  "flexi_logger",
+ "futures",
  "gix",
  "graphql_client",
  "http",
@@ -2246,6 +2315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3224,6 +3300,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3750,6 +3847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,6 +4055,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,6 +4078,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ anstyle = "1"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+crossterm = "0.29"
+futures = "0.3"
 figment = { version = "0.10", features = ["toml"] }
 flexi_logger = { version = "0.31", default-features = false, features = [
   "colors",

--- a/DOCS.md
+++ b/DOCS.md
@@ -13,6 +13,7 @@ This document contains the help content for the `jj-gh` command-line program.
 - [`jj-gh pr auto-merge`↴](#jj-gh-pr-auto-merge)
 - [`jj-gh pr edit`↴](#jj-gh-pr-edit)
 - [`jj-gh pr log`↴](#jj-gh-pr-log)
+- [`jj-gh pr restack`↴](#jj-gh-pr-restack)
 - [`jj-gh pr retry-failed`↴](#jj-gh-pr-retry-failed)
 - [`jj-gh debug`↴](#jj-gh-debug)
 - [`jj-gh debug config`↴](#jj-gh-debug-config)
@@ -56,6 +57,7 @@ Commands to work with PRs
 - `auto-merge` — Enable auto-merge on a PR
 - `edit` — Edit an existing PR's title, body, base, labels, reviewers, draft state, and auto-merge settings via the markdown frontmatter editor flow
 - `log` — Like `jj log`, but injects PR metadata (e.g. number, CI status, URL)
+- `restack` — Push the current `jj` stack shape up to GitHub by updating each PR's base branch to match its closest stacked ancestor bookmark
 - `retry-failed` — Re-run failed CI jobs on a PR
 
 ## `jj-gh pr create`
@@ -181,6 +183,26 @@ The following template aliases are available for use if you pass your own templa
 
 - `--nerdfonts <NERDFONTS>` — Force enable the use of nerdfont icons in the default `pr log` template. Overrides config. Use `--no-nerdfonts` to disable
 - `--no-nerdfonts` — Force the default `pr log` template not to use nerdfont icons. Overrides config
+
+## `jj-gh pr restack`
+
+Push the current `jj` stack shape up to GitHub by updating each PR's base branch to match its closest stacked ancestor bookmark.
+
+Restack does not rewrite the jj graph; the user shapes the graph first (e.g. via `jj rebase`) and then runs `jj-gh pr restack` to set each PR's `baseRefName` on the remote. Launches an interactive TUI by default. Pass `--dry-run` or `--json` to print the proposed plan without making any API calls.
+
+**Usage:** `jj-gh pr restack [OPTIONS] [PR_NUM|REV]`
+
+**Command Alias:** `rs`
+
+###### **Arguments:**
+
+- `<PR_NUM|REV>` — PR number or revision ID to position the cursor on when the TUI opens; if omitted the cursor starts on the first PR in the stack
+
+###### **Options:**
+
+- `--dry-run` — Print the proposed plan and exit without launching the TUI. No PR is updated. Auto-enabled when stdout is not a terminal
+- `--json` — Emit the proposed plan as JSON. Implies `--dry-run`
+- `-T`, `--template <TEMPLATE>` — Template to use in interactive mode; conflicts with `--json` and `--dry-run`
 
 ## `jj-gh pr retry-failed`
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Enable auto-merge for a PR by its revision ID, without having to know/find its PR number (e.g. `jj pr auto-merge zqxy`)
 - Create local bookmarks for PRs, including across forks (e.g. `jj pr fetch 1234 && jj new pr-1234/...`, useful for testing PRs to OSS repos)
 - Show PR metadata like number and CI status in commit graph (e.g. `jj pr log`)
+- Interactively re-stack PRs (update PR base branch based on local revision graph shape)
 
 all from the comfort of your terminal, without touching GitHub's clunky web UI.
 Works great when combined with the [jj megamerge](https://isaaccorbrey.com/notes/jujutsu-megamerges-for-fun-and-profit) workflow!
@@ -182,6 +183,16 @@ pr_create_template_file = ".github/PULL_REQUEST_TEMPLATE.md"
 # the full list.
 pr_fetch_bookmark_template = '"pr-" ++ pr_number ++ "/" ++ pr_branch'
 
+# default template to use for `jj pr log`, a jj template string.
+# the default template mimics jj's default template with PR metadata
+# added inline.
+pr_log_template = 'format_short_commit_header(self) ++ "#" ++ surround(" ", "", pr_number)'
+
+# default template to be used in interactive `jj pr restack` UI;
+# by default, it re-uses the `jj pr log` template, but may also be customized
+# separately
+pr_restack_template = 'format_short_commit_header(self) ++ "#" ++ surround(" ", "", pr_number)'
+
 # Editor command, shell-words split. Falls back to $VISUAL, then $EDITOR.
 editor = [
   "nvim",
@@ -287,6 +298,10 @@ a matching open PR:
 - `pr_merge_status`: merged / in-merge-queue / auto-merge label.
 - `pr_meta`: pre-formatted hyperlinked PR number, colored CI icon, and merge
   status.
+
+### `pr restack`
+
+Same aliases available as `pr log`. By default, `pr restack` uses the same template as `pr log`.
 
 ## PR body template resolution
 

--- a/flake.nix
+++ b/flake.nix
@@ -256,8 +256,6 @@
                 if ! diff -u rust-fields.txt nix-fields.txt >&2; then
                   echo "" >&2
                   echo "ERROR: jj-gh Config struct fields drifted from hm-module.nix settings options." >&2
-                  echo "  left  = Rust Config field names (tools/print-config-schema)" >&2
-                  echo "  right = nix/hm-module.nix settings options" >&2
                   exit 1
                 fi
                 touch $out

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -134,6 +134,27 @@ in
         '';
       };
 
+      pr_log_template = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = ''description ++ " #" ++ pr_number ++ "\n"'';
+        description = ''
+          jj template string used to render the `pr log` subcommand. Template aliases
+          for PR metadata are injected. See https://github.com/mrjones2014/jj-gh#template-aliases
+        '';
+      };
+
+      pr_restack_template = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = ''description ++ " #" ++ pr_number ++ "\n"'';
+        description = ''
+          jj template string used to render the `pr restack` subcommand.
+          By default, uses `pr_log_template`. Template aliases
+          for PR metadata are injected. See https://github.com/mrjones2014/jj-gh#template-aliases
+        '';
+      };
+
       draft = mkOption {
         type = types.nullOr types.bool;
         default = null;

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,8 @@ pub struct Config {
     pub auto_merge_method: AutoMergeMethod,
     pub editor: Option<Vec<String>>,
     pub pr_fetch_bookmark_template: Option<String>,
+    pub pr_log_template: Option<String>,
+    pub pr_restack_template: Option<String>,
     pub nerdfonts: bool,
 }
 
@@ -65,6 +67,8 @@ impl Default for Config {
             auto_merge_method: AutoMergeMethod::default(),
             editor: None,
             pr_fetch_bookmark_template: None,
+            pr_log_template: None,
+            pr_restack_template: None,
             nerdfonts: true,
         }
     }
@@ -328,6 +332,8 @@ impl DefaultsOverlay {
             gh_askpass: _,
             gh_token: _,
             pr_fetch_bookmark_template: _,
+            pr_log_template: _,
+            pr_restack_template: _,
             pr_create_template: _,
             pr_create_template_file: _,
         } = Config::default();

--- a/src/gh/queries/prs_with_ci_status.gql
+++ b/src/gh/queries/prs_with_ci_status.gql
@@ -9,6 +9,7 @@ query PrsWithCiStatusInternal($query: String!) {
         title
         headRefName
         headRefOid
+        baseRefName
         isDraft
         merged
         isInMergeQueue

--- a/src/gh/queries/prs_with_ci_status.rs
+++ b/src/gh/queries/prs_with_ci_status.rs
@@ -73,6 +73,10 @@ pub struct PrWithCiStatus {
     /// from the remote PR head (e.g. if you rebase the PR on `trunk()` but have
     /// not pushed it to the remote yet).
     pub head_sha: String,
+    /// Name of the branch the PR is currently targeted at on the remote.
+    /// Used by `pr restack` to detect which PRs already point at the proposed
+    /// base.
+    pub base_ref_name: String,
     /// Whether the PR is a draft.
     pub is_draft: bool,
     /// Whether the PR is merged
@@ -108,6 +112,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                      title,
                      head_ref_name,
                      head_ref_oid,
+                     base_ref_name,
                      is_draft,
                      merged,
                      is_in_merge_queue,
@@ -128,6 +133,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                     is_in_merge_queue,
                     head_ref_name,
                     head_sha: head_ref_oid,
+                    base_ref_name,
                     ci_status: status_check_rollup.into(),
                     auto_merge_enabled: auto_merge_request.is_some_and(|r| r.enabled_at.is_some()),
                 },

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -216,7 +216,11 @@ impl Jj for JjCli {
             ("name", "name"),
             ("local_commit_id", "normal_target.commit_id()"),
         ]);
-        let template = format!(r#"if(remote, "", {record} ++ "\n")"#);
+        // Skip the remote-side row, and skip local rows whose normal_target
+        // is missing (e.g. the remote bookmark was deleted); calling
+        // `commit_id()` on an absent target leaks jj's
+        // `<Error: No Commit available>` literal into the JSON stream.
+        let template = format!(r#"if(remote, "", if(normal_target, {record} ++ "\n", ""))"#);
         let stdout = run_jj(&[
             "bookmark",
             "list",

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -5,6 +5,7 @@ mod editor;
 pub mod fetch;
 mod frontmatter;
 mod pr_log;
+mod restack;
 mod retry_failed;
 mod template;
 mod validation;
@@ -25,6 +26,7 @@ use crate::{
         editor::{TempfileEditor, edit::EditArgs},
         fetch::FetchArgs,
         pr_log::PrLogArgs,
+        restack::RestackArgs,
         retry_failed::RetryFailedArgs,
         template::TemplateSource,
     },
@@ -85,6 +87,17 @@ pub enum PrAction {
     #[command(visible_alias = "l")]
     Log(PrLogArgs),
 
+    /// Push the current `jj` stack shape up to GitHub by updating each PR's
+    /// base branch to match its closest stacked ancestor bookmark.
+    ///
+    /// Restack does not rewrite the jj graph; the user shapes the graph first
+    /// (e.g. via `jj rebase`) and then runs `jj-gh pr restack` to set each
+    /// PR's `baseRefName` on the remote. Launches an interactive TUI by
+    /// default. Pass `--dry-run` or `--json` to print the proposed plan
+    /// without making any API calls.
+    #[command(visible_alias = "rs")]
+    Restack(RestackArgs),
+
     /// Re-run failed CI jobs on a PR.
     ///
     /// Resolves the PR from a revision (via its local bookmark) or PR number,
@@ -113,6 +126,7 @@ pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
         PrAction::AutoMerge(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Edit(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Log(a) => fig.merge(Serialized::defaults(a)),
+        PrAction::Restack(a) => fig.merge(Serialized::defaults(a)),
         PrAction::RetryFailed(a) => fig.merge(Serialized::defaults(a)),
     };
     let config = config::extract(&fig)?;
@@ -134,6 +148,7 @@ pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
             editor::edit::run(&jj, &gh, &OsEnv, &editor, &config, &args).await?;
         }
         PrAction::Log(args) => pr_log::run(&args, &config, &gh, &jj).await?,
+        PrAction::Restack(args) => restack::run(&jj, &gh, &config, &args).await?,
         PrAction::RetryFailed(args) => retry_failed::run(&jj, &gh, &config, &args).await?,
     }
     Ok(())

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -33,9 +33,10 @@ const COLOR_CI_PENDING: &str = "gh-ci-pending";
 const COLOR_PR_MERGE_STATUS: &str = "gh-pr-merge-status";
 
 /// Default `pr_log` template applied when the user did not pass their own
-/// `-T` / `--template`. References the `pr_meta` alias so spacing only appears
-/// for commits that actually have a PR.
-const PR_LOG_TEMPLATE: &str = r#"
+/// `-T` / `--template` and no `pr_log_template` config override is set.
+/// References the `pr_meta` alias so spacing only appears for commits that
+/// actually have a PR.
+pub(crate) const PR_LOG_TEMPLATE: &str = r#"
 if(root,
   format_root_commit(self),
   label(
@@ -152,7 +153,7 @@ fn user_set_template(args: &[String]) -> bool {
 /// `pr_number`, `pr_url`, and `pr_ci_status` as raw `String` aliases for
 /// users who want to build custom templates; they work in direct contexts
 /// even if they cannot be re-chained through `if()`.
-fn build_aliases(
+pub(crate) fn build_aliases(
     prs: &[PrWithCiStatus],
     branch_to_local: &HashMap<String, String>,
     config: &Config,
@@ -169,13 +170,14 @@ fn build_aliases(
     });
     let meta = if_chain_alias(prs, branch_to_local, |pr| render_pr_meta_body(pr, config));
 
+    let pr_log_body = config.pr_log_template.as_deref().unwrap_or(PR_LOG_TEMPLATE);
     TemplateAliases::builder()
         .alias("pr_number", number)
         .alias("pr_url", url)
         .alias("pr_ci_status", status)
         .alias("pr_meta", meta)
         .alias("pr_merge_status", merge_status)
-        .alias("pr_log", PR_LOG_TEMPLATE)
+        .alias("pr_log", pr_log_body)
         .color(COLOR_CI_SUCCESS, "green")
         .color(COLOR_CI_FAILED, "red")
         .color(COLOR_CI_PENDING, "yellow")
@@ -291,6 +293,7 @@ mod tests {
             title: format!("PR {number}"),
             head_ref_name: format!("branch-{number}"),
             head_sha: sha.into(),
+            base_ref_name: "master".into(),
             is_draft: false,
             is_in_merge_queue: false,
             ci_status: status,
@@ -312,6 +315,7 @@ mod tests {
             title: format!("PR {number}"),
             head_ref_name: format!("branch-{number}"),
             head_sha: number.to_string(),
+            base_ref_name: "master".into(),
             is_draft: false,
             ci_status: CiStatus::Success,
             auto_merge_enabled,

--- a/src/pr/restack/interactive.rs
+++ b/src/pr/restack/interactive.rs
@@ -1,0 +1,1048 @@
+//! Crossterm-based TUI for `jj-gh pr restack`.
+//!
+//! Layout:
+//!
+//! ```text
+//! +----------------------------------------+
+//! | <scrollable rendered `jj log`>         |
+//! | ...                                    |
+//! +----------------------------------------+
+//! | <pinned keymap bar / inline prompt>    |
+//! +----------------------------------------+
+//! ```
+//!
+//! The log is captured via the user's configured template (either
+//! `pr_restack_template`, `pr_log_template`, or the built-in default) so it
+//! can be freely customized. To highlight which row in the graph belongs to
+//! the focused PR, the user template is wrapped with two invisible Unicode
+//! Private-Use markers (`U+E000` open, `U+E001` close) bracketing the
+//! commit id; the wrapper sits *outside* the user's body so the user can
+//! template anything inside it. After capture we strip the markers from
+//! each line and record the line index → commit id mapping, which drives
+//! reverse-video on the focused PR's commit row.
+//! Nothing is sent to the GitHub API until the user accepts the summary
+//! screen.
+
+use super::{Decision, PrPlan, RestackContext};
+use crate::{
+    config::Config,
+    jj::Jj,
+    pr::{
+        pr_log::{PR_LOG_TEMPLATE, build_aliases},
+        restack::RestackArgs,
+    },
+};
+use anyhow::{Context, Result, anyhow};
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute, queue, style, terminal,
+};
+use std::collections::HashMap;
+use std::io::{Stdout, Write};
+use tokio::process::Command;
+
+const CONTROL_BAR_LINES: u16 = 2;
+const DEFAULT_LOG_HEIGHT: usize = 20;
+
+/// Unicode Private-Use Area markers wrapping the commit id in our
+/// restack-specific template. Invisible in terminals (no glyph), so users
+/// who render the captured log directly (unlikely, since we strip them)
+/// would not see them either. PUA chars round-trip through TOML and jj's
+/// template-string parser as plain UTF-8.
+const SENTINEL_OPEN: char = '\u{E000}';
+const SENTINEL_CLOSE: char = '\u{E001}';
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Browse,
+    Picker,
+    Summary,
+    QuitConfirm,
+}
+
+enum LoopOutcome {
+    Continue,
+    Submit,
+    Abort,
+}
+
+struct PickerState {
+    target_pr: u64,
+    input: String,
+    selected: usize,
+    candidates: Vec<String>,
+}
+
+struct UiState {
+    plans: Vec<PrPlan>,
+    decisions: HashMap<u64, Decision>,
+    log_lines: Vec<String>,
+    pr_to_line: HashMap<u64, usize>,
+    pr_order: Vec<u64>,
+    cursor_pr_idx: usize,
+    scroll_offset: usize,
+    mode: Mode,
+    picker: Option<PickerState>,
+    base_candidates: Vec<String>,
+    summary_scroll: usize,
+}
+
+pub async fn run<J: Jj>(
+    jj: &J,
+    ctx: &RestackContext,
+    config: &Config,
+    args: &RestackArgs,
+) -> Result<HashMap<u64, Decision>> {
+    let stdout_bytes = capture_log(ctx, config, args).await?;
+    let (log_lines, commit_to_line) = parse_sentinel_lines(&stdout_bytes);
+    let pr_to_line = commit_map_to_pr_map(&commit_to_line, &ctx.plans);
+    let pr_order = order_prs_topologically(jj, &ctx.plans).await?;
+
+    let cursor_pr_idx = args
+        .number_or_rev
+        .as_ref()
+        .and_then(|s| s.parse::<u64>().ok())
+        .and_then(|num| pr_order.iter().position(|n| *n == num))
+        .unwrap_or(0);
+
+    let decisions = ctx
+        .plans
+        .iter()
+        .map(|p| (p.pr_number, Decision::Unset))
+        .collect();
+
+    let mut state = UiState {
+        plans: ctx.plans.clone(),
+        decisions,
+        log_lines,
+        pr_to_line,
+        pr_order,
+        cursor_pr_idx,
+        scroll_offset: 0,
+        mode: Mode::Browse,
+        picker: None,
+        base_candidates: build_base_candidates(ctx),
+        summary_scroll: 0,
+    };
+
+    let guard = AltScreenGuard::enter()?;
+    let mut out = std::io::stdout();
+
+    let result = loop {
+        render(&mut out, &state)?;
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+        match handle_key(&mut state, key) {
+            LoopOutcome::Continue => {}
+            LoopOutcome::Submit => break Ok(()),
+            LoopOutcome::Abort => break Err(anyhow!("restack aborted")),
+        }
+    };
+
+    drop(guard);
+
+    match result {
+        Ok(()) => Ok(state.decisions),
+        Err(e) => Err(e),
+    }
+}
+
+struct AltScreenGuard;
+
+impl AltScreenGuard {
+    fn enter() -> Result<Self> {
+        terminal::enable_raw_mode().context("enabling raw mode")?;
+        execute!(
+            std::io::stdout(),
+            terminal::EnterAlternateScreen,
+            cursor::Hide,
+        )
+        .context("entering alt screen")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for AltScreenGuard {
+    fn drop(&mut self) {
+        let _ = execute!(
+            std::io::stdout(),
+            cursor::Show,
+            terminal::LeaveAlternateScreen,
+        );
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+fn render(out: &mut Stdout, state: &UiState) -> Result<()> {
+    let (cols, rows) = terminal::size().context("reading terminal size")?;
+    let log_height = rows.saturating_sub(CONTROL_BAR_LINES).into();
+
+    queue!(
+        out,
+        terminal::Clear(terminal::ClearType::All),
+        cursor::MoveTo(0, 0),
+    )?;
+
+    match state.mode {
+        Mode::Summary => render_summary(out, state, log_height)?,
+        _ => render_log(out, state, log_height)?,
+    }
+
+    render_control_bar(out, state, cols, rows)?;
+    out.flush()?;
+    Ok(())
+}
+
+fn render_log(out: &mut Stdout, state: &UiState, log_height: usize) -> Result<()> {
+    let cursor_line = state
+        .pr_order
+        .get(state.cursor_pr_idx)
+        .and_then(|n| state.pr_to_line.get(n))
+        .copied();
+    let cols: usize = terminal::size().ok().map_or(80, |(c, _)| c.into());
+    let viewport_end = (state.scroll_offset + log_height).min(state.log_lines.len());
+    for (i, line) in state.log_lines[state.scroll_offset..viewport_end]
+        .iter()
+        .enumerate()
+    {
+        let absolute = state.scroll_offset + i;
+        let highlighted = Some(absolute) == cursor_line;
+        queue!(out, cursor::MoveTo(0, u16::try_from(i).unwrap_or(u16::MAX)))?;
+        if highlighted {
+            let (painted, visible) = apply_bg_highlight(line, HIGHLIGHT_BG);
+            let pad = cols.saturating_sub(visible);
+            queue!(
+                out,
+                style::Print(painted),
+                style::Print(format!("{HIGHLIGHT_BG}{:pad$}\x1b[0m", "", pad = pad)),
+            )?;
+        } else {
+            queue!(out, style::Print(line))?;
+        }
+    }
+    Ok(())
+}
+
+/// ANSI sequence applied to highlight the cursor row's background
+const HIGHLIGHT_BG: &str = "\x1b[48;5;236m";
+
+/// Wrap `line` so the background-color escape stays active across any
+/// `\x1b[0m`/`\x1b[m` resets embedded in the captured output, and return the
+/// number of visible (non-ANSI) characters for downstream padding.
+fn apply_bg_highlight(line: &str, bg_code: &str) -> (String, usize) {
+    let mut out = String::with_capacity(line.len() + bg_code.len() * 4);
+    out.push_str(bg_code);
+    let mut visible = 0usize;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            let mut esc = String::from("\x1b[");
+            chars.next();
+            for ch in chars.by_ref() {
+                esc.push(ch);
+                if ch.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            out.push_str(&esc);
+            if esc.ends_with('m') {
+                let body = &esc[2..esc.len() - 1];
+                let is_reset = body.is_empty() || body.split(';').any(|p| p == "0" || p == "00");
+                if is_reset {
+                    out.push_str(bg_code);
+                }
+            }
+        } else {
+            out.push(c);
+            visible += 1;
+        }
+    }
+    out.push_str("\x1b[0m");
+    (out, visible)
+}
+
+fn render_summary(out: &mut Stdout, state: &UiState, height: usize) -> Result<()> {
+    let total_rows = state.plans.len() + 2;
+    let visible_rows = height.min(total_rows.saturating_sub(state.summary_scroll));
+    let mut row: u16 = 0;
+    let mut idx = state.summary_scroll;
+    while idx < state.summary_scroll + visible_rows {
+        queue!(out, cursor::MoveTo(0, row))?;
+        if idx == 0 {
+            queue!(
+                out,
+                style::SetAttribute(style::Attribute::Bold),
+                style::Print("Summary"),
+                style::SetAttribute(style::Attribute::Reset),
+                style::SetForegroundColor(style::Color::DarkGrey),
+                style::Print("  (y = submit, Esc/q = back)"),
+                style::ResetColor,
+            )?;
+        } else if idx == 1 {
+            // blank spacer
+        } else {
+            let p = &state.plans[idx - 2];
+            let decision = state
+                .decisions
+                .get(&p.pr_number)
+                .unwrap_or(&Decision::Unset);
+            render_summary_row(out, p, decision)?;
+        }
+        row = row.saturating_add(1);
+        idx += 1;
+    }
+    Ok(())
+}
+
+fn render_summary_row(out: &mut Stdout, p: &PrPlan, decision: &Decision) -> Result<()> {
+    let title = truncate(&p.title, 40);
+    queue!(
+        out,
+        style::SetForegroundColor(style::Color::Cyan),
+        style::Print(format!("#{:<5} ", p.pr_number)),
+        style::SetForegroundColor(style::Color::White),
+        style::Print(format!("{title:<41} ")),
+        style::ResetColor,
+    )?;
+
+    let final_base = decision.final_base(p);
+    let (base, changed) = match final_base {
+        Some(b) if b != p.current_base => (b, true),
+        _ => (p.current_base.as_str(), false),
+    };
+    let base_color = if changed {
+        style::Color::Green
+    } else {
+        style::Color::Blue
+    };
+    queue!(
+        out,
+        style::SetForegroundColor(base_color),
+        style::Print(base),
+        style::SetForegroundColor(style::Color::DarkGrey),
+        style::Print(" \u{2190} "),
+        style::SetForegroundColor(style::Color::Magenta),
+        style::Print(&p.bookmark),
+        style::ResetColor,
+    )?;
+    if changed {
+        queue!(
+            out,
+            style::SetForegroundColor(style::Color::DarkGrey),
+            style::Print(format!("  (was: {})", p.current_base)),
+            style::ResetColor,
+        )?;
+    }
+
+    queue!(out, style::Print("  "))?;
+    render_badge(out, decision, p)?;
+    Ok(())
+}
+
+const BROWSE_KEYMAP: &str = "c=confirm e=edit s=skip j/k=move Enter=summary q=quit";
+const SUMMARY_KEYMAP: &str = "y=submit  Esc/q=back";
+const PICKER_KEYMAP: &str = "Enter=apply Esc=cancel C-n/C-p";
+
+fn render_control_bar(out: &mut Stdout, state: &UiState, cols: u16, rows: u16) -> Result<()> {
+    let bar_top = rows.saturating_sub(CONTROL_BAR_LINES);
+    let border = "\u{2501}".repeat(cols.into());
+    queue!(
+        out,
+        cursor::MoveTo(0, bar_top),
+        style::SetAttribute(style::Attribute::Reset),
+        style::SetForegroundColor(style::Color::DarkGrey),
+        style::Print(border),
+        style::ResetColor,
+        cursor::MoveTo(0, bar_top + 1),
+        terminal::Clear(terminal::ClearType::UntilNewLine),
+    )?;
+
+    match state.mode {
+        Mode::Browse => render_browse_status(out, state, cols)?,
+        Mode::Picker => render_picker_status(out, state, cols)?,
+        Mode::Summary => render_summary_status(out, state, cols)?,
+        Mode::QuitConfirm => queue!(
+            out,
+            style::SetForegroundColor(style::Color::Yellow),
+            style::Print("Discard decisions and quit? (y/N)"),
+            style::ResetColor,
+        )?,
+    }
+    Ok(())
+}
+
+fn render_browse_status(out: &mut Stdout, state: &UiState, cols: u16) -> Result<()> {
+    let Some(idx) = state.pr_order.get(state.cursor_pr_idx) else {
+        queue!(out, style::Print("no PRs in stack  (q=quit)"))?;
+        return Ok(());
+    };
+    let plan = state
+        .plans
+        .iter()
+        .find(|p| p.pr_number == *idx)
+        .expect("cursor pr must have a plan");
+    let decision = state.decisions.get(idx).unwrap_or(&Decision::Unset);
+
+    let n = state.cursor_pr_idx + 1;
+    let total = state.pr_order.len();
+    let title = truncate(&plan.title, 50);
+    let base = display_base(plan);
+    let left_plain = format!(
+        "[{n}/{total}] #{pr} {title}  {base} \u{2190} {bookmark} [{badge}]",
+        pr = plan.pr_number,
+        bookmark = plan.bookmark,
+        badge = decision_badge(decision, plan),
+    );
+
+    queue!(
+        out,
+        style::SetForegroundColor(style::Color::DarkGrey),
+        style::Print(format!("[{n}/{total}] ")),
+        style::SetForegroundColor(style::Color::Cyan),
+        style::Print(format!("#{} ", plan.pr_number)),
+        style::SetForegroundColor(style::Color::White),
+        style::Print(title),
+        style::Print("  "),
+        style::ResetColor,
+    )?;
+    render_base_arrow(out, plan)?;
+    queue!(out, style::Print(" "))?;
+    render_badge(out, decision, plan)?;
+
+    let right = BROWSE_KEYMAP;
+    let used = left_plain.chars().count();
+    let right_w = right.chars().count();
+    let cols: usize = cols.into();
+    if used + 2 + right_w <= cols {
+        let pad = cols - used - right_w;
+        queue!(
+            out,
+            style::Print(" ".repeat(pad)),
+            style::SetForegroundColor(style::Color::DarkGrey),
+            style::Print(right),
+            style::ResetColor,
+        )?;
+    }
+    Ok(())
+}
+
+fn render_picker_status(out: &mut Stdout, state: &UiState, cols: u16) -> Result<()> {
+    let Some(picker) = &state.picker else {
+        return Ok(());
+    };
+    let candidate = picker
+        .candidates
+        .get(picker.selected)
+        .map_or("(no candidate)", String::as_str);
+    let left_plain = format!(
+        "edit #{pr}: {input}_  -> {candidate}",
+        pr = picker.target_pr,
+        input = picker.input,
+    );
+    queue!(
+        out,
+        style::SetForegroundColor(style::Color::Cyan),
+        style::Print(format!("edit #{}: ", picker.target_pr)),
+        style::ResetColor,
+        style::Print(format!("{}_", picker.input)),
+        style::SetForegroundColor(style::Color::DarkGrey),
+        style::Print("  \u{2192} "),
+        style::ResetColor,
+        style::Print(candidate),
+    )?;
+    let used = left_plain.chars().count();
+    let right_w = PICKER_KEYMAP.chars().count();
+    let cols: usize = cols.into();
+    if used + 2 + right_w <= cols {
+        let pad = cols - used - right_w;
+        queue!(
+            out,
+            style::Print(" ".repeat(pad)),
+            style::SetForegroundColor(style::Color::DarkGrey),
+            style::Print(PICKER_KEYMAP),
+            style::ResetColor,
+        )?;
+    }
+    Ok(())
+}
+
+fn render_summary_status(out: &mut Stdout, state: &UiState, cols: u16) -> Result<()> {
+    let ready = count_submittable(state);
+    let left_plain = format!("summary  ({ready} change(s) ready)");
+    queue!(
+        out,
+        style::SetForegroundColor(style::Color::Green),
+        style::Print("summary"),
+        style::ResetColor,
+        style::Print(format!("  ({ready} change(s) ready)")),
+    )?;
+    let used = left_plain.chars().count();
+    let right_w = SUMMARY_KEYMAP.chars().count();
+    let cols: usize = cols.into();
+    if used + 2 + right_w <= cols {
+        let pad = cols - used - right_w;
+        queue!(
+            out,
+            style::Print(" ".repeat(pad)),
+            style::SetForegroundColor(style::Color::DarkGrey),
+            style::Print(SUMMARY_KEYMAP),
+            style::ResetColor,
+        )?;
+    }
+    Ok(())
+}
+
+/// Base ref to render as the merge target. Proposed for change PRs (the
+/// new base after restack), current for no-change PRs (unchanged target).
+fn display_base(plan: &PrPlan) -> &str {
+    if plan.is_no_change() {
+        &plan.current_base
+    } else {
+        &plan.proposed_base
+    }
+}
+
+/// Render `<base> ← <bookmark>` mirroring GitHub's PR header layout
+/// (base on the left, head/bookmark on the right). Base is colored
+/// green for a change, blue for no-change.
+fn render_base_arrow(out: &mut Stdout, plan: &PrPlan) -> Result<()> {
+    let base_color = if plan.is_no_change() {
+        style::Color::Blue
+    } else {
+        style::Color::Green
+    };
+    queue!(
+        out,
+        style::SetForegroundColor(base_color),
+        style::Print(display_base(plan)),
+        style::SetForegroundColor(style::Color::DarkGrey),
+        style::Print(" \u{2190} "),
+        style::SetForegroundColor(style::Color::Magenta),
+        style::Print(&plan.bookmark),
+        style::ResetColor,
+    )?;
+    Ok(())
+}
+
+fn render_badge(out: &mut Stdout, decision: &Decision, plan: &PrPlan) -> Result<()> {
+    let (label, color) = match decision {
+        Decision::Unset if plan.is_no_change() => ("no-change", style::Color::DarkGrey),
+        Decision::Unset => ("unset", style::Color::Yellow),
+        Decision::Confirm => ("confirm", style::Color::Green),
+        Decision::EditedTo(_) => ("edited", style::Color::Cyan),
+        Decision::Skip => ("skip", style::Color::Red),
+    };
+    queue!(
+        out,
+        style::SetForegroundColor(color),
+        style::Print(format!("[{label}]")),
+        style::ResetColor,
+    )?;
+    Ok(())
+}
+
+fn decision_badge(decision: &Decision, plan: &PrPlan) -> &'static str {
+    match decision {
+        Decision::Unset if plan.is_no_change() => "no-change",
+        Decision::Unset => "unset",
+        Decision::Confirm => "confirm",
+        Decision::EditedTo(_) => "edited",
+        Decision::Skip => "skip",
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('\u{2026}');
+    out
+}
+
+fn count_submittable(state: &UiState) -> usize {
+    state
+        .plans
+        .iter()
+        .filter(|p| {
+            state
+                .decisions
+                .get(&p.pr_number)
+                .and_then(|d| d.final_base(p))
+                .is_some_and(|b| b != p.current_base)
+        })
+        .count()
+}
+
+fn handle_key(state: &mut UiState, key: KeyEvent) -> LoopOutcome {
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return LoopOutcome::Abort;
+    }
+    match state.mode {
+        Mode::Browse => handle_browse(state, key),
+        Mode::Picker => handle_picker(state, key),
+        Mode::Summary => handle_summary(state, key),
+        Mode::QuitConfirm => handle_quit_confirm(state, key),
+    }
+}
+
+fn handle_browse(state: &mut UiState, key: KeyEvent) -> LoopOutcome {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match (key.code, ctrl) {
+        (KeyCode::Char('j') | KeyCode::Down, false) => move_cursor(state, 1),
+        (KeyCode::Char('k') | KeyCode::Up, false) => move_cursor(state, -1),
+        (KeyCode::Char('d'), true) => scroll_viewport(state, 8),
+        (KeyCode::Char('u'), true) => scroll_viewport(state, -8),
+        (KeyCode::Char('g'), false) => move_cursor_to(state, 0),
+        (KeyCode::Char('G'), _) => {
+            let last = state.pr_order.len().saturating_sub(1);
+            move_cursor_to(state, last);
+        }
+        (KeyCode::Char('c'), false) => set_decision_at_cursor(state, Decision::Confirm),
+        (KeyCode::Char('s'), false) => set_decision_at_cursor(state, Decision::Skip),
+        (KeyCode::Char('e'), false) => open_picker(state),
+        (KeyCode::Enter, _) => state.mode = Mode::Summary,
+        (KeyCode::Char('q'), false) | (KeyCode::Esc, _) => {
+            let any_set = state
+                .decisions
+                .values()
+                .any(|d| !matches!(d, Decision::Unset));
+            if any_set {
+                state.mode = Mode::QuitConfirm;
+            } else {
+                return LoopOutcome::Abort;
+            }
+        }
+        _ => {}
+    }
+    LoopOutcome::Continue
+}
+
+fn handle_picker(state: &mut UiState, key: KeyEvent) -> LoopOutcome {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let Some(picker) = state.picker.as_mut() else {
+        state.mode = Mode::Browse;
+        return LoopOutcome::Continue;
+    };
+    match (key.code, ctrl) {
+        (KeyCode::Esc, _) => {
+            state.picker = None;
+            state.mode = Mode::Browse;
+        }
+        (KeyCode::Enter, _) => {
+            if let Some(chosen) = picker.candidates.get(picker.selected).cloned() {
+                let bookmark = extract_bookmark(&chosen);
+                state
+                    .decisions
+                    .insert(picker.target_pr, Decision::EditedTo(bookmark));
+            }
+            state.picker = None;
+            state.mode = Mode::Browse;
+        }
+        (KeyCode::Char('n'), true) | (KeyCode::Down, _) if !picker.candidates.is_empty() => {
+            picker.selected = (picker.selected + 1) % picker.candidates.len();
+        }
+        (KeyCode::Char('p'), true) | (KeyCode::Up, _) if !picker.candidates.is_empty() => {
+            picker.selected = picker
+                .selected
+                .checked_sub(1)
+                .unwrap_or(picker.candidates.len() - 1);
+        }
+        (KeyCode::Backspace, _) => {
+            picker.input.pop();
+            refresh_picker_candidates(picker, &state.base_candidates);
+        }
+        (KeyCode::Char(c), false) => {
+            picker.input.push(c);
+            refresh_picker_candidates(picker, &state.base_candidates);
+        }
+        _ => {}
+    }
+    LoopOutcome::Continue
+}
+
+fn handle_summary(state: &mut UiState, key: KeyEvent) -> LoopOutcome {
+    match (key.code, key.modifiers.contains(KeyModifiers::CONTROL)) {
+        (KeyCode::Char('y'), false) => LoopOutcome::Submit,
+        (KeyCode::Esc, _) | (KeyCode::Char('q'), false) => {
+            state.mode = Mode::Browse;
+            LoopOutcome::Continue
+        }
+        (KeyCode::Char('j') | KeyCode::Down, false) => {
+            state.summary_scroll = state.summary_scroll.saturating_add(1);
+            LoopOutcome::Continue
+        }
+        (KeyCode::Char('k') | KeyCode::Up, false) => {
+            state.summary_scroll = state.summary_scroll.saturating_sub(1);
+            LoopOutcome::Continue
+        }
+        _ => LoopOutcome::Continue,
+    }
+}
+
+fn handle_quit_confirm(state: &mut UiState, key: KeyEvent) -> LoopOutcome {
+    match key.code {
+        KeyCode::Char('y' | 'Y') => LoopOutcome::Abort,
+        KeyCode::Char('n' | 'N') | KeyCode::Esc => {
+            state.mode = Mode::Browse;
+            LoopOutcome::Continue
+        }
+        _ => LoopOutcome::Continue,
+    }
+}
+
+fn move_cursor(state: &mut UiState, delta: isize) {
+    if state.pr_order.is_empty() {
+        return;
+    }
+    let len = i64::try_from(state.pr_order.len()).unwrap_or(i64::MAX);
+    let delta: i64 = delta.try_into().expect("Cursor delta out of range");
+    let next = (i64::try_from(state.cursor_pr_idx).unwrap_or(0) + delta).clamp(0, len - 1);
+    move_cursor_to(state, usize::try_from(next).unwrap_or(0));
+}
+
+fn move_cursor_to(state: &mut UiState, idx: usize) {
+    state.cursor_pr_idx = idx.min(state.pr_order.len().saturating_sub(1));
+    let Some(pr) = state.pr_order.get(state.cursor_pr_idx) else {
+        return;
+    };
+    let Some(target_line) = state.pr_to_line.get(pr).copied() else {
+        return;
+    };
+    let height = visible_log_rows().unwrap_or(DEFAULT_LOG_HEIGHT);
+    if target_line < state.scroll_offset {
+        state.scroll_offset = target_line;
+    } else if target_line >= state.scroll_offset + height {
+        state.scroll_offset = target_line + 1 - height;
+    }
+}
+
+fn visible_log_rows() -> Option<usize> {
+    terminal::size()
+        .ok()
+        .map(|(_, r)| r.saturating_sub(CONTROL_BAR_LINES).into())
+}
+
+fn scroll_viewport(state: &mut UiState, delta: isize) {
+    let height = visible_log_rows().unwrap_or(DEFAULT_LOG_HEIGHT);
+    let max_offset = state.log_lines.len().saturating_sub(height);
+    let delta: i64 = delta.try_into().expect("Scroll delta out of range");
+    let next = i64::try_from(state.scroll_offset).unwrap_or(0) + delta;
+    let clamped = next.max(0);
+    state.scroll_offset = usize::try_from(clamped).unwrap_or(0).min(max_offset);
+}
+
+fn set_decision_at_cursor(state: &mut UiState, decision: Decision) {
+    let Some(pr) = state.pr_order.get(state.cursor_pr_idx).copied() else {
+        return;
+    };
+    state.decisions.insert(pr, decision);
+    if state.cursor_pr_idx + 1 < state.pr_order.len() {
+        move_cursor_to(state, state.cursor_pr_idx + 1);
+    }
+}
+
+fn open_picker(state: &mut UiState) {
+    let Some(pr) = state.pr_order.get(state.cursor_pr_idx).copied() else {
+        return;
+    };
+    if state.base_candidates.is_empty() {
+        return;
+    }
+    let mut picker = PickerState {
+        target_pr: pr,
+        input: String::new(),
+        selected: 0,
+        candidates: state.base_candidates.clone(),
+    };
+    refresh_picker_candidates(&mut picker, &state.base_candidates);
+    state.picker = Some(picker);
+    state.mode = Mode::Picker;
+}
+
+fn refresh_picker_candidates(picker: &mut PickerState, all: &[String]) {
+    let needle = picker.input.to_lowercase();
+    picker.candidates = all
+        .iter()
+        .filter(|c| needle.is_empty() || c.to_lowercase().contains(&needle))
+        .cloned()
+        .collect();
+    if picker.selected >= picker.candidates.len() {
+        picker.selected = 0;
+    }
+}
+
+pub(crate) fn extract_bookmark(candidate: &str) -> String {
+    candidate
+        .split_once(" (")
+        .map_or(candidate, |(name, _)| name)
+        .to_string()
+}
+
+pub(crate) fn build_base_candidates(ctx: &RestackContext) -> Vec<String> {
+    let mut by_bookmark = HashMap::new();
+    for pr in &ctx.prs {
+        by_bookmark.insert(pr.head_ref_name.as_str(), pr.number);
+    }
+    let mut out = ctx
+        .bookmarks
+        .iter()
+        .map(|b| match by_bookmark.get(b.name.as_str()) {
+            Some(n) => format!("{} (#{n})", b.name),
+            None => b.name.clone(),
+        })
+        .collect::<Vec<_>>();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Capture `jj log` rendered with the user's chosen template wrapped in our
+/// commit-id sentinel markers. Template resolution chain:
+/// `pr_restack_template` -> `pr_log_template` -> built-in [`PR_LOG_TEMPLATE`].
+/// The wrapper sits outside the user body so anything the user templates
+/// renders as-is; we only consume the markers when post-processing the
+/// captured stream.
+async fn capture_log(ctx: &RestackContext, config: &Config, args: &RestackArgs) -> Result<String> {
+    let branch_to_local: HashMap<String, String> = ctx
+        .bookmarks
+        .iter()
+        .map(|b| (b.name.clone(), b.local_commit_id.clone()))
+        .collect();
+    let user_body = args
+        .template
+        .as_deref()
+        .or(config.pr_restack_template.as_deref())
+        .or(config.pr_log_template.as_deref())
+        .unwrap_or(PR_LOG_TEMPLATE);
+    let wrapped = format!(
+        "\"{SENTINEL_OPEN}\" ++ commit_id.short(40) ++ \"{SENTINEL_CLOSE}\" ++ ({user_body})"
+    );
+    let aliases = build_aliases(&ctx.prs, &branch_to_local, config).alias("pr_log", wrapped);
+    let tmp = aliases.write_temp_config()?;
+
+    let mut cmd = Command::new("jj");
+    cmd.arg("--ignore-working-copy")
+        .arg("--config-file")
+        .arg(tmp.path())
+        .arg("log")
+        .arg("--color=always")
+        .args(["-T", "pr_log"]);
+    let output = cmd
+        .output()
+        .await
+        .context("spawning `jj log` for restack")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "`jj log` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    drop(tmp);
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Walk `raw` line-by-line; for each line containing the sentinel pair,
+/// extract the embedded commit id (40-hex, with any ANSI color escapes
+/// stripped from the captured bytes), record its line index, and strip the
+/// sentinels (and any color escapes that landed between them) from the
+/// displayed line.
+fn parse_sentinel_lines(raw: &str) -> (Vec<String>, HashMap<String, usize>) {
+    let mut out_lines = Vec::new();
+    let mut commit_to_line: HashMap<String, usize> = HashMap::new();
+    for line in raw.lines() {
+        let (cleaned, commit) = strip_sentinel(line);
+        if let Some(id) = commit {
+            commit_to_line.entry(id).or_insert(out_lines.len());
+        }
+        out_lines.push(cleaned);
+    }
+    (out_lines, commit_to_line)
+}
+
+fn strip_sentinel(line: &str) -> (String, Option<String>) {
+    let Some(open_idx) = line.find(SENTINEL_OPEN) else {
+        return (line.to_string(), None);
+    };
+    let after_open = open_idx + SENTINEL_OPEN.len_utf8();
+    let Some(rel_close) = line[after_open..].find(SENTINEL_CLOSE) else {
+        return (line.to_string(), None);
+    };
+    let close_idx = after_open + rel_close;
+    let id_raw = &line[after_open..close_idx];
+    let id_clean = strip_ansi(id_raw);
+    if id_clean.len() != 40 || !id_clean.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return (line.to_string(), None);
+    }
+    let mut cleaned = String::with_capacity(line.len());
+    cleaned.push_str(&line[..open_idx]);
+    cleaned.push_str(&line[close_idx + SENTINEL_CLOSE.len_utf8()..]);
+    (cleaned, Some(id_clean))
+}
+
+/// Strip ANSI CSI escapes (`ESC [ ... letter`) from `s`. jj's `--color=always`
+/// wraps `commit_id.short(40)` in color codes; we need a clean 40-hex string
+/// to validate and key on.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            if chars.next() == Some('[') {
+                for ch in chars.by_ref() {
+                    if ch.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn commit_map_to_pr_map(commits: &HashMap<String, usize>, plans: &[PrPlan]) -> HashMap<u64, usize> {
+    let mut out = HashMap::new();
+    for p in plans {
+        if let Some(line) = commits.get(&p.local_commit_id) {
+            out.insert(p.pr_number, *line);
+        }
+    }
+    out
+}
+
+/// Order PRs by topology (newest first) so cursor navigation matches what
+/// the user sees in the rendered log. Falls back to plan order for any PRs
+/// the jj query does not emit.
+async fn order_prs_topologically<J: Jj>(jj: &J, plans: &[PrPlan]) -> Result<Vec<u64>> {
+    if plans.is_empty() {
+        return Ok(Vec::new());
+    }
+    let revset = plans
+        .iter()
+        .map(|p| format!("({})", p.local_commit_id))
+        .collect::<Vec<_>>()
+        .join("|");
+    let template = r#"commit_id.short(40) ++ "\n""#;
+    let stdout = jj
+        .eval_template(&revset, template, None, false)
+        .await
+        .context("ordering PRs by topology")?;
+    let commit_to_pr: HashMap<&str, u64> = plans
+        .iter()
+        .map(|p| (p.local_commit_id.as_str(), p.pr_number))
+        .collect();
+    let mut order: Vec<u64> = Vec::with_capacity(plans.len());
+    for line in stdout.lines() {
+        let id = line.trim();
+        if let Some(&pr) = commit_to_pr.get(id)
+            && !order.contains(&pr)
+        {
+            order.push(pr);
+        }
+    }
+    for p in plans {
+        if !order.contains(&p.pr_number) {
+            order.push(p.pr_number);
+        }
+    }
+    Ok(order)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picker_filter_substring_matches_bookmark_and_pr_number() {
+        let mut picker = PickerState {
+            target_pr: 1,
+            input: "1234".into(),
+            selected: 0,
+            candidates: vec![],
+        };
+        let all = vec![
+            "master".to_string(),
+            "feature-a (#1234)".to_string(),
+            "feature-b (#999)".to_string(),
+        ];
+        refresh_picker_candidates(&mut picker, &all);
+        assert_eq!(picker.candidates, vec!["feature-a (#1234)"]);
+
+        picker.input = "feature".into();
+        refresh_picker_candidates(&mut picker, &all);
+        assert_eq!(
+            picker.candidates,
+            vec!["feature-a (#1234)", "feature-b (#999)"],
+        );
+
+        picker.input = String::new();
+        refresh_picker_candidates(&mut picker, &all);
+        assert_eq!(picker.candidates.len(), 3);
+    }
+
+    #[test]
+    fn extract_bookmark_strips_pr_suffix() {
+        assert_eq!(extract_bookmark("master"), "master");
+        assert_eq!(extract_bookmark("feature-a (#1234)"), "feature-a");
+    }
+
+    #[test]
+    fn strip_ansi_removes_csi_escapes() {
+        assert_eq!(strip_ansi("\x1b[38;5;4mhello\x1b[39m"), "hello");
+        assert_eq!(strip_ansi("plain"), "plain");
+        assert_eq!(strip_ansi("\x1b[1m\x1b[31mx\x1b[0m"), "x");
+    }
+
+    #[test]
+    fn strip_sentinel_recognizes_plain_id() {
+        let id = "a".repeat(40);
+        let raw = format!("{SENTINEL_OPEN}{id}{SENTINEL_CLOSE}  description");
+        let (cleaned, commit) = strip_sentinel(&raw);
+        assert_eq!(cleaned, "  description");
+        assert_eq!(commit, Some(id));
+    }
+
+    #[test]
+    fn strip_sentinel_recognizes_ansi_wrapped_id() {
+        let id = "b".repeat(40);
+        let raw = format!("@  {SENTINEL_OPEN}\x1b[38;5;4m{id}\x1b[39m{SENTINEL_CLOSE} header");
+        let (cleaned, commit) = strip_sentinel(&raw);
+        assert_eq!(cleaned, "@   header");
+        assert_eq!(commit, Some(id));
+    }
+
+    #[test]
+    fn strip_sentinel_passes_through_non_marker_lines() {
+        let (cleaned, commit) = strip_sentinel("\u{2502}  no marker here");
+        assert_eq!(cleaned, "\u{2502}  no marker here");
+        assert!(commit.is_none());
+    }
+
+    #[test]
+    fn strip_sentinel_rejects_short_id() {
+        let id = "a".repeat(10);
+        let raw = format!("{SENTINEL_OPEN}{id}{SENTINEL_CLOSE}tail");
+        let (_cleaned, commit) = strip_sentinel(&raw);
+        assert!(commit.is_none());
+    }
+
+    #[test]
+    fn parse_sentinel_lines_builds_commit_map() {
+        let id1 = "a".repeat(40);
+        let id2 = "b".repeat(40);
+        let raw = format!(
+            "@ {SENTINEL_OPEN}{id1}{SENTINEL_CLOSE} header\n  description\n\u{2502} {SENTINEL_OPEN}{id2}{SENTINEL_CLOSE} other\n",
+        );
+        let (lines, map) = parse_sentinel_lines(&raw);
+        assert_eq!(lines.len(), 3);
+        assert_eq!(map.get(&id1), Some(&0));
+        assert_eq!(map.get(&id2), Some(&2));
+    }
+}

--- a/src/pr/restack/mod.rs
+++ b/src/pr/restack/mod.rs
@@ -1,0 +1,358 @@
+//! `jj-gh pr restack`: update PR base refs on GitHub to match the current
+//! `jj` graph shape. Restack does not touch the jj graph itself; the user
+//! shapes the graph first, then runs this command to push the new bases up.
+//!
+//! The command always launches an interactive TUI unless `--dry-run` /
+//! `--json` is passed, or stdin/stdout is not a TTY (in which case it falls
+//! back to a dry-run print).
+
+mod interactive;
+
+use crate::{
+    config::Config,
+    gh::{Gh, PrWithCiStatus, UpdatePr},
+    git,
+    jj::{Jj, PushedBookmark},
+    ui::Spinner,
+};
+use anyhow::{Result, anyhow};
+use futures::{StreamExt, stream::FuturesUnordered};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::IsTerminal;
+
+#[derive(Debug, clap::Args, Serialize)]
+pub struct RestackArgs {
+    /// PR number or revision ID to position the cursor on when the TUI opens;
+    /// if omitted the cursor starts on the first PR in the stack.
+    #[arg(value_name = "PR_NUM|REV")]
+    #[serde(skip)]
+    pub number_or_rev: Option<String>,
+
+    /// Print the proposed plan and exit without launching the TUI. No PR is
+    /// updated. Auto-enabled when stdout is not a terminal.
+    #[arg(long)]
+    #[serde(skip)]
+    pub dry_run: bool,
+
+    /// Emit the proposed plan as JSON. Implies `--dry-run`.
+    #[arg(long)]
+    #[serde(skip)]
+    pub json: bool,
+
+    /// Template to use in interactive mode; conflicts with `--json` and `--dry-run`.
+    #[arg(long, short = 'T', conflicts_with_all = ["json", "dry_run"])]
+    #[serde(
+        rename = "pr_restack_template",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub template: Option<String>,
+}
+
+/// One PR's proposed base-ref transition. Computed up-front so the TUI and
+/// dry-run output share a single representation.
+#[derive(Debug, Clone, Serialize)]
+pub struct PrPlan {
+    pub pr_number: u64,
+    pub pr_node_id: String,
+    pub title: String,
+    pub bookmark: String,
+    pub local_commit_id: String,
+    pub current_base: String,
+    pub proposed_base: String,
+}
+
+impl PrPlan {
+    #[must_use]
+    pub fn is_no_change(&self) -> bool {
+        self.current_base == self.proposed_base
+    }
+}
+
+/// User's decision for a single PR in the interactive loop.
+#[derive(Debug, Clone)]
+pub enum Decision {
+    /// User hasn't acted on this PR yet.
+    Unset,
+    /// Apply the proposed base.
+    Confirm,
+    /// Apply this bookmark name instead of the proposed base.
+    EditedTo(String),
+    /// Leave this PR alone.
+    Skip,
+}
+
+impl Decision {
+    /// Resolve the final base ref this decision should submit, if any.
+    /// `Unset` and `Skip` produce `None`; `Confirm` returns the plan's
+    /// proposed base; `EditedTo` returns the override.
+    #[must_use]
+    pub fn final_base<'a>(&'a self, plan: &'a PrPlan) -> Option<&'a str> {
+        match self {
+            Self::Unset | Self::Skip => None,
+            Self::Confirm => Some(&plan.proposed_base),
+            Self::EditedTo(b) => Some(b.as_str()),
+        }
+    }
+}
+
+pub async fn run<J, G>(jj: &J, gh: &G, config: &Config, args: &RestackArgs) -> Result<()>
+where
+    J: Jj,
+    G: Gh,
+{
+    let ctx = gather_context(jj, gh, config).await?;
+    let force_dry = args.dry_run
+        || args.json
+        || !std::io::stdout().is_terminal()
+        || !std::io::stderr().is_terminal();
+
+    if ctx.plans.is_empty() {
+        if args.json {
+            println!("[]");
+        } else {
+            println!("no PRs to restack");
+        }
+        return Ok(());
+    }
+
+    if force_dry {
+        if args.json {
+            serde_json::to_writer_pretty(std::io::stdout().lock(), &ctx.plans)?;
+            println!();
+        } else {
+            print_dry_run_text(&ctx.plans);
+        }
+        return Ok(());
+    }
+
+    let decisions = interactive::run(jj, &ctx, config, args).await?;
+    submit(gh, &ctx, &decisions).await
+}
+
+/// Bundle of everything restack needs after the initial fetch: PR metadata,
+/// bookmark map, and the per-PR plan.
+pub(crate) struct RestackContext {
+    pub plans: Vec<PrPlan>,
+    pub prs: Vec<PrWithCiStatus>,
+    pub bookmarks: Vec<PushedBookmark>,
+}
+
+async fn gather_context<J: Jj, G: Gh>(jj: &J, gh: &G, config: &Config) -> Result<RestackContext> {
+    let origin_url = jj
+        .remote_url(&config.default_remote)
+        .await?
+        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+    let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
+
+    let spinner = Spinner::start("Resolving local PRs");
+    let bookmarks = jj.pushed_bookmarks(&config.default_remote).await?;
+    let branch_to_local: HashMap<String, String> = bookmarks
+        .iter()
+        .map(|b| (b.name.clone(), b.local_commit_id.clone()))
+        .collect();
+    let names: Vec<String> = bookmarks.iter().map(|b| b.name.clone()).collect();
+    let prs = gh.local_pulls(&owner, &repo, &names).await?;
+    let trunk = jj.trunk_branch().await?;
+    let plans = propose_plans(jj, &prs, &branch_to_local, trunk.as_deref()).await?;
+    spinner.stop().await;
+
+    Ok(RestackContext {
+        plans,
+        prs,
+        bookmarks,
+    })
+}
+
+/// Compute the proposed base for every PR. Pure aside from the per-PR
+/// `stacked_ancestor_bookmark` jj call; that's the only piece that needs the
+/// real graph.
+async fn propose_plans<J: Jj>(
+    jj: &J,
+    prs: &[PrWithCiStatus],
+    branch_to_local: &HashMap<String, String>,
+    trunk: Option<&str>,
+) -> Result<Vec<PrPlan>> {
+    let mut plans = Vec::with_capacity(prs.len());
+    for pr in prs {
+        let Some(local_commit) = branch_to_local.get(&pr.head_ref_name) else {
+            continue;
+        };
+        let ancestor = jj.stacked_ancestor_bookmark(local_commit).await?;
+        let proposed = ancestor
+            .or_else(|| trunk.map(str::to_string))
+            .unwrap_or_else(|| pr.base_ref_name.clone());
+        plans.push(PrPlan {
+            pr_number: pr.number,
+            pr_node_id: pr.id.clone(),
+            title: pr.title.clone(),
+            bookmark: pr.head_ref_name.clone(),
+            local_commit_id: local_commit.clone(),
+            current_base: pr.base_ref_name.clone(),
+            proposed_base: proposed,
+        });
+    }
+    plans.sort_by_key(|p| p.pr_number);
+    Ok(plans)
+}
+
+fn print_dry_run_text(plans: &[PrPlan]) {
+    const RESET: &str = "\x1b[0m";
+    const CYAN: &str = "\x1b[36m";
+    const MAGENTA: &str = "\x1b[35m";
+    const GREEN: &str = "\x1b[32m";
+    const BLUE: &str = "\x1b[34m";
+    const DIM: &str = "\x1b[2m";
+
+    let tty = std::io::stdout().is_terminal();
+    let on = |code: &'static str| -> &'static str { if tty { code } else { "" } };
+
+    let title_w = plans
+        .iter()
+        .map(|p| p.title.len())
+        .max()
+        .unwrap_or(0)
+        .max(8);
+    let base_w = plans
+        .iter()
+        .map(|p| p.proposed_base.len().max(p.current_base.len()))
+        .max()
+        .unwrap_or(0)
+        .max(4);
+    let mut changes = 0usize;
+    for p in plans {
+        let PrPlan {
+            pr_number,
+            title,
+            bookmark,
+            current_base,
+            proposed_base,
+            ..
+        } = p;
+        let (base, base_color) = if p.is_no_change() {
+            (current_base, on(BLUE))
+        } else {
+            (proposed_base, on(GREEN))
+        };
+        let num = format!("{}#{pr_number:<5}{}", on(CYAN), on(RESET));
+        let title_field = format!("{title:<title_w$}");
+        let base_field = format!("{}{base:<base_w$}{}", base_color, on(RESET));
+        let arrow = format!("{}\u{2190}{}", on(DIM), on(RESET));
+        let bookmark_field = format!("{}{bookmark}{}", on(MAGENTA), on(RESET));
+        let suffix = if p.is_no_change() {
+            format!("{}(no change){}", on(DIM), on(RESET))
+        } else {
+            changes += 1;
+            format!("{}(was: {current_base}){}", on(DIM), on(RESET))
+        };
+        println!("{num} {title_field}  {base_field} {arrow} {bookmark_field}  {suffix}");
+    }
+    let count = plans.len();
+    println!();
+    println!(
+        "{dim}{count} PR(s), {changes} change(s) proposed{reset}",
+        dim = on(DIM),
+        reset = on(RESET),
+    );
+}
+
+async fn submit<G: Gh>(
+    gh: &G,
+    ctx: &RestackContext,
+    decisions: &HashMap<u64, Decision>,
+) -> Result<()> {
+    let updates: Vec<(u64, UpdatePr)> = ctx
+        .plans
+        .iter()
+        .filter_map(|p| {
+            let decision = decisions.get(&p.pr_number).unwrap_or(&Decision::Unset);
+            let base = decision.final_base(p)?;
+            if base == p.current_base {
+                return None;
+            }
+            Some((
+                p.pr_number,
+                UpdatePr {
+                    pr_node_id: p.pr_node_id.clone(),
+                    base_ref_name: Some(base.to_string()),
+                    ..Default::default()
+                },
+            ))
+        })
+        .collect();
+
+    if updates.is_empty() {
+        println!("no PRs updated");
+        return Ok(());
+    }
+
+    let total = updates.len();
+    let spinner = Spinner::start(format!("Updating PRs (0/{total})"));
+    let mut futs: FuturesUnordered<_> = updates
+        .into_iter()
+        .map(|(num, req)| async move {
+            let result = gh.update_pr(req).await;
+            (num, result)
+        })
+        .collect();
+
+    let mut results: Vec<(u64, Result<()>)> = Vec::with_capacity(total);
+    while let Some((num, res)) = futs.next().await {
+        results.push((num, res));
+        spinner.set_message(format!("Updating PRs ({}/{total})", results.len()));
+    }
+    spinner.stop().await;
+
+    results.sort_by_key(|(n, _)| *n);
+    let mut had_failure = false;
+    for (num, res) in &results {
+        match res {
+            Ok(()) => println!("OK  #{num} base updated"),
+            Err(e) => {
+                println!("ERR #{num}: {e:#}");
+                had_failure = true;
+            }
+        }
+    }
+
+    if had_failure {
+        Err(anyhow!("one or more PR updates failed"))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan(number: u64, bookmark: &str, current: &str, proposed: &str) -> PrPlan {
+        PrPlan {
+            pr_number: number,
+            pr_node_id: format!("ID{number}"),
+            title: format!("title {number}"),
+            bookmark: bookmark.into(),
+            local_commit_id: format!("{number:040}"),
+            current_base: current.into(),
+            proposed_base: proposed.into(),
+        }
+    }
+
+    #[test]
+    fn plan_no_change_when_current_eq_proposed() {
+        assert!(plan(1, "b", "master", "master").is_no_change());
+        assert!(!plan(1, "b", "master", "feature").is_no_change());
+    }
+
+    #[test]
+    fn decision_final_base_resolves_each_variant() {
+        let p = plan(1, "b", "master", "feature");
+        assert_eq!(Decision::Unset.final_base(&p), None);
+        assert_eq!(Decision::Skip.final_base(&p), None);
+        assert_eq!(Decision::Confirm.final_base(&p), Some("feature"));
+        assert_eq!(
+            Decision::EditedTo("custom".into()).final_base(&p),
+            Some("custom")
+        );
+    }
+}

--- a/src/ui/spinner.rs
+++ b/src/ui/spinner.rs
@@ -5,6 +5,7 @@
 //! loop.
 
 use std::io::{IsTerminal, Write};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -18,19 +19,22 @@ const TICK: Duration = Duration::from_millis(100);
 pub struct Spinner {
     handle: Option<JoinHandle<()>>,
     stop_tx: Option<oneshot::Sender<()>>,
+    msg: Arc<Mutex<String>>,
 }
 
 impl Spinner {
     /// Start a spinner with `msg`. When stderr is not a terminal, returns a
     /// no-op spinner so callers can use it unconditionally.
     pub fn start(msg: impl Into<String>) -> Self {
+        let msg = Arc::new(Mutex::new(msg.into()));
         if !std::io::stderr().is_terminal() {
             return Self {
                 handle: None,
                 stop_tx: None,
+                msg,
             };
         }
-        let msg = msg.into();
+        let task_msg = Arc::clone(&msg);
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
         let handle = tokio::spawn(async move {
             let dim = anstyle::Style::new().dimmed();
@@ -43,8 +47,9 @@ impl Spinner {
                     _ = interval.tick() => {
                         let glyph = FRAMES[frame % FRAMES.len()];
                         frame = frame.wrapping_add(1);
+                        let current = task_msg.lock().expect("spinner msg poisoned").clone();
                         let mut err = std::io::stderr().lock();
-                        let _ = write!(err, "\r{dim}{glyph} {msg}{dim:#}");
+                        let _ = write!(err, "\r\x1b[2K{dim}{glyph} {current}{dim:#}");
                         let _ = err.flush();
                     }
                 }
@@ -56,7 +61,14 @@ impl Spinner {
         Self {
             handle: Some(handle),
             stop_tx: Some(stop_tx),
+            msg,
         }
+    }
+
+    /// Replace the message shown next to the spinner glyph. No-op when stderr
+    /// is not a terminal.
+    pub fn set_message(&self, msg: String) {
+        *self.msg.lock().expect("spinner msg poisoned") = msg;
     }
 
     /// Stop the spinner and clear its line. Awaiting ensures the cleared line


### PR DESCRIPTION
Add a `jj pr restack` subcommand. This is useful, for example, when:

- You put up PR 1
- You put up PR 2 stacked on 1
- You put up PR 3 as sibling of 1
- Then you realize you need to land PR 4 first, so you rebase the revisions for PR 1-3 on top of that for PR 4

Then `jj pr restack` will recompute the base branch for each PR, and open an interactive editor for you to confirm or make tweaks.

Fixes #136 

Fixes #101 