### PR TITLE
refactor(config): Refactor/simplify config/args layering with proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,7 @@ dependencies = [
  "gix",
  "graphql_client",
  "http",
+ "jj-gh-config-derive",
  "log",
  "octocrab",
  "schemars",
@@ -2229,6 +2230,15 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "jj-gh-config-derive"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,11 @@ include = [
 ]
 
 [workspace]
-members = ["tools/gen-docs", "tools/print-config-schema"]
+members = [
+  "tools/gen-docs",
+  "tools/jj-gh-config-derive",
+  "tools/print-config-schema",
+]
 
 [features]
 schema-validation = ["dep:schemars"]
@@ -47,6 +51,7 @@ gix = { version = "0.84", default-features = false, features = [
 ] }
 graphql_client = "0.16"
 http = "1"
+jj-gh-config-derive = { path = "tools/jj-gh-config-derive" }
 log = "0.4"
 octocrab = "0.51"
 schemars = { version = "1", optional = true }

--- a/DOCS.md
+++ b/DOCS.md
@@ -39,8 +39,8 @@ Opinionated `jj` tools for working with GitHub from your terminal
 - `-v`, `--verbose` — Increase log verbosity (repeat for more, e.g. `-vv`)
 - `-q`, `--quiet` — Drop log level to `ERROR`
 - `--log-level <LEVEL>` — Set log level explicitly, overrides `-v` and `-q`
-- `--remote <NAME>` — Git remote used for the user's own pushes and PR head lookups. Overrides config `default_remote` (default: `origin`)
-- `--upstream-remote <NAME>` — Git remote used as the PR target in fork workflows. Overrides config `upstream_remote` (default: `upstream`)
+- `--remote <NAME>` — Git remote used for the user's own pushes and PR head lookups. Default: `origin` (or `default_remote` in config)
+- `--upstream-remote <NAME>` — Git remote used as the PR target in fork workflows. Default: `upstream` (or `upstream_remote` in config)
 - `--gh-askpass <CMD>` — Askpass helper command that prints a GitHub token on stdout; shell-words split, e.g. `--gh-askpass "op read op://Vault/gh/token"`. Default: `gh_askpass` in config, then `$GH_ASKPASS`
 - `--askpass-timeout <SECS>` — Timeout in seconds for the askpass helper. Default: 20
 
@@ -76,7 +76,7 @@ Opens your editor to a markdown file where you can write the PR description, and
 
 ###### **Options:**
 
-- `--base <BRANCH>` — Override the base bookmark. Default: closest ancestor bookmark on the stack, falling back to the remote's `main` / `master` / configured `default_base_branch`
+- `--base <BRANCH>` — Override the base bookmark. Default: closest ancestor bookmark on the stack, falling back to jj `trunk()`, then to the configured `default_base_branch`. Errors if none resolve
 - `--draft <DRAFT>` — Force the PR to be a draft. Overrides config (default: `draft = false`). Use `--no-draft` to force non-draft
 - `--no-draft` — Force the PR to be non-draft. Overrides config
 - `--auto-merge <AUTO_MERGE>` — Enable auto-merge on the PR after creation (merges once required checks pass). Overrides config (default: `auto_merge = false`). Use `--no-auto-merge` to force no auto-merge
@@ -87,14 +87,20 @@ Opens your editor to a markdown file where you can write the PR description, and
 
 - `-T`, `--template <TEMPLATE>` — jj template string used to render the PR body. Evaluated against the revset being PR'd in chronological order (`--reversed`), so a multi-commit stack renders bottom-up.
 
-  All standard jj template builtins are available (`description`, `commit_id`, `author`, etc.). The following string aliases are also injected:
-  - `pr_title`: default title (first-line description of the oldest commit on the stack). - `pr_base`: resolved base branch. - `pr_head_branch`: existing local bookmark on the rev, or empty if the rev is unpushed. - `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in the revset. Because the template runs once per commit in the revset, static content like a fixed PR header would otherwise be duplicated N times for an N-commit stack. Comparing `commit_id.short(40) == pr_oldest_rev_id` lets the template emit such content exactly once, at the bottom-most commit (which lands at the top of the output thanks to `--reversed`).
-
   Mutually exclusive with `--template-file` and `--no-template`.
+
+  All standard jj template builtins are available (`description`, `commit_id`, `author`, etc.). The following template aliases are also injected:
+  - `pr_title`: default title (first-line description of the oldest commit on the stack).
+
+  - `pr_base`: resolved base branch.
+
+  - `pr_head_branch`: existing local bookmark on the rev, or empty if the rev is unpushed.
+
+  - `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in the revset.
 
 - `--template-file <PATH_OR_NAME>` — Path or name (under `.github/PULL_REQUEST_TEMPLATE/`) of a markdown template file to use as the PR body. Mutually exclusive with `-T` and `--no-template`
 - `--no-template` — Skip body templating entirely
-- `-e`, `--editor <CMD>` — Editor command; shell-words split, e.g. `--editor "nvim +7"`. Default: `editor` in config, then `$VISUAL`, then `$EDITOR`
+- `-e`, `--editor <CMD>` — Editor command, e.g. `--editor "nvim +7"`. Default: `editor` in config, then `$VISUAL`, then `$EDITOR`
 
 ## `jj-gh pr fetch`
 
@@ -116,8 +122,22 @@ See: <https://github.com/jj-vcs/jj/issues/4388>
 
 - `-T`, `--template <TEMPLATE>` — Override the bookmark template. The argument is a jj template string evaluated once against `root()` (no commit context). Default: `pr_fetch_bookmark_template` in config, else `"pr-" ++ pr_number ++ "/" ++ pr_branch"`.
 
-  Injected string aliases (each is already double-quoted, so use them directly without wrapping in `"..."`):
-  - `pr_number`: PR number as a decimal string. - `pr_title`: PR title. - `pr_branch`: head ref name (the source branch on the PR's fork). - `pr_url`: PR's `html_url`. - `pr_head_sha`: 40-char hex commit SHA of the PR's head. - `pr_head_user`: PR's head fork owner login, or empty if the fork was deleted. - `pr_head_repo`: PR's head fork repository name, or empty if the fork was deleted. - `pr_slug`: sanitized lowercase ASCII slug of the title (max 50 chars), suitable for embedding in a bookmark name.
+  All standard jj template builtins are available (`description`, `commit_id`, `author`, etc.). The following template aliases are also injected:
+  - `pr_number`: PR number as a decimal string.
+
+  - `pr_title`: PR title.
+
+  - `pr_branch`: head ref name (the source branch on the PR's fork).
+
+  - `pr_url`: PR's `html_url`.
+
+  - `pr_head_sha`: 40-char hex commit SHA of the PR's head.
+
+  - `pr_head_user`: PR's head fork owner login, or empty if the fork was deleted.
+
+  - `pr_head_repo`: PR's head fork repository name, or empty if the fork was deleted.
+
+  - `pr_slug`: sanitized lowercase ASCII slug of the title (max 50 chars), suitable for embedding in a bookmark name.
 
 - `-f`, `--force` — Replace an existing local bookmark of the same name
 
@@ -158,7 +178,7 @@ Resolves the PR from a revision (via its local bookmark) or a PR number, fetches
 ###### **Options:**
 
 - `-f`, `--force` — Edit even if the PR body is empty. By default, `jj-gh` refuses to edit an empty body to avoid clobbering one that exists but failed to load
-- `-e`, `--editor <CMD>` — Editor command; shell-words split, e.g. `--editor "nvim +7"`. Default: `editor` in config, then `$VISUAL`, then `$EDITOR`
+- `-e`, `--editor <CMD>` — Editor command, e.g. `--editor "nvim +7"`. Default: `editor` in config, then `$VISUAL`, then `$EDITOR`
 
 ## `jj-gh pr log`
 
@@ -166,23 +186,30 @@ Like `jj log`, but injects PR metadata (e.g. number, CI status, URL).
 
 This works by injecting template aliases keyed by `commit_id` and renders inline PR info in a temporary config file added via `jj`'s `--config-file` argument. Any arguments after `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`. A default template that mirror's `jj`'s default template is provided, but you may provide your own with the `-T|--template` argument and use the injected template aliases.
 
-The following template aliases are available for use if you pass your own template instead of using the default:
-
-`pr_number`, `pr_url`, `pr_ci_status`, `pr_merge_status`, `pr_meta` (formatted string containing all PR information).
-
 **Usage:** `jj-gh pr log [OPTIONS] [-- <JJ_LOG_ARGS>...]`
 
 **Command Alias:** `l`
 
 ###### **Arguments:**
 
-- `<JJ_LOG_ARGS>` — Arguments forwarded verbatim to the underlying `jj log` invocation. Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`. If you pass `-T` / `--template`, the default PR-aware template is not applied; the following per-commit aliases are then available in your own template, each keyed on `commit_id`:
-  - `pr_number`: PR number as a string, or empty for commits without a PR. - `pr_url`: PR URL, or empty. - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty. - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or empty. - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon plus merge status (empty for commits without a PR).
+- `<JJ_LOG_ARGS>` — Arguments forwarded verbatim to the underlying `jj log` invocation. Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`. If you pass `-T` / `--template`, the default PR-aware template is not applied.
+
+  All standard jj template builtins are available (`description`, `commit_id`, `author`, etc.). The following template aliases are also injected:
+  - `pr_number`: PR number as a string, or empty for commits without a PR.
+
+  - `pr_url`: PR URL, or empty.
+
+  - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty.
+
+  - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or empty.
+
+  - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon plus merge status.
 
 ###### **Options:**
 
 - `--nerdfonts <NERDFONTS>` — Force enable the use of nerdfont icons in the default `pr log` template. Overrides config. Use `--no-nerdfonts` to disable
 - `--no-nerdfonts` — Force the default `pr log` template not to use nerdfont icons. Overrides config
+- `-T <TEMPLATE>` — Override `pr_log_template` from config for this invocation. Sets the body of the default `pr_log` template alias jj-gh injects. Has no effect if you pass your own `-T` / `--template` in forwarded `jj log` args (after `--`)
 
 ## `jj-gh pr restack`
 
@@ -202,7 +229,9 @@ Restack does not rewrite the jj graph; the user shapes the graph first (e.g. via
 
 - `--dry-run` — Print the proposed plan and exit without launching the TUI. No PR is updated. Auto-enabled when stdout is not a terminal
 - `--json` — Emit the proposed plan as JSON. Implies `--dry-run`
-- `-T`, `--template <TEMPLATE>` — Template to use in interactive mode; conflicts with `--json` and `--dry-run`
+- `-T`, `--template <TEMPLATE>` — Template to use in interactive mode; conflicts with `--json` and `--dry-run`. The same template aliases as `pr log` are injected here. See `jj-gh pr log --help`
+- `--nerdfonts <NERDFONTS>` — Force enable nerdfont icons in the default restack/log template. Overrides config. Use `--no-nerdfonts` to disable
+- `--no-nerdfonts` — Force the default restack/log template not to use nerdfont icons. Overrides config
 
 ## `jj-gh pr retry-failed`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,8 +6,8 @@ use clap::{
     builder::{Styles, styling::AnsiColor},
 };
 use clap_complete::Shell;
+use jj_gh_config_derive::subcommand_args;
 use log::LevelFilter;
-use serde::Serialize;
 use std::io::IsTerminal;
 
 const STYLES: Styles = Styles::styled()
@@ -23,47 +23,54 @@ const STYLES: Styles = Styles::styled()
 #[command(name = "jj-gh", version, about, styles = STYLES)]
 pub struct Cli {
     #[command(flatten)]
-    pub global: GlobalOpts,
+    pub global: GlobalOptsInput,
 
     #[command(subcommand)]
     pub command: Command,
 }
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct GlobalOpts {
-    /// Increase log verbosity (repeat for more, e.g. `-vv`).
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, global = true)]
-    #[serde(skip)]
-    pub verbose: u8,
+subcommand_args! {
+    #[no_globals]
+    pub struct GlobalOpts {
+        /// Increase log verbosity (repeat for more, e.g. `-vv`).
+        #[arg(short = 'v', long, action = clap::ArgAction::Count, global = true)]
+        pub verbose: u8,
 
-    /// Drop log level to `ERROR`.
-    #[arg(short = 'q', long = "quiet", global = true, conflicts_with = "verbose")]
-    #[serde(skip)]
-    pub quiet: bool,
+        /// Drop log level to `ERROR`.
+        #[arg(short = 'q', long, global = true, conflicts_with = "verbose")]
+        pub quiet: bool,
 
-    /// Set log level explicitly, overrides `-v` and `-q`.
-    #[arg(long = "log-level", value_name = "LEVEL", global = true)]
-    #[serde(skip)]
-    pub log_level: Option<LevelFilter>,
+        /// Set log level explicitly, overrides `-v` and `-q`.
+        #[arg(long, value_name = "LEVEL", global = true)]
+        pub log_level: Option<LevelFilter>,
 
-    /// Git remote used for the user's own pushes and PR head lookups.
-    /// Overrides config `default_remote` (default: `origin`).
-    #[arg(long = "remote", value_name = "NAME", global = true)]
-    #[serde(rename = "default_remote", skip_serializing_if = "Option::is_none")]
-    pub remote: Option<String>,
+        /// Git remote used for the user's own pushes and PR head lookups.
+        /// Default: `origin` (or `default_remote` in config).
+        #[arg(long, value_name = "NAME", global = true)]
+        #[config(maps_to = "default_remote")]
+        pub remote: String,
 
-    /// Git remote used as the PR target in fork workflows. Overrides config
-    /// `upstream_remote` (default: `upstream`).
-    #[arg(long = "upstream-remote", value_name = "NAME", global = true)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub upstream_remote: Option<String>,
+        /// Git remote used as the PR target in fork workflows. Default:
+        /// `upstream` (or `upstream_remote` in config).
+        #[arg(long, value_name = "NAME", global = true)]
+        #[config]
+        pub upstream_remote: String,
 
-    #[command(flatten)]
-    #[serde(flatten)]
-    pub auth: AuthArgs,
+        /// Askpass helper command that prints a GitHub token on stdout;
+        /// shell-words split, e.g. `--gh-askpass "op read op://Vault/gh/token"`.
+        /// Default: `gh_askpass` in config, then `$GH_ASKPASS`.
+        #[arg(long, value_name = "CMD", value_parser = shell_words::split, global = true)]
+        #[config]
+        pub gh_askpass: Option<Vec<String>>,
+
+        /// Timeout in seconds for the askpass helper. Default: 20.
+        #[arg(long = "askpass-timeout", value_name = "SECS", global = true)]
+        #[config]
+        pub askpass_timeout_secs: u64,
+    }
 }
 
-impl GlobalOpts {
+impl GlobalOptsInput {
     pub fn resolve_log_level(&self) -> LevelFilter {
         if let Some(level) = self.log_level {
             return level;
@@ -111,28 +118,13 @@ pub enum Command {
         /// Emit an overlay for `jj <NAME> <tab>` instead of the standalone
         /// `jj-gh` script. Pass the jj alias name (e.g. `pr`). Must be
         /// paired with `--subcommand`.
-        #[arg(long = "jj-alias", value_name = "NAME", requires = "jj_gh_subcommand")]
+        #[arg(long, value_name = "NAME", requires = "jj_gh_subcommand")]
         jj_alias: Option<String>,
         /// jj-gh top-level subcommand whose tree the overlay describes
         /// (e.g. `pr`). Must be paired with `--jj-alias`.
         #[arg(long = "subcommand", value_name = "NAME", requires = "jj_alias")]
         jj_gh_subcommand: Option<SubcommandStr>,
     },
-}
-
-#[derive(Debug, clap::Args, Serialize)]
-pub struct AuthArgs {
-    /// Askpass helper command that prints a GitHub token on stdout;
-    /// shell-words split, e.g. `--gh-askpass "op read op://Vault/gh/token"`.
-    /// Default: `gh_askpass` in config, then `$GH_ASKPASS`.
-    #[arg(long = "gh-askpass", value_name = "CMD", value_parser = shell_words::split)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gh_askpass: Option<Vec<String>>,
-
-    /// Timeout in seconds for the askpass helper. Default: 20.
-    #[arg(long = "askpass-timeout", value_name = "SECS")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub askpass_timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,54 +24,69 @@ use figment::{
     providers::Serialized,
     value::{Dict, Map},
 };
+use jj_gh_config_derive::config_schema;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Deserialize)]
-#[cfg_attr(feature = "schema-validation", derive(schemars::JsonSchema))]
-#[serde(default)]
-pub struct Config {
-    pub gh_askpass: Option<Vec<String>>,
-    pub askpass_timeout_secs: u64,
-    #[cfg_attr(feature = "schema-validation", schemars(with = "Option<String>"))]
-    pub gh_token: Option<SecretString>,
-    pub default_base_branch: String,
-    pub default_remote: String,
-    pub upstream_remote: String,
-    pub pr_create_template_file: Option<PathBuf>,
-    pub pr_create_template: Option<String>,
-    pub draft: bool,
-    pub auto_merge: bool,
-    pub auto_merge_method: AutoMergeMethod,
-    pub editor: Option<Vec<String>>,
-    pub pr_fetch_bookmark_template: Option<String>,
-    pub pr_log_template: Option<String>,
-    pub pr_restack_template: Option<String>,
-    pub nerdfonts: bool,
-}
+config_schema! {
+    /// Askpass helper command that prints a GitHub token on stdout.
+    #[env("GH_ASKPASS", argv)]
+    gh_askpass: Option<Vec<String>> = None,
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            gh_askpass: None,
-            askpass_timeout_secs: 20,
-            gh_token: None,
-            default_base_branch: "master".into(),
-            default_remote: "origin".into(),
-            upstream_remote: "upstream".into(),
-            pr_create_template_file: None,
-            pr_create_template: None,
-            draft: false,
-            auto_merge: false,
-            auto_merge_method: AutoMergeMethod::default(),
-            editor: None,
-            pr_fetch_bookmark_template: None,
-            pr_log_template: None,
-            pr_restack_template: None,
-            nerdfonts: true,
-        }
-    }
+    /// Timeout in seconds for the askpass helper.
+    askpass_timeout_secs: u64 = 20,
+
+    /// GitHub auth token. Never logged. Resolved via askpass when absent.
+    /// `SecretString` does not impl `Serialize` (intentional; we never emit
+    /// it back to figment), so the serde skip is per-field rather than via
+    /// the macro's default `skip_serializing_if = "Option::is_none"`.
+    #[serde(skip_serializing)]
+    #[forward(cfg_attr(feature = "schema-validation", schemars(with = "Option<String>")))]
+    gh_token: Option<SecretString> = None,
+
+    /// Fallback base branch when neither `--base` nor an ancestor bookmark
+    /// nor jj `trunk()` resolves. If none of the above resolve, and this
+    /// option is not set, an error will occur.
+    default_base_branch: Option<String> = None,
+
+    /// Git remote used for the user's own pushes and PR head lookups.
+    default_remote: String = "origin".into(),
+
+    /// Git remote used as the PR target in fork workflows.
+    upstream_remote: String = "upstream".into(),
+
+    /// Path to a markdown template file used as the PR body.
+    #[env("JJ_GH_TEMPLATE_FILE", path)]
+    pr_create_template_file: Option<PathBuf> = None,
+
+    /// jj template string used to render the PR body.
+    #[env("JJ_GH_TEMPLATE", string)]
+    pr_create_template: Option<String> = None,
+
+    /// Open new PRs as drafts.
+    draft: bool = false,
+
+    /// Enable auto-merge on newly created PRs.
+    auto_merge: bool = false,
+
+    /// Merge method used when auto-merge is enabled.
+    auto_merge_method: AutoMergeMethod = AutoMergeMethod::Merge,
+
+    /// Editor command for the PR editor flow.
+    editor: Option<Vec<String>> = None,
+
+    /// jj template used to render the bookmark name in `pr fetch`.
+    pr_fetch_bookmark_template: Option<String> = None,
+
+    /// jj template used by `pr log`.
+    pr_log_template: Option<String> = None,
+
+    /// jj template used by `pr restack`. Falls back to `pr_log_template`.
+    pr_restack_template: Option<String> = None,
+
+    /// Render Nerd-Fonts glyphs in TUI output.
+    nerdfonts: bool = true,
 }
 
 /// GitHub merge method used when enabling auto-merge on a PR.
@@ -95,14 +110,14 @@ pub fn load_figment() -> Figment {
     for path in discover_layers() {
         fig = fig.merge(JjConfProvider::from_file(path));
     }
-    fig.merge(Serialized::defaults(EnvOverlay::from_env()))
+    fig.merge(Serialized::defaults(env_overlay()))
 }
 
-/// A [`Figment`] preloaded with the built-in defaults. Compose [`JjToolsProvider`]s
+/// A [`Figment`] preloaded with the built-in defaults. Compose [`JjConfProvider`]s
 /// onto this for hermetic tests, then hand to [`extract`].
 #[must_use]
 pub fn defaults_figment() -> Figment {
-    Figment::from(Serialized::defaults(DefaultsOverlay::from_defaults()))
+    Figment::from(Serialized::defaults(Config::default()))
 }
 
 /// PR-body template values resolved against a single jj config layer (or a
@@ -305,86 +320,6 @@ fn extract_jj_gh_subtree(contents: &str) -> Result<Option<toml::Table>, SourceEr
     Ok(Some(table))
 }
 
-#[derive(Serialize)]
-struct DefaultsOverlay {
-    askpass_timeout_secs: u64,
-    default_base_branch: String,
-    default_remote: String,
-    upstream_remote: String,
-    draft: bool,
-    auto_merge: bool,
-    auto_merge_method: AutoMergeMethod,
-    nerdfonts: bool,
-}
-
-impl DefaultsOverlay {
-    fn from_defaults() -> Self {
-        let Config {
-            askpass_timeout_secs,
-            auto_merge,
-            auto_merge_method,
-            default_base_branch,
-            default_remote,
-            upstream_remote,
-            draft,
-            nerdfonts,
-            editor: _,
-            gh_askpass: _,
-            gh_token: _,
-            pr_fetch_bookmark_template: _,
-            pr_log_template: _,
-            pr_restack_template: _,
-            pr_create_template: _,
-            pr_create_template_file: _,
-        } = Config::default();
-        Self {
-            askpass_timeout_secs,
-            default_base_branch,
-            default_remote,
-            upstream_remote,
-            draft,
-            auto_merge,
-            auto_merge_method,
-            nerdfonts,
-        }
-    }
-}
-
-#[derive(Serialize)]
-struct EnvOverlay {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    gh_askpass: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pr_create_template: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pr_create_template_file: Option<PathBuf>,
-}
-
-impl EnvOverlay {
-    fn from_env() -> Self {
-        Self {
-            gh_askpass: read_argv_env("GH_ASKPASS"),
-            pr_create_template: read_string_env("JJ_GH_TEMPLATE"),
-            pr_create_template_file: read_path_env("JJ_GH_TEMPLATE_FILE"),
-        }
-    }
-}
-
-fn read_path_env(key: &str) -> Option<PathBuf> {
-    std::env::var_os(key)
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-}
-
-fn read_string_env(key: &str) -> Option<String> {
-    std::env::var(key).ok().filter(|s| !s.is_empty())
-}
-
-fn read_argv_env(key: &str) -> Option<Vec<String>> {
-    let raw = std::env::var(key).ok().filter(|s| !s.is_empty())?;
-    shell_words::split(&raw).ok().filter(|v| !v.is_empty())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -402,7 +337,7 @@ mod tests {
     fn defaults_when_no_layers() {
         let config = from_layers([]).unwrap();
         assert_eq!(config.askpass_timeout_secs, 20);
-        assert_eq!(config.default_base_branch, "master");
+        assert_eq!(config.default_base_branch, None);
         assert!(!config.draft);
         assert!(config.gh_token.is_none());
     }
@@ -410,7 +345,7 @@ mod tests {
     #[test]
     fn absent_source_is_non_fatal() {
         let config = from_layers([JjConfProvider::from_absent("global")]).unwrap();
-        assert_eq!(config.default_base_branch, "master");
+        assert_eq!(config.default_base_branch, None);
     }
 
     #[test]
@@ -433,7 +368,7 @@ mod tests {
             ),
         ])
         .unwrap();
-        assert_eq!(config.default_base_branch, "trunk");
+        assert_eq!(config.default_base_branch.as_deref(), Some("trunk"));
         assert_eq!(config.askpass_timeout_secs, 5);
     }
 
@@ -471,7 +406,7 @@ mod tests {
             "#,
         )])
         .unwrap();
-        assert_eq!(config.default_base_branch, "main");
+        assert_eq!(config.default_base_branch.as_deref(), Some("main"));
     }
 
     #[test]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     auth,
-    cli::{DebugAction, GlobalOpts},
+    cli::{DebugAction, GlobalOpts, GlobalOptsInput},
     config::{self, Config},
     gh::{Gh, real::OctocrabGh},
     git::url::parse_owner_repo,
@@ -18,35 +18,42 @@ use figment::providers::Serialized;
 ///
 /// Returns an error from the underlying operation; for `auth` this means token
 /// resolution failed, for `rev`/`pr-lookup` the jj or GH read failed.
-pub async fn dispatch(global: &GlobalOpts, action: DebugAction) -> Result<()> {
+pub async fn dispatch(global: GlobalOptsInput, action: DebugAction) -> Result<()> {
+    let (globals, config) = resolve_globals(global)?;
     match action {
-        DebugAction::Config => print_config(global),
-        DebugAction::Auth => check_auth(global).await,
-        DebugAction::Rev { rev } => print_rev(global, &rev).await,
-        DebugAction::PrLookup { rev } => print_pr_lookup(global, &rev).await,
+        DebugAction::Config => {
+            println!("{config:#?}");
+            Ok(())
+        }
+        DebugAction::Auth => check_auth(&config).await,
+        DebugAction::Rev { rev } => print_rev(&globals, &config, &rev).await,
+        DebugAction::PrLookup { rev } => print_pr_lookup(&globals, &config, &rev).await,
     }
 }
 
-fn load_config(global: &GlobalOpts) -> Result<Config> {
-    let fig = config::load_figment().merge(Serialized::defaults(global));
-    config::extract(&fig)
+fn resolve_globals(global: GlobalOptsInput) -> Result<(GlobalOpts, Config)> {
+    let fig = config::load_figment().merge(Serialized::defaults(&global));
+    let config = config::extract(&fig)?;
+    let globals = GlobalOpts::resolve(global, &config);
+    Ok((globals, config))
 }
 
-fn print_config(global: &GlobalOpts) -> Result<()> {
-    let config = load_config(global)?;
-    println!("{config:#?}");
-    Ok(())
-}
-
-async fn check_auth(global: &GlobalOpts) -> Result<()> {
-    let config = load_config(global)?;
-    auth::resolve_token(&config).await?;
+async fn check_auth(config: &Config) -> Result<()> {
+    auth::resolve_token(config).await?;
     println!("ok");
     Ok(())
 }
 
-async fn print_rev(global: &GlobalOpts, rev: &str) -> Result<()> {
-    let config = load_config(global)?;
+async fn print_rev(globals: &GlobalOpts, _config: &Config, rev: &str) -> Result<()> {
+    let GlobalOpts {
+        remote,
+        upstream_remote,
+        verbose: _,
+        quiet: _,
+        log_level: _,
+        gh_askpass: _,
+        askpass_timeout_secs: _,
+    } = globals;
     let jj = JjCli::new().await?;
 
     let CommitInfo {
@@ -59,14 +66,11 @@ async fn print_rev(global: &GlobalOpts, rev: &str) -> Result<()> {
     let title_revset = jj::title_base_revset(rev, ancestor.as_deref());
     let default_title = jj.first_commit_description(&title_revset).await?;
 
-    let origin_url = jj.remote_url(&config.default_remote).await?;
-    let upstream_url = jj.remote_url(&config.upstream_remote).await?;
+    let origin_url = jj.remote_url(remote).await?;
+    let upstream_url = jj.remote_url(upstream_remote).await?;
     let default_branch = jj.trunk_branch().await?;
     let default_branch_sha = match &default_branch {
-        Some(branch) => {
-            jj.remote_bookmark_sha(branch, &config.default_remote)
-                .await?
-        }
+        Some(branch) => jj.remote_bookmark_sha(branch, remote).await?,
         None => None,
     };
 
@@ -91,13 +95,21 @@ async fn print_rev(global: &GlobalOpts, rev: &str) -> Result<()> {
     Ok(())
 }
 
-async fn print_pr_lookup(global: &GlobalOpts, rev: &str) -> Result<()> {
-    let config = load_config(global)?;
+async fn print_pr_lookup(globals: &GlobalOpts, config: &Config, rev: &str) -> Result<()> {
+    let GlobalOpts {
+        remote,
+        upstream_remote,
+        verbose: _,
+        quiet: _,
+        log_level: _,
+        gh_askpass: _,
+        askpass_timeout_secs: _,
+    } = globals;
     let jj = JjCli::new().await?;
-    let token = auth::resolve_token(&config).await?;
+    let token = auth::resolve_token(config).await?;
     let gh = OctocrabGh::new(&token)?;
 
-    let lookup = pr::resolve_pr_for_rev(&jj, &gh, &config, rev).await?;
+    let lookup = pr::resolve_pr_for_rev(&jj, &gh, remote, upstream_remote, rev).await?;
     let base = gh
         .lookup_base(
             &lookup.target.owner,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod git;
 mod jj;
 mod pr;
 mod ui;
+mod util;
 
 pub mod logging;
 
@@ -28,8 +29,8 @@ pub async fn dispatch(bin_name: &str) -> anyhow::Result<()> {
     let _logger = logging::init(args.global.resolve_log_level())?;
     let global = args.global;
     match args.command {
-        Command::Pr { action } => pr::dispatch(&global, action).await?,
-        Command::Debug { action } => debug::dispatch(&global, action).await?,
+        Command::Pr { action } => pr::dispatch(global, action).await?,
+        Command::Debug { action } => debug::dispatch(global, action).await?,
         Command::Completions {
             shell,
             jj_alias,

--- a/src/pr/auto_merge.rs
+++ b/src/pr/auto_merge.rs
@@ -1,44 +1,46 @@
-use crate::{
-    config::{AutoMergeMethod, Config},
-    gh::Gh,
-    jj::Jj,
-    pr::{self},
-};
+use crate::{cli::GlobalOpts, config::AutoMergeMethod, gh::Gh, jj::Jj, pr};
 use anyhow::{Context, Result};
-use serde::Serialize;
+use jj_gh_config_derive::subcommand_args;
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct AutoMergeArgs {
-    /// PR number, or revision ID to look up a PR from.
-    #[arg(value_name = "PR_NUM|REV")]
-    #[serde(skip)]
-    pub number_or_rev: String,
+subcommand_args! {
+    pub struct AutoMergeArgs {
+        /// PR number, or revision ID to look up a PR from.
+        #[arg(value_name = "PR_NUM|REV")]
+        pub number_or_rev: String,
 
-    /// Merge method used when enabling auto-merge. Overrides config
-    /// `auto_merge_method` (default `merge`).
-    #[arg(long = "method", short = 'm', value_name = "METHOD", value_enum)]
-    #[serde(rename = "auto_merge_method", skip_serializing_if = "Option::is_none")]
-    pub method: Option<AutoMergeMethod>,
+        /// Merge method used when enabling auto-merge. Overrides config
+        /// `auto_merge_method` (default `merge`).
+        #[arg(long = "method", short = 'm', value_name = "METHOD", value_enum)]
+        #[config]
+        pub auto_merge_method: AutoMergeMethod,
+    }
 }
 
-pub async fn run<J, G>(jj: &J, gh: &G, config: &Config, args: &AutoMergeArgs) -> Result<()>
+pub async fn run<J, G>(jj: &J, gh: &G, args: &AutoMergeArgs) -> Result<()>
 where
     J: Jj,
     G: Gh,
 {
     let AutoMergeArgs {
         number_or_rev,
-        method,
+        auto_merge_method,
+        globals:
+            GlobalOpts {
+                remote,
+                upstream_remote,
+                verbose: _,
+                quiet: _,
+                log_level: _,
+                gh_askpass: _,
+                askpass_timeout_secs: _,
+            },
     } = args;
-    let pr = pr::get_pr(jj, gh, config, number_or_rev).await?;
 
-    gh.enable_auto_merge(
-        &pr.graphql_node_id,
-        pr.in_merge_queue,
-        method.unwrap_or(config.auto_merge_method),
-    )
-    .await
-    .with_context(|| format!("enabling auto-merge on #{}", pr.number))?;
+    let pr = pr::get_pr(jj, gh, remote, upstream_remote, number_or_rev).await?;
+
+    gh.enable_auto_merge(&pr.graphql_node_id, pr.in_merge_queue, *auto_merge_method)
+        .await
+        .with_context(|| format!("enabling auto-merge on #{}", pr.number))?;
 
     log::info!("Enabled auto-merge for PR");
     println!("{}", pr.html_url);

--- a/src/pr/editor/create.rs
+++ b/src/pr/editor/create.rs
@@ -1,114 +1,106 @@
 use crate::{
     auth::EnvReader,
-    config::{AutoMergeMethod, Config},
+    cli::GlobalOpts,
+    config::AutoMergeMethod,
     gh::{CreatePrRequest, Gh, remote},
     jj::{self, Jj},
+    logging::ResultExt,
     pr::{
         editor::{self, ApplyChangesCtx, Editor, resolve_editor_argv},
         frontmatter::Frontmatter,
-        load_template_for, resolve_base, validation,
+        load_template_for, validation,
     },
 };
 use anyhow::{Context, Result, anyhow};
-use serde::Serialize;
+use jj_gh_config_derive::subcommand_args;
 use std::collections::HashMap;
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct CreateArgs {
-    /// Revision to create the PR from.
-    #[arg(value_name = "REV")]
-    #[serde(skip)]
-    pub rev: String,
+subcommand_args! {
+    pub struct CreateArgs {
+        /// Revision to create the PR from.
+        #[arg(value_name = "REV")]
+        pub rev: String,
 
-    /// Override the base bookmark. Default: closest ancestor bookmark on the
-    /// stack, falling back to the remote's `main` / `master` / configured
-    /// `default_base_branch`.
-    #[arg(long, value_name = "BRANCH")]
-    #[serde(skip)]
-    pub base: Option<String>,
+        /// Override the base bookmark. Default: closest ancestor bookmark on
+        /// the stack, falling back to jj `trunk()`, then to the configured
+        /// `default_base_branch`. Errors if none resolve.
+        #[arg(long, value_name = "BRANCH")]
+        #[config(fallback = "default_base_branch")]
+        pub base: Option<String>,
 
-    /// Force the PR to be a draft. Overrides config (default: `draft = false`).
-    /// Use `--no-draft` to force non-draft.
-    #[arg(
-        long,
-        num_args = 0,
-        default_missing_value = "true",
-        default_value_if("no_draft", "true", Some("false"))
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub draft: Option<bool>,
+        /// Force the PR to be a draft. Overrides config (default: `draft = false`).
+        /// Use `--no-draft` to force non-draft.
+        #[arg(
+            long,
+            num_args = 0,
+            default_missing_value = "true",
+            default_value_if("no_draft", "true", Some("false"))
+        )]
+        #[config]
+        pub draft: bool,
 
-    /// Force the PR to be non-draft. Overrides config.
-    #[arg(long = "no-draft", conflicts_with = "draft")]
-    #[serde(skip)]
-    pub no_draft: bool,
+        /// Force the PR to be non-draft. Overrides config.
+        #[arg(long, conflicts_with = "draft")]
+        pub no_draft: bool,
 
-    /// Enable auto-merge on the PR after creation (merges once required checks
-    /// pass). Overrides config (default: `auto_merge = false`). Use
-    /// `--no-auto-merge` to force no auto-merge.
-    #[arg(
-        long = "auto-merge",
-        num_args = 0,
-        default_missing_value = "true",
-        default_value_if("no_auto_merge", "true", Some("false"))
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_merge: Option<bool>,
+        /// Enable auto-merge on the PR after creation (merges once required checks
+        /// pass). Overrides config (default: `auto_merge = false`). Use
+        /// `--no-auto-merge` to force no auto-merge.
+        #[arg(
+            long,
+            num_args = 0,
+            default_missing_value = "true",
+            default_value_if("no_auto_merge", "true", Some("false"))
+        )]
+        #[config]
+        pub auto_merge: bool,
 
-    /// Disable auto-merge on the created PR. Overrides config.
-    #[arg(long = "no-auto-merge", conflicts_with = "auto_merge")]
-    #[serde(skip)]
-    pub no_auto_merge: bool,
+        /// Disable auto-merge on the created PR. Overrides config.
+        #[arg(long, conflicts_with = "auto_merge")]
+        pub no_auto_merge: bool,
 
-    /// Merge method used when auto-merge is enabled. Overrides config
-    /// `auto_merge_method` (default `merge`).
-    #[arg(long = "auto-merge-method", value_name = "METHOD", value_enum)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_merge_method: Option<AutoMergeMethod>,
+        /// Merge method used when auto-merge is enabled. Overrides config
+        /// `auto_merge_method` (default `merge`).
+        #[arg(long, value_name = "METHOD", value_enum)]
+        #[config]
+        pub auto_merge_method: AutoMergeMethod,
 
-    /// jj template string used to render the PR body. Evaluated against the
-    /// revset being PR'd in chronological order (`--reversed`), so a
-    /// multi-commit stack renders bottom-up.
-    ///
-    /// All standard jj template builtins are available (`description`,
-    /// `commit_id`, `author`, etc.). The following string aliases are also
-    /// injected:
-    ///
-    /// - `pr_title`: default title (first-line description of the oldest
-    ///   commit on the stack).
-    /// - `pr_base`: resolved base branch.
-    /// - `pr_head_branch`: existing local bookmark on the rev, or empty if
-    ///   the rev is unpushed.
-    /// - `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in
-    ///   the revset. Because the template runs once per commit in the
-    ///   revset, static content like a fixed PR header would otherwise be
-    ///   duplicated N times for an N-commit stack. Comparing
-    ///   `commit_id.short(40) == pr_oldest_rev_id` lets the template emit
-    ///   such content exactly once, at the bottom-most commit (which lands
-    ///   at the top of the output thanks to `--reversed`).
-    ///
-    /// Mutually exclusive with `--template-file` and `--no-template`.
-    #[arg(short = 'T', long, value_name = "TEMPLATE", conflicts_with_all = ["template_file", "no_template"])]
-    #[serde(skip)]
-    pub template: Option<String>,
+        /// jj template string used to render the PR body. Evaluated against the
+        /// revset being PR'd in chronological order (`--reversed`), so a
+        /// multi-commit stack renders bottom-up.
+        ///
+        /// Mutually exclusive with `--template-file` and `--no-template`.
+        ///
+        /// All standard jj template builtins are available (`description`,
+        /// `commit_id`, `author`, etc.). The following template aliases are also
+        /// injected:
+        ///
+        /// - `pr_title`: default title (first-line description of the oldest commit on the stack).
+        ///
+        /// - `pr_base`: resolved base branch.
+        ///
+        /// - `pr_head_branch`: existing local bookmark on the rev, or empty if the rev is unpushed.
+        ///
+        /// - `pr_oldest_rev_id`: 40-char hex commit SHA of the oldest commit in the revset.
+        #[arg(short = 'T', long, value_name = "TEMPLATE", conflicts_with_all = ["template_file", "no_template"])]
+        pub template: Option<String>,
 
-    /// Path or name (under `.github/PULL_REQUEST_TEMPLATE/`) of a markdown
-    /// template file to use as the PR body. Mutually exclusive with `-T` and
-    /// `--no-template`.
-    #[arg(long = "template-file", value_name = "PATH_OR_NAME", conflicts_with_all = ["template", "no_template"])]
-    #[serde(skip)]
-    pub template_file: Option<String>,
+        /// Path or name (under `.github/PULL_REQUEST_TEMPLATE/`) of a markdown
+        /// template file to use as the PR body. Mutually exclusive with `-T` and
+        /// `--no-template`.
+        #[arg(long, value_name = "PATH_OR_NAME", conflicts_with_all = ["template", "no_template"])]
+        pub template_file: Option<String>,
 
-    /// Skip body templating entirely.
-    #[arg(long = "no-template", conflicts_with_all = ["template", "template_file"])]
-    #[serde(skip)]
-    pub no_template: bool,
+        /// Skip body templating entirely.
+        #[arg(long, conflicts_with_all = ["template", "template_file"])]
+        pub no_template: bool,
 
-    /// Editor command; shell-words split, e.g. `--editor "nvim +7"`. Default:
-    /// `editor` in config, then `$VISUAL`, then `$EDITOR`.
-    #[arg(short = 'e', long, value_name = "CMD", value_parser = shell_words::split)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub editor: Option<Vec<String>>,
+        /// Editor command, e.g. `--editor "nvim +7"`. Default:
+        /// `editor` in config, then `$VISUAL`, then `$EDITOR`.
+        #[arg(short = 'e', long, value_name = "CMD", value_parser = shell_words::split)]
+        #[config]
+        pub editor: Option<Vec<String>>,
+    }
 }
 
 /// Run the full pr-create flow.
@@ -122,7 +114,6 @@ pub async fn run<J, G, E, ENV>(
     gh: &G,
     env: &ENV,
     editor: &E,
-    config: &Config,
     args: &CreateArgs,
 ) -> Result<()>
 where
@@ -131,14 +122,24 @@ where
     E: Editor,
     ENV: EnvReader,
 {
+    let GlobalOpts {
+        remote,
+        upstream_remote,
+        verbose: _,
+        quiet: _,
+        log_level: _,
+        gh_askpass: _,
+        askpass_timeout_secs: _,
+    } = &args.globals;
+
     let info = jj.resolve_rev(&args.rev).await?;
     let existing_branch = info.bookmarks.first().cloned();
 
     let origin_url = jj
-        .remote_url(&config.default_remote)
+        .remote_url(remote)
         .await?
-        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
-    let upstream_url = jj.remote_url(&config.upstream_remote).await?;
+        .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
+    let upstream_url = jj.remote_url(upstream_remote).await?;
     let target = remote::target(&origin_url, upstream_url.as_deref())?;
 
     // Pre-flight only when we already have a bookmark; an unpushed rev can't have
@@ -162,11 +163,20 @@ where
     }
 
     let ancestor = jj.stacked_ancestor_bookmark(&args.rev).await?;
-    let detected_base = jj
-        .trunk_branch()
-        .await?
-        .unwrap_or_else(|| config.default_base_branch.clone());
-    let base = resolve_base(args, ancestor.as_deref(), &detected_base);
+    let base = args
+        .base
+        .resolve_or(
+            || async {
+                if let Some(a) = &ancestor {
+                    return Some(a.clone());
+                }
+                jj.trunk_branch().await.log_err().ok().flatten()
+            },
+            "could not detect base branch: `--base` not passed, no ancestor \
+             bookmark on the stack, jj `trunk()` resolves to nothing, and \
+             `default_base_branch` is not set in config",
+        )
+        .await?;
 
     let base_lookup = gh.lookup_base(&target.owner, &target.repo, &base).await?;
     if !base_lookup.branch_exists {
@@ -194,13 +204,13 @@ where
         base: base.clone(),
         labels: vec![],
         reviewers: vec![],
-        draft: config.draft,
-        auto_merge: config.auto_merge,
-        auto_merge_method: config.auto_merge_method,
+        draft: args.draft,
+        auto_merge: args.auto_merge,
+        auto_merge_method: args.auto_merge_method,
     };
     let raw_template_body = raw_template.clone().unwrap_or_default();
 
-    let editor_argv = resolve_editor_argv(config, env)?;
+    let editor_argv = resolve_editor_argv(args.editor.as_deref(), env)?;
     let (final_fm, body) = editor::round_trip(
         editor,
         &editor_argv,

--- a/src/pr/editor/edit.rs
+++ b/src/pr/editor/edit.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth::EnvReader,
-    config::Config,
+    cli::GlobalOpts,
     gh::{Gh, PrDetails, remote::Target},
     jj::Jj,
     pr::{
@@ -10,27 +10,26 @@ use crate::{
     },
 };
 use anyhow::{Context, Result, anyhow, bail};
-use serde::Serialize;
+use jj_gh_config_derive::subcommand_args;
 use std::collections::HashMap;
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct EditArgs {
-    /// PR number, or revision ID to look up a PR from.
-    #[arg(value_name = "PR_NUM|REV")]
-    #[serde(skip)]
-    pub number_or_rev: String,
+subcommand_args! {
+    pub struct EditArgs {
+        /// PR number, or revision ID to look up a PR from.
+        #[arg(value_name = "PR_NUM|REV")]
+        pub number_or_rev: String,
 
-    /// Edit even if the PR body is empty. By default, `jj-gh` refuses to edit
-    /// an empty body to avoid clobbering one that exists but failed to load.
-    #[arg(short = 'f', long)]
-    #[serde(skip)]
-    pub force: bool,
+        /// Edit even if the PR body is empty. By default, `jj-gh` refuses to edit
+        /// an empty body to avoid clobbering one that exists but failed to load.
+        #[arg(short = 'f', long)]
+        pub force: bool,
 
-    /// Editor command; shell-words split, e.g. `--editor "nvim +7"`. Default:
-    /// `editor` in config, then `$VISUAL`, then `$EDITOR`.
-    #[arg(short = 'e', long, value_name = "CMD", value_parser = shell_words::split)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub editor: Option<Vec<String>>,
+        /// Editor command, e.g. `--editor "nvim +7"`. Default:
+        /// `editor` in config, then `$VISUAL`, then `$EDITOR`.
+        #[arg(short = 'e', long, value_name = "CMD", value_parser = shell_words::split)]
+        #[config]
+        pub editor: Option<Vec<String>>,
+    }
 }
 
 /// Fetch a PR, open the editor, and apply only the diff. Properties the user
@@ -40,23 +39,33 @@ pub struct EditArgs {
 /// # Errors
 ///
 /// Returns an error from any step (rev resolution, GH API, editor, etc.).
-pub async fn run<J, G, E, ENV>(
-    jj: &J,
-    gh: &G,
-    env: &ENV,
-    editor: &E,
-    config: &Config,
-    args: &EditArgs,
-) -> Result<()>
+pub async fn run<J, G, E, ENV>(jj: &J, gh: &G, env: &ENV, editor: &E, args: &EditArgs) -> Result<()>
 where
     J: Jj,
     G: Gh,
     E: Editor,
     ENV: EnvReader,
 {
-    let editor_argv = resolve_editor_argv(config, env)?;
+    let EditArgs {
+        number_or_rev,
+        force,
+        editor: editor_cfg,
+        globals:
+            GlobalOpts {
+                remote,
+                upstream_remote,
+                verbose: _,
+                quiet: _,
+                log_level: _,
+                gh_askpass: _,
+                askpass_timeout_secs: _,
+            },
+    } = args;
 
-    let (owner, repo, pr_number) = resolve_pr_target(jj, gh, config, &args.number_or_rev).await?;
+    let editor_argv = resolve_editor_argv(editor_cfg.as_deref(), env)?;
+
+    let (owner, repo, pr_number) =
+        resolve_pr_target(jj, gh, remote, upstream_remote, number_or_rev).await?;
     let details = gh
         .get_pr(&owner, &repo, pr_number)
         .await
@@ -78,7 +87,7 @@ where
     } = details;
 
     if body.is_empty() {
-        if args.force {
+        if *force {
             log::warn!("PR body is empty, but `--force` was passed");
         } else {
             bail!(
@@ -111,7 +120,7 @@ where
     if after_fm.base.trim().is_empty() {
         bail!("base is empty");
     }
-    if after_body.trim().is_empty() && !args.force {
+    if after_body.trim().is_empty() && !force {
         bail!("body is empty; pass `--force` to confirm");
     }
 
@@ -137,15 +146,16 @@ where
 async fn resolve_pr_target<J: Jj, G: Gh>(
     jj: &J,
     gh: &G,
-    config: &Config,
+    default_remote: &str,
+    upstream_remote: &str,
     number_or_rev: &str,
 ) -> Result<(String, String, u64)> {
     if let Ok(num) = number_or_rev.parse::<u64>() {
         let origin_url = jj
-            .remote_url(&config.default_remote)
+            .remote_url(default_remote)
             .await?
-            .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
-        let upstream_url = jj.remote_url(&config.upstream_remote).await?;
+            .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
+        let upstream_url = jj.remote_url(upstream_remote).await?;
         let target = crate::gh::remote::target(&origin_url, upstream_url.as_deref())?;
         return Ok((target.owner, target.repo, num));
     }
@@ -154,7 +164,7 @@ async fn resolve_pr_target<J: Jj, G: Gh>(
         head_spec,
         summary,
         ..
-    } = pr::resolve_pr_for_rev(jj, gh, config, number_or_rev).await?;
+    } = pr::resolve_pr_for_rev(jj, gh, default_remote, upstream_remote, number_or_rev).await?;
     let summary = summary
         .ok_or_else(|| anyhow!("no open PR for revision `{number_or_rev}` (head `{head_spec}`)"))?;
     Ok((owner, repo, summary.number))

--- a/src/pr/editor/mod.rs
+++ b/src/pr/editor/mod.rs
@@ -8,7 +8,6 @@ pub(crate) mod edit;
 
 use crate::{
     auth::EnvReader,
-    config::Config,
     gh::{Gh, Reviewer, UpdatePr},
     pr::frontmatter::Frontmatter,
 };
@@ -37,8 +36,11 @@ pub trait Editor {
 /// # Errors
 ///
 /// Returns an error if no source produced a non-empty argv.
-pub fn resolve_editor_argv<E: EnvReader>(config: &Config, env: &E) -> Result<Vec<String>> {
-    if let Some(argv) = config.editor.as_deref().filter(|v| !v.is_empty()) {
+pub fn resolve_editor_argv<E: EnvReader>(
+    editor: Option<&[String]>,
+    env: &E,
+) -> Result<Vec<String>> {
+    if let Some(argv) = editor.filter(|v| !v.is_empty()) {
         return Ok(argv.to_vec());
     }
 
@@ -229,53 +231,47 @@ mod tests {
         }
     }
 
-    fn cfg() -> Config {
-        Config::default()
-    }
-
     #[test]
     fn config_used_when_set() {
-        let mut c = cfg();
-        c.editor = Some(vec!["code".into(), "--wait".into()]);
+        let argv_cfg = vec!["code".to_string(), "--wait".into()];
         let env = FakeEnv::with(&[("VISUAL", "vim"), ("EDITOR", "vi")]);
-        let argv = resolve_editor_argv(&c, &env).unwrap();
+        let argv = resolve_editor_argv(Some(&argv_cfg), &env).unwrap();
         assert_eq!(argv, vec!["code".to_string(), "--wait".into()]);
     }
 
     #[test]
     fn visual_outranks_editor() {
         let env = FakeEnv::with(&[("VISUAL", "nvim +7"), ("EDITOR", "vi")]);
-        let argv = resolve_editor_argv(&cfg(), &env).unwrap();
+        let argv = resolve_editor_argv(None, &env).unwrap();
         assert_eq!(argv, vec!["nvim".to_string(), "+7".into()]);
     }
 
     #[test]
     fn editor_env_used_when_visual_absent() {
         let env = FakeEnv::with(&[("EDITOR", "vi")]);
-        let argv = resolve_editor_argv(&cfg(), &env).unwrap();
+        let argv = resolve_editor_argv(None, &env).unwrap();
         assert_eq!(argv, vec!["vi".to_string()]);
     }
 
     #[test]
     fn empty_visual_falls_through_to_editor() {
         let env = FakeEnv::with(&[("VISUAL", ""), ("EDITOR", "vi")]);
-        let argv = resolve_editor_argv(&cfg(), &env).unwrap();
+        let argv = resolve_editor_argv(None, &env).unwrap();
         assert_eq!(argv, vec!["vi".to_string()]);
     }
 
     #[test]
     fn empty_config_editor_falls_through() {
-        let mut c = cfg();
-        c.editor = Some(vec![]);
+        let empty: Vec<String> = vec![];
         let env = FakeEnv::with(&[("EDITOR", "vi")]);
-        let argv = resolve_editor_argv(&c, &env).unwrap();
+        let argv = resolve_editor_argv(Some(&empty), &env).unwrap();
         assert_eq!(argv, vec!["vi".to_string()]);
     }
 
     #[test]
     fn no_sources_errors() {
         let env = FakeEnv::default();
-        let err = resolve_editor_argv(&cfg(), &env).unwrap_err();
+        let err = resolve_editor_argv(None, &env).unwrap_err();
         assert!(err.to_string().contains("no editor configured"));
     }
 }

--- a/src/pr/fetch/mod.rs
+++ b/src/pr/fetch/mod.rs
@@ -9,7 +9,7 @@
 //! (only `refs/heads/*`), so we shell to git for the special pull ref.
 
 use crate::{
-    config::Config,
+    cli::GlobalOpts,
     gh::{Gh, PrDetails},
     git::{real::GitOps, url::parse_owner_repo},
     jj::{
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 use anyhow::{Context, Result, anyhow};
-use serde::Serialize;
+use jj_gh_config_derive::subcommand_args;
 use std::path::Path;
 
 /// Default jj template used to render the bookmark name when neither the
@@ -47,52 +47,44 @@ fn ensure_colocated(workspace_root: &Path) -> Result<()> {
     ))
 }
 
-/// Pick the jj template string to evaluate for this fetch, honoring CLI then
-/// config then the built-in default.
-fn resolve_template<'a>(args: &'a FetchArgs, config: &'a Config) -> &'a str {
-    args.template
-        .as_deref()
-        .or(config.pr_fetch_bookmark_template.as_deref())
-        .unwrap_or(DEFAULT_FETCH_TEMPLATE)
-}
+subcommand_args! {
+    pub struct FetchArgs {
+        /// PR number to fetch.
+        #[arg(value_name = "PR_NUM")]
+        pub pr: u64,
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct FetchArgs {
-    /// PR number to fetch.
-    #[arg(value_name = "PR_NUM")]
-    #[serde(skip)]
-    pub pr: u64,
+        /// Override the bookmark template. The argument is a jj template string
+        /// evaluated once against `root()` (no commit context). Default:
+        /// `pr_fetch_bookmark_template` in config, else
+        /// `"pr-" ++ pr_number ++ "/" ++ pr_branch"`.
+        ///
+        /// All standard jj template builtins are available (`description`,
+        /// `commit_id`, `author`, etc.). The following template aliases are also
+        /// injected:
+        ///
+        /// - `pr_number`: PR number as a decimal string.
+        ///
+        /// - `pr_title`: PR title.
+        ///
+        /// - `pr_branch`: head ref name (the source branch on the PR's fork).
+        ///
+        /// - `pr_url`: PR's `html_url`.
+        ///
+        /// - `pr_head_sha`: 40-char hex commit SHA of the PR's head.
+        ///
+        /// - `pr_head_user`: PR's head fork owner login, or empty if the fork was deleted.
+        ///
+        /// - `pr_head_repo`: PR's head fork repository name, or empty if the fork was deleted.
+        ///
+        /// - `pr_slug`: sanitized lowercase ASCII slug of the title (max 50 chars), suitable for embedding in a bookmark name.
+        #[arg(short = 'T', long, value_name = "TEMPLATE")]
+        #[config(maps_to = "pr_fetch_bookmark_template")]
+        pub template: Option<String>,
 
-    /// Override the bookmark template. The argument is a jj template string
-    /// evaluated once against `root()` (no commit context). Default:
-    /// `pr_fetch_bookmark_template` in config, else
-    /// `"pr-" ++ pr_number ++ "/" ++ pr_branch"`.
-    ///
-    /// Injected string aliases (each is already double-quoted, so use them
-    /// directly without wrapping in `"..."`):
-    ///
-    /// - `pr_number`: PR number as a decimal string.
-    /// - `pr_title`: PR title.
-    /// - `pr_branch`: head ref name (the source branch on the PR's fork).
-    /// - `pr_url`: PR's `html_url`.
-    /// - `pr_head_sha`: 40-char hex commit SHA of the PR's head.
-    /// - `pr_head_user`: PR's head fork owner login, or empty if the fork
-    ///   was deleted.
-    /// - `pr_head_repo`: PR's head fork repository name, or empty if the
-    ///   fork was deleted.
-    /// - `pr_slug`: sanitized lowercase ASCII slug of the title (max 50
-    ///   chars), suitable for embedding in a bookmark name.
-    #[arg(short = 'T', long, value_name = "TEMPLATE")]
-    #[serde(
-        rename = "pr_fetch_bookmark_template",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub template: Option<String>,
-
-    /// Replace an existing local bookmark of the same name.
-    #[arg(short = 'f', long)]
-    #[serde(skip)]
-    pub force: bool,
+        /// Replace an existing local bookmark of the same name.
+        #[arg(short = 'f', long)]
+        pub force: bool,
+    }
 }
 
 /// Run `pr fetch` end-to-end. Parameterized over [`GitOps`] so tests can
@@ -102,23 +94,38 @@ pub struct FetchArgs {
 ///
 /// Propagates errors from any step (auth, GH API, colocation, git fetch, jj
 /// import, template eval).
-pub async fn run_with<J: Jj, G: Gh, GO: GitOps>(
+pub async fn run<J: Jj, G: Gh, GO: GitOps>(
     jj: &J,
     gh: &G,
     git: &GO,
-    config: &Config,
     args: &FetchArgs,
 ) -> Result<()> {
+    let FetchArgs {
+        pr: pr_num,
+        template,
+        force,
+        globals:
+            GlobalOpts {
+                remote,
+                verbose: _,
+                quiet: _,
+                log_level: _,
+                upstream_remote: _,
+                gh_askpass: _,
+                askpass_timeout_secs: _,
+            },
+    } = args;
+
     let workspace_root = jj.workspace_root().await?;
     ensure_colocated(workspace_root)?;
 
     let origin_url = jj
-        .remote_url(&config.default_remote)
+        .remote_url(remote)
         .await?
-        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+        .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
     let (owner, repo) = parse_owner_repo(&origin_url)?;
 
-    let pr = gh.get_pr(&owner, &repo, args.pr).await?;
+    let pr = gh.get_pr(&owner, &repo, *pr_num).await?;
     if pr.head_user_login.is_none() || pr.head_repo_name.is_none() {
         log::warn!(
             "PR #{}: head fork appears deleted; `pr_head_user` / `pr_head_repo` will be empty",
@@ -126,11 +133,11 @@ pub async fn run_with<J: Jj, G: Gh, GO: GitOps>(
         );
     }
 
-    let template = resolve_template(args, config);
+    let tmpl = template.as_deref().unwrap_or(DEFAULT_FETCH_TEMPLATE);
     let aliases = build_fetch_aliases(&pr);
     let tmp = aliases.write_temp_config()?;
     let bookmark = jj
-        .eval_template("root()", template, Some(tmp.path()), false)
+        .eval_template("root()", tmpl, Some(tmp.path()), false)
         .await
         .context("evaluating bookmark template")?
         .trim()
@@ -142,14 +149,13 @@ pub async fn run_with<J: Jj, G: Gh, GO: GitOps>(
         ));
     }
 
-    if git.local_bookmark_exists(&bookmark).await? && !args.force {
+    if git.local_bookmark_exists(&bookmark).await? && !force {
         return Err(anyhow!(
             "local bookmark `{bookmark}` already exists; pass --force to overwrite"
         ));
     }
 
-    git.fetch_pr(&config.default_remote, args.pr, &bookmark, args.force)
-        .await?;
+    git.fetch_pr(remote, *pr_num, &bookmark, *force).await?;
     jj.git_import().await?;
 
     log::info!("PR #{}: {}", pr.number, pr.title);
@@ -422,10 +428,23 @@ mod tests {
     }
 
     fn args(pr: u64, template: Option<&str>, force: bool) -> FetchArgs {
+        args_with_remote(pr, template, force, "origin")
+    }
+
+    fn args_with_remote(pr: u64, template: Option<&str>, force: bool, remote: &str) -> FetchArgs {
         FetchArgs {
             pr,
             template: template.map(str::to_string),
             force,
+            globals: GlobalOpts {
+                verbose: 0,
+                quiet: false,
+                log_level: None,
+                remote: remote.into(),
+                upstream_remote: "upstream".into(),
+                gh_askpass: None,
+                askpass_timeout_secs: 20,
+            },
         }
     }
 
@@ -460,11 +479,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        run_with(&jj, &gh, &git, &config, &args(1234, None, false))
-            .await
-            .unwrap();
+        run(&jj, &gh, &git, &args(1234, None, false)).await.unwrap();
 
         let calls = git.fetches.borrow();
         assert_eq!(calls.len(), 1);
@@ -485,12 +500,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config {
-            default_remote: "fork".into(),
-            ..Config::default()
-        };
-
-        run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+        run(&jj, &gh, &git, &args_with_remote(1234, None, false, "fork"))
             .await
             .unwrap();
 
@@ -507,9 +517,7 @@ mod tests {
             exists: true,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        let err = run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+        let err = run(&jj, &gh, &git, &args(1234, None, false))
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -526,11 +534,7 @@ mod tests {
             exists: true,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        run_with(&jj, &gh, &git, &config, &args(1234, None, true))
-            .await
-            .unwrap();
+        run(&jj, &gh, &git, &args(1234, None, true)).await.unwrap();
 
         let calls = git.fetches.borrow();
         assert_eq!(calls.len(), 1);
@@ -547,12 +551,8 @@ mod tests {
             fetches: RefCell::new(vec![]),
         };
         let cfg_template = r#""cfg-" ++ pr_number ++ "-" ++ pr_head_user"#;
-        let config = Config {
-            pr_fetch_bookmark_template: Some(cfg_template.into()),
-            ..Config::default()
-        };
 
-        run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+        run(&jj, &gh, &git, &args(1234, Some(cfg_template), false))
             .await
             .unwrap();
 
@@ -574,20 +574,10 @@ mod tests {
             fetches: RefCell::new(vec![]),
         };
         let cli_template = r#""cli-" ++ pr_number"#;
-        let config = Config {
-            pr_fetch_bookmark_template: Some(r#""cfg-" ++ pr_number"#.into()),
-            ..Config::default()
-        };
 
-        run_with(
-            &jj,
-            &gh,
-            &git,
-            &config,
-            &args(1234, Some(cli_template), false),
-        )
-        .await
-        .unwrap();
+        run(&jj, &gh, &git, &args(1234, Some(cli_template), false))
+            .await
+            .unwrap();
 
         let evals = jj.eval_template_calls.lock().unwrap();
         assert_eq!(evals[0].template, cli_template);
@@ -602,11 +592,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        run_with(&jj, &gh, &git, &config, &args(1234, None, false))
-            .await
-            .unwrap();
+        run(&jj, &gh, &git, &args(1234, None, false)).await.unwrap();
 
         let evals = jj.eval_template_calls.lock().unwrap();
         assert_eq!(evals[0].template, DEFAULT_FETCH_TEMPLATE);
@@ -621,9 +607,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        let err = run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+        let err = run(&jj, &gh, &git, &args(1234, None, false))
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -640,9 +624,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        let err = run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+        let err = run(&jj, &gh, &git, &args(1234, None, false))
             .await
             .unwrap_err();
         assert!(
@@ -661,9 +643,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let config = Config::default();
-
-        let err = run_with(&jj, &gh, &git, &config, &args(1234, None, false))
+        let err = run(&jj, &gh, &git, &args(1234, None, false))
             .await
             .unwrap_err();
         let msg = format!("{err:#}");

--- a/src/pr/mod.rs
+++ b/src/pr/mod.rs
@@ -12,8 +12,8 @@ mod validation;
 
 use crate::{
     auth::{self, OsEnv},
-    cli::GlobalOpts,
-    config::{self, Config},
+    cli::{GlobalOpts, GlobalOptsInput},
+    config,
     fs::RealFs,
     gh::{self, Gh, PrDetails, PrSummary, remote},
     git::real::RealGit,
@@ -22,12 +22,15 @@ use crate::{
         inject::{TemplateAliases, escape_jj_string},
     },
     pr::{
-        auto_merge::AutoMergeArgs,
-        editor::{TempfileEditor, edit::EditArgs},
-        fetch::FetchArgs,
-        pr_log::PrLogArgs,
-        restack::RestackArgs,
-        retry_failed::RetryFailedArgs,
+        auto_merge::{AutoMergeArgs, AutoMergeArgsInput},
+        editor::{
+            TempfileEditor,
+            edit::{EditArgs, EditArgsInput},
+        },
+        fetch::{FetchArgs, FetchArgsInput},
+        pr_log::{PrLogArgs, PrLogArgsInput},
+        restack::{RestackArgs, RestackArgsInput},
+        retry_failed::{RetryFailedArgs, RetryFailedArgsInput},
         template::TemplateSource,
     },
 };
@@ -35,7 +38,7 @@ use anyhow::{Context, Result, anyhow};
 use clap::Subcommand;
 use figment::providers::Serialized;
 
-pub use editor::create::CreateArgs;
+pub use editor::create::{CreateArgs, CreateArgsInput};
 
 #[derive(Debug, Subcommand)]
 pub enum PrAction {
@@ -46,7 +49,7 @@ pub enum PrAction {
     /// This supports stacked PRs; by default the base branch is set to the closest ancestor bookmark
     /// if one exists, otherwise `trunk()`.
     #[command(visible_alias = "c")]
-    Create(CreateArgs),
+    Create(CreateArgsInput),
     /// Fetch a pull request into a local bookmark.
     ///
     /// This command accepts either a revision ID or a PR number. If given a revision ID, the
@@ -55,13 +58,13 @@ pub enum PrAction {
     ///
     /// See: <https://github.com/jj-vcs/jj/issues/4388>
     #[command(visible_alias = "f")]
-    Fetch(FetchArgs),
+    Fetch(FetchArgsInput),
     /// Enable auto-merge on a PR.
     ///
     /// Accepts either a PR number or a revision; with a revision, the PR is looked up by the rev's
     /// local bookmark. Fails if the repo does not allow auto-merge.
     #[command(visible_alias = "am")]
-    AutoMerge(AutoMergeArgs),
+    AutoMerge(AutoMergeArgsInput),
     /// Edit an existing PR's title, body, base, labels, reviewers, draft state,
     /// and auto-merge settings via the markdown frontmatter editor flow.
     ///
@@ -69,7 +72,7 @@ pub enum PrAction {
     /// fetches its current state, opens your editor, and applies only the diffs:
     /// labels you didn't touch keep whatever others (CI bots, etc.) set.
     #[command(visible_alias = "e")]
-    Edit(EditArgs),
+    Edit(EditArgsInput),
 
     /// Like `jj log`, but injects PR metadata (e.g. number, CI status, URL).
     ///
@@ -78,14 +81,8 @@ pub enum PrAction {
     /// `--` are forwarded to the underlying `jj log` invocation, e.g. `jj-gh pr log -- -r 'mine()'`.
     /// A default template that mirror's `jj`'s default template is provided, but you may provide
     /// your own with the `-T|--template` argument and use the injected template aliases.
-    ///
-    /// The following template aliases are available for use if you pass your
-    /// own template instead of using the default:
-    ///
-    /// `pr_number`, `pr_url`, `pr_ci_status`, `pr_merge_status`, `pr_meta` (formatted string
-    /// containing all PR information).
     #[command(visible_alias = "l")]
-    Log(PrLogArgs),
+    Log(PrLogArgsInput),
 
     /// Push the current `jj` stack shape up to GitHub by updating each PR's
     /// base branch to match its closest stacked ancestor bookmark.
@@ -96,7 +93,7 @@ pub enum PrAction {
     /// default. Pass `--dry-run` or `--json` to print the proposed plan
     /// without making any API calls.
     #[command(visible_alias = "rs")]
-    Restack(RestackArgs),
+    Restack(RestackArgsInput),
 
     /// Re-run failed CI jobs on a PR.
     ///
@@ -108,7 +105,7 @@ pub enum PrAction {
     /// With `--cancel`, in-progress runs are cancelled first; once they
     /// finalize, every workflow run is re-run (full pipeline restart).
     #[command(visible_alias = "rerun")]
-    RetryFailed(RetryFailedArgs),
+    RetryFailed(RetryFailedArgsInput),
 }
 
 /// Dispatch the `pr` subcommand to the matching handler.
@@ -118,8 +115,8 @@ pub enum PrAction {
 /// Propagates errors from config loading, auth resolution, jj/GitHub API
 /// calls, the editor round-trip, or any sub-handler (`create`, `fetch`,
 /// `auto-merge`).
-pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
-    let mut fig = config::load_figment().merge(Serialized::defaults(global));
+pub async fn dispatch(global: GlobalOptsInput, action: PrAction) -> Result<()> {
+    let mut fig = config::load_figment().merge(Serialized::defaults(&global));
     fig = match &action {
         PrAction::Create(a) => fig.merge(Serialized::defaults(a)),
         PrAction::Fetch(a) => fig.merge(Serialized::defaults(a)),
@@ -130,26 +127,42 @@ pub async fn dispatch(global: &GlobalOpts, action: PrAction) -> Result<()> {
         PrAction::RetryFailed(a) => fig.merge(Serialized::defaults(a)),
     };
     let config = config::extract(&fig)?;
+    let globals = GlobalOpts::resolve(global, &config);
 
     let token = auth::resolve_token(&config).await?;
     let jj = jj::real::JjCli::new().await?;
     let gh = gh::real::OctocrabGh::new(&token)?;
     let editor = TempfileEditor;
     match action {
-        PrAction::Create(args) => {
-            editor::create::run(&jj, &gh, &OsEnv, &editor, &config, &args).await?;
+        PrAction::AutoMerge(input) => {
+            let args = AutoMergeArgs::resolve(input, &config, &globals);
+            auto_merge::run(&jj, &gh, &args).await?;
         }
-        PrAction::Fetch(args) => {
+        PrAction::Create(input) => {
+            let args = CreateArgs::resolve(input, &config, &globals);
+            editor::create::run(&jj, &gh, &OsEnv, &editor, &args).await?;
+        }
+        PrAction::Edit(input) => {
+            let args = EditArgs::resolve(input, &config, &globals);
+            editor::edit::run(&jj, &gh, &OsEnv, &editor, &args).await?;
+        }
+        PrAction::Fetch(input) => {
             let git = RealGit::new(jj.repo().clone());
-            fetch::run_with(&jj, &gh, &git, &config, &args).await?;
+            let args = FetchArgs::resolve(input, &config, &globals);
+            fetch::run(&jj, &gh, &git, &args).await?;
         }
-        PrAction::AutoMerge(args) => auto_merge::run(&jj, &gh, &config, &args).await?,
-        PrAction::Edit(args) => {
-            editor::edit::run(&jj, &gh, &OsEnv, &editor, &config, &args).await?;
+        PrAction::Log(input) => {
+            let args = PrLogArgs::resolve(input, &config, &globals);
+            pr_log::run(&gh, &jj, &args).await?;
         }
-        PrAction::Log(args) => pr_log::run(&args, &config, &gh, &jj).await?,
-        PrAction::Restack(args) => restack::run(&jj, &gh, &config, &args).await?,
-        PrAction::RetryFailed(args) => retry_failed::run(&jj, &gh, &config, &args).await?,
+        PrAction::Restack(input) => {
+            let args = RestackArgs::resolve(input, &config, &globals);
+            restack::run(&jj, &gh, &args).await?;
+        }
+        PrAction::RetryFailed(input) => {
+            let args = RetryFailedArgs::resolve(input, &config, &globals);
+            retry_failed::run(&jj, &gh, &args).await?;
+        }
     }
     Ok(())
 }
@@ -178,12 +191,15 @@ pub struct PrLookup {
 pub async fn get_pr<J: Jj, G: Gh>(
     jj: &J,
     gh: &G,
-    config: &Config,
+    default_remote: &str,
+    upstream_remote: &str,
     number_or_rev: &str,
 ) -> Result<PrDetails> {
-    Ok(resolve_pr_with_target(jj, gh, config, number_or_rev)
-        .await?
-        .0)
+    Ok(
+        resolve_pr_with_target(jj, gh, default_remote, upstream_remote, number_or_rev)
+            .await?
+            .0,
+    )
 }
 
 /// Same as [`get_pr`] but also returns the resolved [`remote::Target`] so
@@ -196,20 +212,22 @@ pub async fn get_pr<J: Jj, G: Gh>(
 pub async fn resolve_pr_with_target<J: Jj, G: Gh>(
     jj: &J,
     gh: &G,
-    config: &Config,
+    default_remote: &str,
+    upstream_remote: &str,
     number_or_rev: &str,
 ) -> Result<(PrDetails, remote::Target)> {
     if let Ok(num) = number_or_rev.parse::<u64>() {
         let origin_url = jj
-            .remote_url(&config.default_remote)
+            .remote_url(default_remote)
             .await?
-            .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
-        let upstream_url = jj.remote_url(&config.upstream_remote).await?;
+            .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
+        let upstream_url = jj.remote_url(upstream_remote).await?;
         let target = remote::target(&origin_url, upstream_url.as_deref())?;
         let pr = gh.get_pr(&target.owner, &target.repo, num).await?;
         Ok((pr, target))
     } else {
-        let lookup = resolve_pr_for_rev(jj, gh, config, number_or_rev).await?;
+        let lookup =
+            resolve_pr_for_rev(jj, gh, default_remote, upstream_remote, number_or_rev).await?;
         let summary = lookup.summary.ok_or_else(|| {
             anyhow!(
                 "no open PR for revision `{number_or_rev}` (head `{}`)",
@@ -234,7 +252,8 @@ pub async fn resolve_pr_with_target<J: Jj, G: Gh>(
 pub async fn resolve_pr_for_rev<J: Jj, G: Gh>(
     jj: &J,
     gh: &G,
-    config: &Config,
+    default_remote: &str,
+    upstream_remote: &str,
     rev: &str,
 ) -> Result<PrLookup> {
     let info = jj.resolve_rev(rev).await?;
@@ -245,10 +264,10 @@ pub async fn resolve_pr_for_rev<J: Jj, G: Gh>(
         .ok_or_else(|| anyhow!("no local bookmark on `{rev}`; nothing to look up"))?;
 
     let origin_url = jj
-        .remote_url(&config.default_remote)
+        .remote_url(default_remote)
         .await?
-        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
-    let upstream_url = jj.remote_url(&config.upstream_remote).await?;
+        .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
+    let upstream_url = jj.remote_url(upstream_remote).await?;
     let target = remote::target(&origin_url, upstream_url.as_deref())?;
     let head_spec = target.head_spec(&branch);
 
@@ -268,13 +287,6 @@ pub async fn resolve_pr_for_rev<J: Jj, G: Gh>(
         default_base,
         summary,
     })
-}
-
-fn resolve_base(args: &CreateArgs, ancestor: Option<&str>, detected: &str) -> String {
-    args.base
-        .clone()
-        .or_else(|| ancestor.map(str::to_string))
-        .unwrap_or_else(|| detected.to_string())
 }
 
 async fn load_template_for<J: Jj>(
@@ -324,35 +336,32 @@ fn quote_jj(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        config::AutoMergeMethod,
-        pr::{auto_merge::AutoMergeArgs, fetch::FetchArgs},
-    };
+    use crate::config::{AutoMergeMethod, Config};
     use clap::Parser;
 
     #[derive(clap::Parser, Debug)]
     #[command(no_binary_name = true)]
     struct CreateArgsParser {
         #[command(flatten)]
-        args: CreateArgs,
+        args: CreateArgsInput,
     }
 
     #[derive(clap::Parser, Debug)]
     #[command(no_binary_name = true)]
     struct PrLogArgsParser {
         #[command(flatten)]
-        args: PrLogArgs,
+        args: PrLogArgsInput,
     }
 
-    fn parse_create(argv: &[&str]) -> CreateArgs {
+    fn parse_create(argv: &[&str]) -> CreateArgsInput {
         CreateArgsParser::try_parse_from(argv.iter().copied())
-            .expect("CreateArgs failed to parse")
+            .expect("CreateArgsInput failed to parse")
             .args
     }
 
-    fn parse_pr_log(argv: &[&str]) -> PrLogArgs {
+    fn parse_pr_log(argv: &[&str]) -> PrLogArgsInput {
         PrLogArgsParser::try_parse_from(argv.iter().copied())
-            .expect("PrLogArgs failed to parse")
+            .expect("PrLogArgsInput failed to parse")
             .args
     }
 
@@ -370,33 +379,6 @@ mod tests {
             .merge(config::JjConfProvider::from_memory("test", toml_config))
             .merge(Serialized::defaults(&argv));
         config::extract(&fig).unwrap()
-    }
-
-    fn args_with_base(base: Option<&str>) -> CreateArgs {
-        let mut a = parse_create(&["@-"]);
-        a.base = base.map(str::to_string);
-        a
-    }
-
-    #[test]
-    fn base_cli_wins_over_ancestor_and_detected() {
-        assert_eq!(
-            resolve_base(&args_with_base(Some("release")), Some("ancestor"), "main"),
-            "release"
-        );
-    }
-
-    #[test]
-    fn base_ancestor_wins_over_detected() {
-        assert_eq!(
-            resolve_base(&args_with_base(None), Some("ancestor"), "main"),
-            "ancestor"
-        );
-    }
-
-    #[test]
-    fn base_falls_back_to_detected() {
-        assert_eq!(resolve_base(&args_with_base(None), None, "main"), "main");
     }
 
     #[test]
@@ -518,7 +500,7 @@ mod tests {
 
     #[test]
     fn fetch_cli_template_overrides_config() {
-        let args = FetchArgs {
+        let input = FetchArgsInput {
             pr: 1,
             template: Some("cli-{number}".into()),
             force: false,
@@ -528,7 +510,7 @@ mod tests {
                 "pr_fetch_bookmark_template",
                 "cfg-{number}",
             ))
-            .merge(Serialized::defaults(&args));
+            .merge(Serialized::defaults(&input));
         let c = config::extract(&fig).unwrap();
         assert_eq!(
             c.pr_fetch_bookmark_template.as_deref(),
@@ -538,30 +520,30 @@ mod tests {
 
     #[test]
     fn auto_merge_args_method_overrides_config_via_rename() {
-        let args = AutoMergeArgs {
+        let input = AutoMergeArgsInput {
             number_or_rev: "1".into(),
-            method: Some(AutoMergeMethod::Squash),
+            auto_merge_method: Some(AutoMergeMethod::Squash),
         };
         let fig = config::defaults_figment()
             .merge(Serialized::default(
                 "auto_merge_method",
                 AutoMergeMethod::Rebase,
             ))
-            .merge(Serialized::defaults(&args));
+            .merge(Serialized::defaults(&input));
         let c = config::extract(&fig).unwrap();
         assert_eq!(c.auto_merge_method, AutoMergeMethod::Squash);
     }
 
     #[test]
     fn global_remote_overrides_default_remote_config() {
-        use crate::cli::GlobalOpts;
+        use crate::cli::GlobalOptsInput;
         use clap::Parser;
 
         #[derive(clap::Parser, Debug)]
         #[command(no_binary_name = true)]
         struct GlobalParser {
             #[command(flatten)]
-            opts: GlobalOpts,
+            opts: GlobalOptsInput,
         }
 
         let global =
@@ -585,14 +567,14 @@ mod tests {
 
     #[test]
     fn config_remote_used_when_global_not_set() {
-        use crate::cli::GlobalOpts;
+        use crate::cli::GlobalOptsInput;
         use clap::Parser;
 
         #[derive(clap::Parser, Debug)]
         #[command(no_binary_name = true)]
         struct GlobalParser {
             #[command(flatten)]
-            opts: GlobalOpts,
+            opts: GlobalOptsInput,
         }
 
         let global = GlobalParser::try_parse_from::<[&str; 0], _>([])

--- a/src/pr/pr_log/mod.rs
+++ b/src/pr/pr_log/mod.rs
@@ -10,7 +10,7 @@
 //! didn't pass their own `-T` / `--template`.
 
 use crate::{
-    config::Config,
+    cli::GlobalOpts,
     gh::{CiStatus, Gh, PrWithCiStatus},
     git,
     jj::{
@@ -20,7 +20,7 @@ use crate::{
     ui::Spinner,
 };
 use anyhow::{Context, Result, anyhow};
-use serde::Serialize;
+use jj_gh_config_derive::subcommand_args;
 use std::collections::HashMap;
 use tokio::process::Command;
 
@@ -59,52 +59,80 @@ if(root,
 )
 "#;
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct PrLogArgs {
-    /// Arguments forwarded verbatim to the underlying `jj log` invocation.
-    /// Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`.
-    /// If you pass `-T` / `--template`, the default PR-aware template is not
-    /// applied; the following per-commit aliases are then available in your
-    /// own template, each keyed on `commit_id`:
-    ///
-    /// - `pr_number`: PR number as a string, or empty for commits without a
-    ///   PR.
-    /// - `pr_url`: PR URL, or empty.
-    /// - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty.
-    /// - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or
-    ///   empty.
-    /// - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon
-    ///   plus merge status (empty for commits without a PR).
-    #[arg(last = true, allow_hyphen_values = true, value_name = "JJ_LOG_ARGS")]
-    #[serde(skip)]
-    pub jj_log_args: Vec<String>,
+subcommand_args! {
+    pub struct PrLogArgs {
+        /// Arguments forwarded verbatim to the underlying `jj log` invocation.
+        /// Pass after `--`, e.g. `jj-gh pr log -- -r 'mine()' -T builtin_log_compact`.
+        /// If you pass `-T` / `--template`, the default PR-aware template is not
+        /// applied.
+        ///
+        /// All standard jj template builtins are available (`description`,
+        /// `commit_id`, `author`, etc.). The following template aliases are also
+        /// injected:
+        ///
+        /// - `pr_number`: PR number as a string, or empty for commits without a PR.
+        ///
+        /// - `pr_url`: PR URL, or empty.
+        ///
+        /// - `pr_ci_status`: `SUCCESS`, `FAILED`, `PENDING`, or empty.
+        ///
+        /// - `pr_merge_status`: merged / in-merge-queue / auto-merge label, or empty.
+        ///
+        /// - `pr_meta`: pre-formatted hyperlinked PR number plus colored CI icon plus merge status.
+        #[arg(last = true, allow_hyphen_values = true, value_name = "JJ_LOG_ARGS")]
+        pub jj_log_args: Vec<String>,
 
-    /// Force enable the use of nerdfont icons in the default
-    /// `pr log` template. Overrides config. Use `--no-nerdfonts` to disable.
-    #[arg(
-        long,
-        num_args = 0,
-        default_missing_value = "true",
-        default_value_if("no_nerdfonts", "true", Some("false"))
-    )]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub nerdfonts: Option<bool>,
+        /// Force enable the use of nerdfont icons in the default
+        /// `pr log` template. Overrides config. Use `--no-nerdfonts` to disable.
+        #[arg(
+            long,
+            num_args = 0,
+            default_missing_value = "true",
+            default_value_if("no_nerdfonts", "true", Some("false"))
+        )]
+        #[config]
+        pub nerdfonts: bool,
 
-    /// Force the default `pr log` template not to use nerdfont icons.
-    /// Overrides config.
-    #[arg(long = "no-nerdfonts", conflicts_with = "nerdfonts")]
-    #[serde(skip)]
-    pub no_nerdfonts: bool,
+        /// Force the default `pr log` template not to use nerdfont icons.
+        /// Overrides config.
+        #[arg(long, conflicts_with = "nerdfonts")]
+        pub no_nerdfonts: bool,
+
+        /// Override `pr_log_template` from config for this invocation.
+        /// Sets the body of the default `pr_log` template alias jj-gh
+        /// injects. Has no effect if you pass your own `-T` / `--template`
+        /// in forwarded `jj log` args (after `--`).
+        #[arg(short = 'T', value_name = "TEMPLATE")]
+        #[config(maps_to = "pr_log_template")]
+        pub template: Option<String>,
+    }
 }
 
-pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) -> Result<()> {
+pub async fn run(gh: &impl Gh, jj: &impl Jj, args: &PrLogArgs) -> Result<()> {
+    let PrLogArgs {
+        jj_log_args,
+        nerdfonts,
+        no_nerdfonts: _,
+        template,
+        globals:
+            GlobalOpts {
+                remote,
+                verbose: _,
+                quiet: _,
+                log_level: _,
+                upstream_remote: _,
+                gh_askpass: _,
+                askpass_timeout_secs: _,
+            },
+    } = args;
+
     let origin_url = jj
-        .remote_url(&config.default_remote)
+        .remote_url(remote)
         .await?
-        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+        .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
     let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
     let spinner = Spinner::start("Resolving local PRs");
-    let bookmarks = jj.pushed_bookmarks(&config.default_remote).await?;
+    let bookmarks = jj.pushed_bookmarks(remote).await?;
     let branch_to_local: HashMap<String, String> = bookmarks
         .iter()
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))
@@ -113,15 +141,15 @@ pub async fn run(args: &PrLogArgs, config: &Config, gh: &impl Gh, jj: &impl Jj) 
     let prs = gh.local_pulls(&owner, &repo, &names).await?;
     spinner.stop().await;
 
-    let aliases = build_aliases(&prs, &branch_to_local, config);
+    let aliases = build_aliases(&prs, &branch_to_local, *nerdfonts, template.as_deref());
     let tmp = aliases.write_temp_config()?;
 
     let mut cmd = Command::new("jj");
     cmd.arg("--config-file").arg(tmp.path()).arg("log");
-    if !user_set_template(&args.jj_log_args) {
+    if !user_set_template(jj_log_args) {
         cmd.args(["-T", "pr_log"]);
     }
-    cmd.args(&args.jj_log_args);
+    cmd.args(jj_log_args);
 
     let status = cmd.status().await.context("failed to spawn `jj log`")?;
     if !status.success() {
@@ -156,7 +184,8 @@ fn user_set_template(args: &[String]) -> bool {
 pub(crate) fn build_aliases(
     prs: &[PrWithCiStatus],
     branch_to_local: &HashMap<String, String>,
-    config: &Config,
+    nerdfonts: bool,
+    pr_log_template: Option<&str>,
 ) -> TemplateAliases {
     let number = if_chain_alias(prs, branch_to_local, |pr| format!(r#""{}""#, pr.number));
     let url = if_chain_alias(prs, branch_to_local, |pr| {
@@ -166,11 +195,13 @@ pub(crate) fn build_aliases(
         format!(r#""{}""#, ci_status_str(pr.ci_status))
     });
     let merge_status = if_chain_alias(prs, branch_to_local, |pr| {
-        format!(r#""{}""#, merge_status(pr, config).unwrap_or_default())
+        format!(r#""{}""#, merge_status(pr, nerdfonts).unwrap_or_default())
     });
-    let meta = if_chain_alias(prs, branch_to_local, |pr| render_pr_meta_body(pr, config));
+    let meta = if_chain_alias(prs, branch_to_local, |pr| {
+        render_pr_meta_body(pr, nerdfonts)
+    });
 
-    let pr_log_body = config.pr_log_template.as_deref().unwrap_or(PR_LOG_TEMPLATE);
+    let pr_log_body = pr_log_template.unwrap_or(PR_LOG_TEMPLATE);
     TemplateAliases::builder()
         .alias("pr_number", number)
         .alias("pr_url", url)
@@ -186,8 +217,8 @@ pub(crate) fn build_aliases(
 
 /// Render the body of a single `pr_meta` if-chain arm: the full template
 /// fragment for one PR (hyperlinked number plus colored CI-status icon).
-fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
-    let github_icon = if config.nerdfonts { " " } else { "" };
+fn render_pr_meta_body(pr: &PrWithCiStatus, nerdfonts: bool) -> String {
+    let github_icon = if nerdfonts { " " } else { "" };
     let url = escape_jj_string(&pr.url);
     let mut template = format!(
         r##""{github_icon}" ++ hyperlink("{url}", "#{n}")"##,
@@ -199,7 +230,7 @@ fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
         None => template,
     };
 
-    template = match merge_status(pr, config) {
+    template = match merge_status(pr, nerdfonts) {
         Some(metadata) => {
             format!(
                 r#"{template} ++ " " ++ label("{COLOR_PR_MERGE_STATUS}", "(") ++ {metadata} ++ label("{COLOR_PR_MERGE_STATUS}", ")")"#
@@ -211,19 +242,19 @@ fn render_pr_meta_body(pr: &PrWithCiStatus, config: &Config) -> String {
     template
 }
 
-fn merge_status(pr: &PrWithCiStatus, config: &Config) -> Option<String> {
+fn merge_status(pr: &PrWithCiStatus, nerdfonts: bool) -> Option<String> {
     if pr.merged {
-        let icon = if config.nerdfonts { " " } else { "" };
+        let icon = if nerdfonts { " " } else { "" };
         Some(format!(
             r#"label("{COLOR_PR_MERGE_STATUS}", "{icon}merged")"#
         ))
     } else if pr.is_in_merge_queue {
-        let icon = if config.nerdfonts { " " } else { "" };
+        let icon = if nerdfonts { " " } else { "" };
         Some(format!(
             r#"label("{COLOR_PR_MERGE_STATUS}", "{icon}in merge queue")"#
         ))
     } else if pr.auto_merge_enabled {
-        let icon = if config.nerdfonts { "󰾨 " } else { "" };
+        let icon = if nerdfonts { "󰾨 " } else { "" };
         Some(format!(
             r#"label("{COLOR_PR_MERGE_STATUS}", "{icon}auto-merge enabled")"#
         ))
@@ -426,7 +457,7 @@ mod tests {
     fn config_contains_alias_for_each_pr() {
         let prs = vec![pr("a".repeat(40).as_str(), 42, CiStatus::Success)];
         let map = local_map_from(&prs);
-        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        let cfg = build_aliases(&prs, &map, true, None).to_toml();
         assert!(
             cfg.contains(r#"commit_id.short(40) == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""#)
         );
@@ -440,17 +471,17 @@ mod tests {
     fn default_template_shows_merge_metadata() {
         let prs = vec![pr_merge_status(1, true, false, false)];
         let map = local_map_from(&prs);
-        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        let cfg = build_aliases(&prs, &map, true, None).to_toml();
         assert!(cfg.contains(" merged"));
 
         let prs = vec![pr_merge_status(2, false, true, false)];
         let map = local_map_from(&prs);
-        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        let cfg = build_aliases(&prs, &map, true, None).to_toml();
         assert!(cfg.contains(" in merge queue"), "{}", cfg);
 
         let prs = vec![pr_merge_status(3, false, false, true)];
         let map = local_map_from(&prs);
-        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        let cfg = build_aliases(&prs, &map, true, None).to_toml();
         assert!(cfg.contains("󰾨 auto-merge enabled"));
     }
 
@@ -458,7 +489,7 @@ mod tests {
     fn merge_status_labels_use_pr_merge_color_const() {
         let prs = vec![pr_merge_status(1, true, false, false)];
         let map = local_map_from(&prs);
-        let cfg = build_aliases(&prs, &map, &Config::default()).to_toml();
+        let cfg = build_aliases(&prs, &map, true, None).to_toml();
         assert!(
             cfg.contains(r#"label("gh-pr-merge-status""#),
             "expected gh-pr-merge-status color label, got: {cfg}"

--- a/src/pr/restack/interactive.rs
+++ b/src/pr/restack/interactive.rs
@@ -25,7 +25,6 @@
 
 use super::{Decision, PrPlan, RestackContext};
 use crate::{
-    config::Config,
     jj::Jj,
     pr::{
         pr_log::{PR_LOG_TEMPLATE, build_aliases},
@@ -91,10 +90,9 @@ struct UiState {
 pub async fn run<J: Jj>(
     jj: &J,
     ctx: &RestackContext,
-    config: &Config,
     args: &RestackArgs,
 ) -> Result<HashMap<u64, Decision>> {
-    let stdout_bytes = capture_log(ctx, config, args).await?;
+    let stdout_bytes = capture_log(ctx, args).await?;
     let (log_lines, commit_to_line) = parse_sentinel_lines(&stdout_bytes);
     let pr_to_line = commit_map_to_pr_map(&commit_to_line, &ctx.plans);
     let pr_order = order_prs_topologically(jj, &ctx.plans).await?;
@@ -808,7 +806,7 @@ pub(crate) fn build_base_candidates(ctx: &RestackContext) -> Vec<String> {
 /// The wrapper sits outside the user body so anything the user templates
 /// renders as-is; we only consume the markers when post-processing the
 /// captured stream.
-async fn capture_log(ctx: &RestackContext, config: &Config, args: &RestackArgs) -> Result<String> {
+async fn capture_log(ctx: &RestackContext, args: &RestackArgs) -> Result<String> {
     let branch_to_local: HashMap<String, String> = ctx
         .bookmarks
         .iter()
@@ -817,13 +815,18 @@ async fn capture_log(ctx: &RestackContext, config: &Config, args: &RestackArgs) 
     let user_body = args
         .template
         .as_deref()
-        .or(config.pr_restack_template.as_deref())
-        .or(config.pr_log_template.as_deref())
+        .or(args.pr_log_template.as_deref())
         .unwrap_or(PR_LOG_TEMPLATE);
     let wrapped = format!(
         "\"{SENTINEL_OPEN}\" ++ commit_id.short(40) ++ \"{SENTINEL_CLOSE}\" ++ ({user_body})"
     );
-    let aliases = build_aliases(&ctx.prs, &branch_to_local, config).alias("pr_log", wrapped);
+    let aliases = build_aliases(
+        &ctx.prs,
+        &branch_to_local,
+        args.nerdfonts,
+        args.pr_log_template.as_deref(),
+    )
+    .alias("pr_log", wrapped);
     let tmp = aliases.write_temp_config()?;
 
     let mut cmd = Command::new("jj");

--- a/src/pr/restack/mod.rs
+++ b/src/pr/restack/mod.rs
@@ -9,7 +9,7 @@
 mod interactive;
 
 use crate::{
-    config::Config,
+    cli::GlobalOpts,
     gh::{Gh, PrWithCiStatus, UpdatePr},
     git,
     jj::{Jj, PushedBookmark},
@@ -17,36 +17,52 @@ use crate::{
 };
 use anyhow::{Result, anyhow};
 use futures::{StreamExt, stream::FuturesUnordered};
+use jj_gh_config_derive::subcommand_args;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::IsTerminal;
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct RestackArgs {
-    /// PR number or revision ID to position the cursor on when the TUI opens;
-    /// if omitted the cursor starts on the first PR in the stack.
-    #[arg(value_name = "PR_NUM|REV")]
-    #[serde(skip)]
-    pub number_or_rev: Option<String>,
+subcommand_args! {
+    pub struct RestackArgs {
+        /// PR number or revision ID to position the cursor on when the TUI opens;
+        /// if omitted the cursor starts on the first PR in the stack.
+        #[arg(value_name = "PR_NUM|REV")]
+        pub number_or_rev: Option<String>,
 
-    /// Print the proposed plan and exit without launching the TUI. No PR is
-    /// updated. Auto-enabled when stdout is not a terminal.
-    #[arg(long)]
-    #[serde(skip)]
-    pub dry_run: bool,
+        /// Print the proposed plan and exit without launching the TUI. No PR is
+        /// updated. Auto-enabled when stdout is not a terminal.
+        #[arg(long)]
+        pub dry_run: bool,
 
-    /// Emit the proposed plan as JSON. Implies `--dry-run`.
-    #[arg(long)]
-    #[serde(skip)]
-    pub json: bool,
+        /// Emit the proposed plan as JSON. Implies `--dry-run`.
+        #[arg(long)]
+        pub json: bool,
 
-    /// Template to use in interactive mode; conflicts with `--json` and `--dry-run`.
-    #[arg(long, short = 'T', conflicts_with_all = ["json", "dry_run"])]
-    #[serde(
-        rename = "pr_restack_template",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub template: Option<String>,
+        /// Template to use in interactive mode; conflicts with `--json` and `--dry-run`.
+        /// The same template aliases as `pr log` are injected here. See `jj-gh pr log --help`.
+        #[arg(long, short = 'T', conflicts_with_all = ["json", "dry_run"])]
+        #[config(maps_to = "pr_restack_template")]
+        pub template: Option<String>,
+
+        #[config]
+        pub pr_log_template: Option<String>,
+
+        /// Force enable nerdfont icons in the default restack/log template.
+        /// Overrides config. Use `--no-nerdfonts` to disable.
+        #[arg(
+            long,
+            num_args = 0,
+            default_missing_value = "true",
+            default_value_if("no_nerdfonts", "true", Some("false"))
+        )]
+        #[config]
+        pub nerdfonts: bool,
+
+        /// Force the default restack/log template not to use nerdfont icons.
+        /// Overrides config.
+        #[arg(long, conflicts_with = "nerdfonts")]
+        pub no_nerdfonts: bool,
+    }
 }
 
 /// One PR's proposed base-ref transition. Computed up-front so the TUI and
@@ -96,12 +112,22 @@ impl Decision {
     }
 }
 
-pub async fn run<J, G>(jj: &J, gh: &G, config: &Config, args: &RestackArgs) -> Result<()>
+pub async fn run<J, G>(jj: &J, gh: &G, args: &RestackArgs) -> Result<()>
 where
     J: Jj,
     G: Gh,
 {
-    let ctx = gather_context(jj, gh, config).await?;
+    let GlobalOpts {
+        remote,
+        verbose: _,
+        quiet: _,
+        log_level: _,
+        upstream_remote: _,
+        gh_askpass: _,
+        askpass_timeout_secs: _,
+    } = &args.globals;
+
+    let ctx = gather_context(jj, gh, remote).await?;
     let force_dry = args.dry_run
         || args.json
         || !std::io::stdout().is_terminal()
@@ -126,7 +152,7 @@ where
         return Ok(());
     }
 
-    let decisions = interactive::run(jj, &ctx, config, args).await?;
+    let decisions = interactive::run(jj, &ctx, args).await?;
     submit(gh, &ctx, &decisions).await
 }
 
@@ -138,15 +164,19 @@ pub(crate) struct RestackContext {
     pub bookmarks: Vec<PushedBookmark>,
 }
 
-async fn gather_context<J: Jj, G: Gh>(jj: &J, gh: &G, config: &Config) -> Result<RestackContext> {
+async fn gather_context<J: Jj, G: Gh>(
+    jj: &J,
+    gh: &G,
+    default_remote: &str,
+) -> Result<RestackContext> {
     let origin_url = jj
-        .remote_url(&config.default_remote)
+        .remote_url(default_remote)
         .await?
-        .ok_or_else(|| anyhow!("`{}` remote is not configured", config.default_remote))?;
+        .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
     let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
 
     let spinner = Spinner::start("Resolving local PRs");
-    let bookmarks = jj.pushed_bookmarks(&config.default_remote).await?;
+    let bookmarks = jj.pushed_bookmarks(default_remote).await?;
     let branch_to_local: HashMap<String, String> = bookmarks
         .iter()
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))

--- a/src/pr/retry_failed.rs
+++ b/src/pr/retry_failed.rs
@@ -7,50 +7,47 @@
 //! re-runs every workflow run (full pipeline restart).
 
 use crate::{
-    config::Config,
+    cli::GlobalOpts,
     gh::{Gh, WorkflowRun, WorkflowRunStatus},
     jj::Jj,
     pr,
     ui::Spinner,
 };
 use anyhow::{Context, Result, bail};
-use serde::Serialize;
+use jj_gh_config_derive::subcommand_args;
 use std::time::{Duration, Instant};
 
-#[derive(Debug, clap::Args, Serialize)]
-pub struct RetryFailedArgs {
-    /// PR number, or revision ID to look up a PR from.
-    #[arg(value_name = "PR_NUM|REV")]
-    #[serde(skip)]
-    pub number_or_rev: String,
+subcommand_args! {
+    pub struct RetryFailedArgs {
+        /// PR number, or revision ID to look up a PR from.
+        #[arg(value_name = "PR_NUM|REV")]
+        pub number_or_rev: String,
 
-    /// Cancel any in-progress runs and restart the entire pipeline.
-    /// Without this flag, the command fails if CI has not yet completed.
-    #[arg(long)]
-    #[serde(skip)]
-    pub cancel: bool,
+        /// Cancel any in-progress runs and restart the entire pipeline.
+        /// Without this flag, the command fails if CI has not yet completed.
+        #[arg(long)]
+        pub cancel: bool,
 
-    /// Seconds to wait for cancelled runs to finalize before re-running.
-    /// Only meaningful with --cancel.
-    #[arg(long, value_name = "SECS", default_value_t = 30, requires = "cancel")]
-    #[serde(skip)]
-    pub cancel_timeout: u64,
+        /// Seconds to wait for cancelled runs to finalize before re-running.
+        /// Only meaningful with --cancel.
+        #[arg(long, value_name = "SECS", default_value_t = 30, requires = "cancel")]
+        pub cancel_timeout: u64,
+    }
 }
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
-pub async fn run<J, G>(jj: &J, gh: &G, config: &Config, args: &RetryFailedArgs) -> Result<()>
+pub async fn run<J, G>(jj: &J, gh: &G, args: &RetryFailedArgs) -> Result<()>
 where
     J: Jj,
     G: Gh,
 {
-    run_with(jj, gh, config, args, DEFAULT_POLL_INTERVAL).await
+    run_with(jj, gh, args, DEFAULT_POLL_INTERVAL).await
 }
 
 async fn run_with<J, G>(
     jj: &J,
     gh: &G,
-    config: &Config,
     args: &RetryFailedArgs,
     poll_interval: Duration,
 ) -> Result<()>
@@ -62,9 +59,20 @@ where
         number_or_rev,
         cancel,
         cancel_timeout,
+        globals:
+            GlobalOpts {
+                remote,
+                upstream_remote,
+                verbose: _,
+                quiet: _,
+                log_level: _,
+                gh_askpass: _,
+                askpass_timeout_secs: _,
+            },
     } = args;
 
-    let (pr, target) = pr::resolve_pr_with_target(jj, gh, config, number_or_rev).await?;
+    let (pr, target) =
+        pr::resolve_pr_with_target(jj, gh, remote, upstream_remote, number_or_rev).await?;
     let owner = &target.owner;
     let repo = &target.repo;
 
@@ -258,7 +266,6 @@ async fn poll_until_completed<G: Gh>(
 mod tests {
     use super::*;
     use crate::{
-        config::{self, Config},
         gh::{
             BaseLookup, CreatePrRequest, Label, PrCreated, PrDetails, PrSummary, PrWithCiStatus,
             UpdatePr, WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus,
@@ -267,11 +274,6 @@ mod tests {
     };
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
-
-    fn default_config() -> Config {
-        let fig = config::defaults_figment();
-        config::extract(&fig).unwrap()
-    }
 
     fn pr_details(number: u64, sha: &str) -> PrDetails {
         PrDetails {
@@ -483,6 +485,15 @@ mod tests {
             number_or_rev: number.into(),
             cancel,
             cancel_timeout: timeout,
+            globals: GlobalOpts {
+                verbose: 0,
+                quiet: false,
+                log_level: None,
+                remote: "origin".into(),
+                upstream_remote: "upstream".into(),
+                gh_askpass: None,
+                askpass_timeout_secs: 20,
+            },
         }
     }
 
@@ -514,15 +525,9 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs]);
         let jj = FakeJj::new();
 
-        run_with(
-            &jj,
-            &gh,
-            &default_config(),
-            &args("42", false, 30),
-            Duration::from_millis(5),
-        )
-        .await
-        .expect("default path should succeed");
+        run_with(&jj, &gh, &args("42", false, 30), Duration::from_millis(5))
+            .await
+            .expect("default path should succeed");
 
         let calls = gh.calls.lock().unwrap();
         assert_eq!(calls.rerun_failed, vec![2, 3]);
@@ -544,15 +549,9 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs]);
         let jj = FakeJj::new();
 
-        let err = run_with(
-            &jj,
-            &gh,
-            &default_config(),
-            &args("7", false, 30),
-            Duration::from_millis(5),
-        )
-        .await
-        .expect_err("should refuse while CI in progress");
+        let err = run_with(&jj, &gh, &args("7", false, 30), Duration::from_millis(5))
+            .await
+            .expect_err("should refuse while CI in progress");
         let msg = format!("{err:#}");
         assert!(msg.contains("still in progress"), "msg: {msg}");
 
@@ -580,15 +579,9 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs]);
         let jj = FakeJj::new();
 
-        run_with(
-            &jj,
-            &gh,
-            &default_config(),
-            &args("9", false, 30),
-            Duration::from_millis(5),
-        )
-        .await
-        .unwrap();
+        run_with(&jj, &gh, &args("9", false, 30), Duration::from_millis(5))
+            .await
+            .unwrap();
 
         let calls = gh.calls.lock().unwrap();
         assert!(calls.rerun_failed.is_empty());
@@ -643,15 +636,9 @@ mod tests {
         let gh = FakeGh::new(pr, vec![initial, still_running, all_done, post_poll]);
         let jj = FakeJj::new();
 
-        run_with(
-            &jj,
-            &gh,
-            &default_config(),
-            &args("11", true, 5),
-            Duration::from_millis(1),
-        )
-        .await
-        .expect("cancel path should succeed once runs settle");
+        run_with(&jj, &gh, &args("11", true, 5), Duration::from_millis(1))
+            .await
+            .expect("cancel path should succeed once runs settle");
 
         let calls = gh.calls.lock().unwrap();
         assert_eq!(calls.cancelled, vec![2, 3]);
@@ -669,7 +656,6 @@ mod tests {
         let err = run_with(
             &jj,
             &gh,
-            &default_config(),
             // 0s timeout: the very first poll iteration sees elapsed >= timeout and errors.
             &args("13", true, 0),
             Duration::from_millis(1),
@@ -703,15 +689,9 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs.clone(), runs]);
         let jj = FakeJj::new();
 
-        run_with(
-            &jj,
-            &gh,
-            &default_config(),
-            &args("21", true, 30),
-            Duration::from_millis(1),
-        )
-        .await
-        .unwrap();
+        run_with(&jj, &gh, &args("21", true, 30), Duration::from_millis(1))
+            .await
+            .unwrap();
 
         let calls = gh.calls.lock().unwrap();
         assert!(calls.cancelled.is_empty());

--- a/src/pr/template.rs
+++ b/src/pr/template.rs
@@ -133,16 +133,25 @@ mod tests {
     fn args() -> CreateArgs {
         CreateArgs {
             rev: "@-".into(),
-            base: None,
-            draft: None,
+            base: crate::util::EvalWithCfgFallback::new(None, None),
+            draft: false,
             no_draft: false,
-            auto_merge: None,
+            auto_merge: false,
             no_auto_merge: false,
-            auto_merge_method: None,
+            auto_merge_method: crate::config::AutoMergeMethod::Merge,
             template: None,
             template_file: None,
             no_template: false,
             editor: None,
+            globals: crate::cli::GlobalOpts {
+                verbose: 0,
+                quiet: false,
+                log_level: None,
+                remote: "origin".into(),
+                upstream_remote: "upstream".into(),
+                gh_askpass: None,
+                askpass_timeout_secs: 20,
+            },
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,116 @@
+//! Small reusable helpers.
+
+use anyhow::{Result, anyhow};
+use std::future::Future;
+
+/// Pair of an explicit override (e.g. CLI flag) and a config-supplied
+/// last-resort default. Used by `subcommand_args!` for
+/// `#[config(fallback = "...")]` fields where intermediate runtime sources
+/// (async jj calls, ancestor bookmarks, etc.) sit between the two ends of the
+/// precedence chain.
+///
+/// Resolution order:
+/// 1. CLI override (if `Some`, the closure is never called);
+/// 2. result of the async closure passed to [`Self::resolve`] / [`Self::resolve_or`];
+/// 3. config fallback.
+#[derive(Debug, Clone)]
+pub struct EvalWithCfgFallback<T> {
+    cli: Option<T>,
+    fallback: Option<T>,
+}
+
+impl<T: Clone> EvalWithCfgFallback<T> {
+    /// Used by macro-emitted code; not part of the public ergonomic API.
+    #[must_use]
+    pub fn new(cli: Option<T>, fallback: Option<T>) -> Self {
+        Self { cli, fallback }
+    }
+
+    /// Resolve CLI first, then the closure result, then the config fallback.
+    /// The closure is only awaited when CLI is `None`. Returns `None` if every
+    /// source is empty.
+    pub async fn resolve<F, Fut>(&self, f: F) -> Option<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Option<T>>,
+    {
+        if let Some(v) = self.cli.clone() {
+            return Some(v);
+        }
+        if let Some(v) = f().await {
+            return Some(v);
+        }
+        self.fallback.clone()
+    }
+
+    /// Like [`Self::resolve`] but errors with `err` if every source is `None`.
+    pub async fn resolve_or<F, Fut, E>(&self, f: F, err: E) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Option<T>>,
+        E: Into<String>,
+    {
+        self.resolve(f)
+            .await
+            .ok_or_else(|| anyhow!("{}", err.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn pair(cli: Option<&str>, fallback: Option<&str>) -> EvalWithCfgFallback<String> {
+        EvalWithCfgFallback::new(cli.map(str::to_string), fallback.map(str::to_string))
+    }
+
+    #[tokio::test]
+    async fn cli_wins_and_closure_never_runs() {
+        let calls = Cell::new(0);
+        let r: Result<String> = pair(Some("from-cli"), Some("from-fallback"))
+            .resolve_or(
+                || async {
+                    calls.set(calls.get() + 1);
+                    Some("from-closure".into())
+                },
+                "should not error",
+            )
+            .await;
+        assert_eq!(r.unwrap(), "from-cli");
+        assert_eq!(calls.get(), 0, "closure must not run when CLI is Some");
+    }
+
+    #[tokio::test]
+    async fn closure_result_wins_over_fallback() {
+        let r: Result<String> = pair(None, Some("from-fallback"))
+            .resolve_or(|| async { Some("from-closure".into()) }, "should not error")
+            .await;
+        assert_eq!(r.unwrap(), "from-closure");
+    }
+
+    #[tokio::test]
+    async fn fallback_used_when_cli_and_closure_both_empty() {
+        let r: Result<String> = pair(None, Some("from-fallback"))
+            .resolve_or(|| async { Option::<String>::None }, "should not error")
+            .await;
+        assert_eq!(r.unwrap(), "from-fallback");
+    }
+
+    #[tokio::test]
+    async fn error_when_every_source_is_none() {
+        let r: Result<String> = pair(None, None)
+            .resolve_or(|| async { Option::<String>::None }, "all sources empty")
+            .await;
+        let err = r.unwrap_err();
+        assert!(err.to_string().contains("all sources empty"));
+    }
+
+    #[tokio::test]
+    async fn resolve_without_err_returns_none_when_all_empty() {
+        let r: Option<String> = pair(None, None)
+            .resolve(|| async { Option::<String>::None })
+            .await;
+        assert!(r.is_none());
+    }
+}

--- a/tools/jj-gh-config-derive/Cargo.toml
+++ b/tools/jj-gh-config-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "jj-gh-config-derive"
+edition = "2024"
+version = "0.0.0"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "extra-traits"] }
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }

--- a/tools/jj-gh-config-derive/src/lib.rs
+++ b/tools/jj-gh-config-derive/src/lib.rs
@@ -1,0 +1,626 @@
+//! Proc-macros backing the `jj-gh` config + CLI layering system.
+//!
+//! Two macros:
+//!
+//! - [`config_schema!`]: central, lives in `src/config.rs`. Declares every
+//!   config-backed field once: storage type, default, optional `#[cli(...)]`
+//!   presentation, optional `#[env(...)]` binding. Emits the `Config` struct,
+//!   `Default` impl, and serde derives (with `skip_serializing_if = "Option::is_none"`
+//!   auto-added on `Option<T>` fields).
+//! - [`subcommand_args!`]: co-located with each command. Emits a clap-parsed
+//!   input struct and a resolved struct handlers consume.
+//!
+//! ## `config_schema!` field attrs
+//!
+//! Each field can be preceded by:
+//!
+//! - `///` doc comments: forwarded to the emitted Config field.
+//! - `#[serde(..)]`: forwarded verbatim. If any such attr touches
+//!   `skip_serializing`, the auto-added `skip_serializing_if` is suppressed.
+//! - `#[cli(long = "...", short = '_', value_name = "...", flip = "no-...")]`:
+//!   stored for [`subcommand_args!`] to consume (not used yet).
+//! - `#[env("ENV_KEY", string | path | argv)]`: env-var binding for the
+//!   `env_overlay()` helper.
+//! - `#[forward(meta)]`: splat an arbitrary attribute onto the emitted Config
+//!   field. Used for `cfg_attr(feature = "schema-validation",
+//!   schemars(with = "Option<String>"))` and similar.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{
+    Attribute, Expr, Ident, LitStr, Token, Type,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+};
+
+struct Schema {
+    fields: Vec<SchemaField>,
+}
+
+struct SchemaField {
+    docs: Vec<Attribute>,
+    forwards: Vec<TokenStream2>,
+    serde_attrs: Vec<TokenStream2>,
+    _cli: Option<TokenStream2>,
+    env: Option<EnvSpec>,
+    name: Ident,
+    ty: Type,
+    default: Expr,
+}
+
+struct EnvSpec {
+    key: LitStr,
+    kind: EnvKind,
+}
+
+enum EnvKind {
+    String,
+    Path,
+    Argv,
+}
+
+impl Parse for EnvSpec {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key: LitStr = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let kind_ident: Ident = input.parse()?;
+        let kind = match kind_ident.to_string().as_str() {
+            "string" => EnvKind::String,
+            "path" => EnvKind::Path,
+            "argv" => EnvKind::Argv,
+            _ => {
+                return Err(syn::Error::new_spanned(
+                    kind_ident,
+                    "expected one of: string, path, argv",
+                ));
+            }
+        };
+        Ok(EnvSpec { key, kind })
+    }
+}
+
+impl Parse for Schema {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut fields = Vec::new();
+        while !input.is_empty() {
+            fields.push(input.parse()?);
+        }
+        Ok(Schema { fields })
+    }
+}
+
+impl Parse for SchemaField {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let raw_attrs = input.call(Attribute::parse_outer)?;
+        let mut docs = Vec::new();
+        let mut forwards = Vec::new();
+        let mut serde_attrs = Vec::new();
+        let mut cli = None;
+        let mut env = None;
+        for attr in raw_attrs {
+            if attr.path().is_ident("doc") {
+                docs.push(attr);
+            } else if attr.path().is_ident("serde") {
+                serde_attrs.push(attr.parse_args::<TokenStream2>()?);
+            } else if attr.path().is_ident("forward") {
+                forwards.push(attr.parse_args::<TokenStream2>()?);
+            } else if attr.path().is_ident("cli") {
+                cli = Some(attr.parse_args::<TokenStream2>()?);
+            } else if attr.path().is_ident("env") {
+                env = Some(attr.parse_args::<EnvSpec>()?);
+            } else {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "unknown config_schema attribute; expected #[serde(..)], \
+                     #[cli(..)], #[env(..)], #[forward(..)], or a doc comment",
+                ));
+            }
+        }
+        let name: Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty: Type = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let default: Expr = input.parse()?;
+        let _trailing: Option<Token![,]> = input.parse()?;
+        Ok(SchemaField {
+            docs,
+            forwards,
+            serde_attrs,
+            _cli: cli,
+            env,
+            name,
+            ty,
+            default,
+        })
+    }
+}
+
+fn is_option(ty: &Type) -> bool {
+    if let Type::Path(p) = ty
+        && let Some(seg) = p.path.segments.last()
+    {
+        return seg.ident == "Option";
+    }
+    false
+}
+
+/// Extracts `T` from `Option<T>`. Returns `None` if `ty` is not syntactically
+/// `Option<...>` with a single generic argument.
+fn option_inner(ty: &Type) -> Option<Type> {
+    let Type::Path(p) = ty else {
+        return None;
+    };
+    let seg = p.path.segments.last()?;
+    if seg.ident != "Option" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &seg.arguments else {
+        return None;
+    };
+    let arg = args.args.first()?;
+    let syn::GenericArgument::Type(inner) = arg else {
+        return None;
+    };
+    Some(inner.clone())
+}
+
+fn touches_skip_serializing(serde_attrs: &[TokenStream2]) -> bool {
+    serde_attrs
+        .iter()
+        .any(|tt| tt.to_string().contains("skip_serializing"))
+}
+
+#[proc_macro]
+pub fn config_schema(input: TokenStream) -> TokenStream {
+    let schema = parse_macro_input!(input as Schema);
+
+    let struct_fields = schema.fields.iter().map(|f| {
+        let docs = &f.docs;
+        let forwards = f.forwards.iter().map(|tt| quote!(#[#tt]));
+        let mut serde_attrs: Vec<TokenStream2> = f
+            .serde_attrs
+            .iter()
+            .map(|inner| quote!(#[serde(#inner)]))
+            .collect();
+        if is_option(&f.ty) && !touches_skip_serializing(&f.serde_attrs) {
+            serde_attrs.push(quote!(#[serde(skip_serializing_if = "Option::is_none")]));
+        }
+        let name = &f.name;
+        let ty = &f.ty;
+        quote! {
+            #(#docs)*
+            #(#forwards)*
+            #(#serde_attrs)*
+            pub #name: #ty,
+        }
+    });
+
+    let default_inits = schema.fields.iter().map(|f| {
+        let name = &f.name;
+        let default = &f.default;
+        quote! { #name: #default, }
+    });
+
+    let env_fields = schema.fields.iter().filter_map(|f| {
+        let env = f.env.as_ref()?;
+        let name = &f.name;
+        let ty = &f.ty;
+        let key = &env.key;
+        let read = match env.kind {
+            EnvKind::String => quote!(__env_read_string(#key)),
+            EnvKind::Path => quote!(__env_read_path(#key)),
+            EnvKind::Argv => quote!(__env_read_argv(#key)),
+        };
+        Some((name.clone(), ty.clone(), read))
+    });
+
+    let (env_struct_fields, env_inits): (Vec<_>, Vec<_>) = env_fields
+        .map(|(name, ty, read)| {
+            let struct_field = quote! {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                #name: #ty,
+            };
+            let init = quote! { #name: #read, };
+            (struct_field, init)
+        })
+        .unzip();
+
+    let schema_aliases = schema.fields.iter().map(|f| {
+        let name = &f.name;
+        let ty = &f.ty;
+        quote! {
+            #[allow(non_camel_case_types)]
+            pub type #name = #ty;
+        }
+    });
+
+    let expanded = quote! {
+        #[derive(::std::fmt::Debug, ::serde::Deserialize, ::serde::Serialize)]
+        #[cfg_attr(feature = "schema-validation", derive(::schemars::JsonSchema))]
+        #[serde(default)]
+        pub struct Config {
+            #(#struct_fields)*
+        }
+
+        impl ::std::default::Default for Config {
+            fn default() -> Self {
+                Self {
+                    #(#default_inits)*
+                }
+            }
+        }
+
+        /// Per-field storage-type aliases, used by `subcommand_args!` to
+        /// compile-time verify that local `#[config]` fields match the
+        /// schema's storage type. Do not depend on this module from outside
+        /// generated macro output.
+        #[doc(hidden)]
+        pub mod __schema {
+            use super::*;
+            #(#schema_aliases)*
+        }
+
+        /// Snapshot of env-var bindings declared in `config_schema!`.
+        ///
+        /// Returned value is a serde-serializable overlay suitable for
+        /// `figment::providers::Serialized::defaults(env_overlay())`. Unset or
+        /// empty env vars produce `None` fields, which are skipped by serde
+        /// so they don't clobber lower layers.
+        #[must_use]
+        pub fn env_overlay() -> impl ::serde::Serialize {
+            #[derive(::serde::Serialize)]
+            struct __EnvOverlay {
+                #(#env_struct_fields)*
+            }
+            fn __env_read_string(key: &str) -> ::std::option::Option<::std::string::String> {
+                ::std::env::var(key).ok().filter(|s| !s.is_empty())
+            }
+            fn __env_read_path(key: &str) -> ::std::option::Option<::std::path::PathBuf> {
+                ::std::env::var_os(key)
+                    .filter(|s| !s.is_empty())
+                    .map(::std::path::PathBuf::from)
+            }
+            fn __env_read_argv(key: &str) -> ::std::option::Option<::std::vec::Vec<::std::string::String>> {
+                let raw = ::std::env::var(key).ok().filter(|s| !s.is_empty())?;
+                ::shell_words::split(&raw).ok().filter(|v| !v.is_empty())
+            }
+            __EnvOverlay {
+                #(#env_inits)*
+            }
+        }
+    };
+
+    expanded.into()
+}
+
+struct SubcommandArgs {
+    no_globals: bool,
+    vis: syn::Visibility,
+    name: Ident,
+    fields: Vec<ArgField>,
+}
+
+struct ArgField {
+    docs: Vec<Attribute>,
+    passthrough_attrs: Vec<Attribute>,
+    arg: Option<Attribute>,
+    config: Option<ConfigLink>,
+    name: Ident,
+    ty: Type,
+}
+
+enum ConfigLink {
+    /// `#[config]`: storage-field name matches the schema key.
+    Same,
+    /// `#[config(maps_to = "schema_key")]`: storage-field name renamed for figment.
+    Renamed(LitStr),
+    /// `#[config(fallback = "schema_key")]`: CLI override at chain top, schema
+    /// key holds last-resort default. Resolved field becomes
+    /// `EvalWithCfgFallback<T>`; the CLI value does not merge into the schema
+    /// key.
+    Fallback(LitStr),
+}
+
+impl Parse for SubcommandArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let outer_attrs = input.call(Attribute::parse_outer)?;
+        let mut no_globals = false;
+        for attr in outer_attrs {
+            if attr.path().is_ident("no_globals") {
+                no_globals = true;
+            } else {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "unknown subcommand_args struct attribute; expected #[no_globals]",
+                ));
+            }
+        }
+        let vis: syn::Visibility = input.parse()?;
+        input.parse::<Token![struct]>()?;
+        let name: Ident = input.parse()?;
+        let content;
+        syn::braced!(content in input);
+        let mut fields = Vec::new();
+        while !content.is_empty() {
+            fields.push(content.parse()?);
+        }
+        Ok(SubcommandArgs {
+            no_globals,
+            vis,
+            name,
+            fields,
+        })
+    }
+}
+
+impl Parse for ArgField {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let raw_attrs = input.call(Attribute::parse_outer)?;
+        let mut docs = Vec::new();
+        let mut passthrough_attrs = Vec::new();
+        let mut arg: Option<Attribute> = None;
+        let mut config: Option<ConfigLink> = None;
+        for attr in raw_attrs {
+            if attr.path().is_ident("doc") {
+                docs.push(attr);
+            } else if attr.path().is_ident("arg") {
+                if arg.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "duplicate #[arg(..)] attribute",
+                    ));
+                }
+                arg = Some(attr);
+            } else if attr.path().is_ident("config") {
+                if config.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "duplicate #[config] attribute",
+                    ));
+                }
+                config = Some(parse_config_attr(&attr)?);
+            } else {
+                passthrough_attrs.push(attr);
+            }
+        }
+        let _vis: syn::Visibility = input.parse()?;
+        let name: Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty: Type = input.parse()?;
+        let _trailing: Option<Token![,]> = input.parse()?;
+        Ok(ArgField {
+            docs,
+            passthrough_attrs,
+            arg,
+            config,
+            name,
+            ty,
+        })
+    }
+}
+
+fn parse_config_attr(attr: &Attribute) -> syn::Result<ConfigLink> {
+    match &attr.meta {
+        syn::Meta::Path(_) => Ok(ConfigLink::Same),
+        syn::Meta::List(list) => {
+            let mut maps_to: Option<LitStr> = None;
+            let mut fallback: Option<LitStr> = None;
+            list.parse_nested_meta(|nested| {
+                if nested.path.is_ident("maps_to") {
+                    let value: LitStr = nested.value()?.parse()?;
+                    maps_to = Some(value);
+                    Ok(())
+                } else if nested.path.is_ident("fallback") {
+                    let value: LitStr = nested.value()?.parse()?;
+                    fallback = Some(value);
+                    Ok(())
+                } else {
+                    Err(nested.error("expected `maps_to = \"...\"` or `fallback = \"...\"`"))
+                }
+            })?;
+            match (maps_to, fallback) {
+                (Some(_), Some(_)) => Err(syn::Error::new_spanned(
+                    attr,
+                    "`maps_to` and `fallback` are mutually exclusive",
+                )),
+                (Some(key), None) => Ok(ConfigLink::Renamed(key)),
+                (None, Some(key)) => Ok(ConfigLink::Fallback(key)),
+                (None, None) => Err(syn::Error::new_spanned(
+                    attr,
+                    "expected #[config(maps_to = \"...\")] or #[config(fallback = \"...\")]",
+                )),
+            }
+        }
+        syn::Meta::NameValue(_) => Err(syn::Error::new_spanned(
+            attr,
+            "expected #[config], #[config(maps_to = \"...\")], or #[config(fallback = \"...\")]",
+        )),
+    }
+}
+
+fn schema_key_for(field: &ArgField) -> String {
+    match &field.config {
+        Some(ConfigLink::Renamed(lit) | ConfigLink::Fallback(lit)) => lit.value(),
+        _ => field.name.to_string(),
+    }
+}
+
+#[proc_macro]
+#[allow(clippy::too_many_lines)]
+pub fn subcommand_args(input: TokenStream) -> TokenStream {
+    let SubcommandArgs {
+        no_globals,
+        vis,
+        name,
+        fields,
+    } = parse_macro_input!(input as SubcommandArgs);
+
+    let input_name = quote::format_ident!("{}Input", name);
+
+    // Validate: every field must have at least one of #[arg] or #[config].
+    for f in &fields {
+        if f.arg.is_none() && f.config.is_none() {
+            return syn::Error::new_spanned(
+                &f.name,
+                "field needs at least one of #[arg(..)] or #[config(..)]",
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
+    // Input-struct fields (clap parsing target): everything with #[arg(..)].
+    let input_fields = fields.iter().filter_map(|f| {
+        let arg = f.arg.as_ref()?;
+        let docs = &f.docs;
+        let passthrough = &f.passthrough_attrs;
+        let fname = &f.name;
+        let fty = &f.ty;
+        // #[config] fields need Option-wrap in input so figment skips when
+        // CLI arg absent. Already-Option types stay as-is. We emit the
+        // unqualified `Option` so clap's derive recognizes the optional
+        // shape (it pattern-matches on the literal ident `Option`).
+        let wrapped = if is_option(fty) {
+            quote!(#fty)
+        } else {
+            quote!(Option<#fty>)
+        };
+        let (input_ty, serde_attr) = match &f.config {
+            Some(ConfigLink::Same | ConfigLink::Renamed(_)) => {
+                let key = schema_key_for(f);
+                (
+                    wrapped,
+                    quote! {
+                        #[serde(rename = #key, skip_serializing_if = "Option::is_none")]
+                    },
+                )
+            }
+            // Fallback: CLI value must NOT merge into the schema key (they sit
+            // at opposite ends of a precedence chain). Input keeps Option<T>
+            // for clap; serde skips entirely.
+            Some(ConfigLink::Fallback(_)) => (wrapped, quote! { #[serde(skip)] }),
+            None => (quote!(#fty), quote! { #[serde(skip)] }),
+        };
+        Some(quote! {
+            #(#docs)*
+            #(#passthrough)*
+            #arg
+            #serde_attr
+            pub #fname: #input_ty,
+        })
+    });
+
+    // Resolved-struct fields and resolve-body initializers.
+    let mut resolved_fields = Vec::new();
+    let mut resolve_inits = Vec::new();
+    for f in &fields {
+        let fname = &f.name;
+        let fty = &f.ty;
+        let docs = &f.docs;
+        match &f.config {
+            Some(ConfigLink::Fallback(_)) => {
+                // Resolved field becomes EvalWithCfgFallback<T>. Inner T is
+                // the CLI field's unwrapped storage type.
+                let key = syn::Ident::new(&schema_key_for(f), proc_macro2::Span::call_site());
+                let inner = option_inner(fty).unwrap_or(fty.clone());
+                resolved_fields.push(quote! {
+                    #(#docs)*
+                    pub #fname: crate::util::EvalWithCfgFallback<#inner>,
+                });
+                resolve_inits.push(quote! {
+                    #fname: crate::util::EvalWithCfgFallback::new(
+                        input.#fname,
+                        ::std::clone::Clone::clone(&config.#key),
+                    ),
+                });
+            }
+            Some(ConfigLink::Same | ConfigLink::Renamed(_)) => {
+                let key = syn::Ident::new(&schema_key_for(f), proc_macro2::Span::call_site());
+                resolved_fields.push(quote! {
+                    #(#docs)*
+                    pub #fname: #fty,
+                });
+                resolve_inits.push(quote! {
+                    #fname: ::std::clone::Clone::clone(&config.#key),
+                });
+            }
+            None => {
+                resolved_fields.push(quote! {
+                    #(#docs)*
+                    pub #fname: #fty,
+                });
+                resolve_inits.push(quote! { #fname: input.#fname, });
+            }
+        }
+    }
+
+    // Compile-time type checks: each #[config] field's local type must match
+    // the schema storage type alias under `crate::config::__schema`.
+    let type_checks = fields.iter().filter_map(|f| {
+        let _ = f.config.as_ref()?;
+        let fty = &f.ty;
+        let key = syn::Ident::new(&schema_key_for(f), proc_macro2::Span::call_site());
+        let check_name = quote::format_ident!(
+            "_CHECK_{}_{}",
+            name.to_string().to_uppercase(),
+            f.name.to_string().to_uppercase()
+        );
+        Some(quote! {
+            #[allow(dead_code)]
+            const #check_name: fn(#fty) -> crate::config::__schema::#key = ::std::convert::identity;
+        })
+    });
+
+    let (globals_field, globals_init, resolve_extra_param, resolved_derives) = if no_globals {
+        (
+            quote!(),
+            quote!(),
+            quote!(),
+            quote!(::std::fmt::Debug, ::std::clone::Clone),
+        )
+    } else {
+        (
+            quote! {
+                /// Resolved globals (remote, askpass, log options, ...).
+                pub globals: crate::cli::GlobalOpts,
+            },
+            quote!(globals: ::std::clone::Clone::clone(globals),),
+            quote!(, globals: &crate::cli::GlobalOpts),
+            quote!(::std::fmt::Debug),
+        )
+    };
+
+    let expanded = quote! {
+        #[derive(::std::fmt::Debug, ::clap::Args, ::serde::Serialize)]
+        #vis struct #input_name {
+            #(#input_fields)*
+        }
+
+        #[derive(#resolved_derives)]
+        #vis struct #name {
+            #globals_field
+            #(#resolved_fields)*
+        }
+
+        impl #name {
+            /// Build the resolved args from the clap-parsed input plus the
+            /// merged Config (and resolved globals, except on `#[no_globals]`
+            /// structs like `GlobalOpts` itself).
+            pub fn resolve(
+                input: #input_name,
+                config: &crate::config::Config
+                #resolve_extra_param
+            ) -> Self {
+                Self {
+                    #globals_init
+                    #(#resolve_inits)*
+                }
+            }
+        }
+
+        #(#type_checks)*
+    };
+
+    expanded.into()
+}


### PR DESCRIPTION
Adds a proc macro to handle mergeing the layers and generating simpler structs.

Command runners now just check one place for the values they need; no `.or()`/`.unwrap_or_else()` shenanigans that is prone to error. Global args are available on your args struct via `args.globals` (injected by the macro) so all arguments are co-located.

Default values and values from the configuration files are injected into the arguments; no need to check layers manually. If an argument is not provided, `args.whatever` will be the `whatever` field from the config file(s) if it exists.
