### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.4...jj-gh-v0.2.5) - 2026-06-11
+
+### Fixed
+
+- *(cli)* Clean up config loader and macro, improve responsiveness
+- *(cli)* Fix color regression by cleaning up & standardizing cmd runner
+- *(jj)* Stream output for cmds where we don't need to parse its STDOUT
+- *(log)* Improve logging readability in many areas
+- *(remotes)* Detect default remote instead of relying on custom config
+
+### Other
+
+- *(cli)* Reorganize modules
+- *(docs)* Clarify details about GitHub tokens
+- Merge pull request #164 from mrjones2014/mrj/push-puqtnponxmuw
+- *(docs)* update README.md with Usage and Tips and Tricks sections
+
 ## [0.2.4](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.3...jj-gh-v0.2.4) - 2026-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh-config-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.2.4"
+version = "0.2.5"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",
@@ -51,7 +51,7 @@ gix = { version = "0.84", default-features = false, features = [
 ] }
 graphql_client = "0.16"
 http = "1"
-jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.0" }
+jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.1" }
 log = "0.4"
 octocrab = "0.53"
 schemars = { version = "1", optional = true }

--- a/tools/jj-gh-config-derive/Cargo.toml
+++ b/tools/jj-gh-config-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jj-gh-config-derive"
 edition = "2024"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/mrjones2014/jj-gh"
 description = "You are probably looking for the `jj-gh` crate instead."
 


### PR DESCRIPTION



## 🤖 New release

* `jj-gh-config-derive`: 0.1.0 -> 0.1.1
* `jj-gh`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>


## `jj-gh`

<blockquote>

## [0.2.5](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.4...jj-gh-v0.2.5) - 2026-06-11

### Fixed

- *(cli)* Clean up config loader and macro, improve responsiveness
- *(cli)* Fix color regression by cleaning up & standardizing cmd runner
- *(jj)* Stream output for cmds where we don't need to parse its STDOUT
- *(log)* Improve logging readability in many areas
- *(remotes)* Detect default remote instead of relying on custom config

### Other

- *(cli)* Reorganize modules
- *(docs)* Clarify details about GitHub tokens
- Merge pull request #164 from mrjones2014/mrj/push-puqtnponxmuw
- *(docs)* update README.md with Usage and Tips and Tricks sections
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).