### PR TITLE
fix(ci): Don't bother running semver checks on CLI crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2ad8abffe4e2b05f9cdc7e061de63d305a6dca0af81ca1064a7d98e0b78267"
+checksum = "46a4184473c1d00a892dad5259e1d19421ab1f8e4b7d714113a6cfdb213d9980"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2515,6 +2525,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "http-serde",
  "hyper",
  "hyper-rustls",
  "hyper-timeout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ graphql_client = "0.16"
 http = "1"
 jj-gh-config-derive = { path = "tools/jj-gh-config-derive" }
 log = "0.4"
-octocrab = "0.51"
+octocrab = "0.53"
 schemars = { version = "1", optional = true }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,3 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [[package]]
 name = "jj-gh"
 changelog_update = true
+# this is a CLI not a library, so the semver checks
+# do not really buy anything; for example it thinks
+# adding a field to the `Config` struct is a breaking
+# change but it isn't, and it would not detect certain
+# real breaking changes like removing a subcommand anyway.
+# keep this under `[[package]]` in case a library is
+# introduced in the future.
+semver_check = false


### PR DESCRIPTION
`cargo-semver-checks` isn't accurate when running on the context of a CLI. For example it considers adding a field to the `Config` struct to be a breaking change. It would also not catch certain classes of real breaking changes anyway, such as removing a subcommand (since they come from an enum that is not `pub`). Therefore, we just rely on proper conventional commits and PR titles to flag breaking chnages like `feat(cli)!: Some breaking change description` (the `!` indicates a breaking change).
