### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.5...jj-gh-v0.2.6) - 2026-06-13
+
+### Added
+
+- *(ci)* Upload binaries to GitHub Releases for `cargo-binstall`
+- *(pr-retry-failed)* Add `--all` flag to retry for all local PRs
+
+### Fixed
+
+- *(pr-create)* Don't try to validate PR body
+- *(cli)* Simplify logging format to avoid contrast readability issues
+
+### Other
+
+- *(dpes)* update GitHub GraphQL schema
+- Merge pull request #184 from mrjones2014/renovate/lock-file-maintenance
+- *(deps)* lock file maintenance
+- *(deps)* update cargo minor and patch
+- *(fmt)* Use turbofish over type ascription
+
 ## [0.2.5](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.4...jj-gh-v0.2.5) - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh-config-derive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.2.5"
+version = "0.2.6"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",
@@ -51,7 +51,7 @@ gix = { version = "0.84", default-features = false, features = [
 ] }
 graphql_client = "0.16"
 http = "1"
-jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.1" }
+jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.2" }
 log = "0.4"
 octocrab = "0.53"
 schemars = { version = "1", optional = true }

--- a/tools/jj-gh-config-derive/Cargo.toml
+++ b/tools/jj-gh-config-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jj-gh-config-derive"
 edition = "2024"
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/mrjones2014/jj-gh"
 description = "You are probably looking for the `jj-gh` crate instead."
 


### PR DESCRIPTION



## 🤖 New release

* `jj-gh-config-derive`: 0.1.1 -> 0.1.2
* `jj-gh`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>


## `jj-gh`

<blockquote>

## [0.2.6](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.5...jj-gh-v0.2.6) - 2026-06-13

### Added

- *(ci)* Upload binaries to GitHub Releases for `cargo-binstall`
- *(pr-retry-failed)* Add `--all` flag to retry for all local PRs

### Fixed

- *(pr-create)* Don't try to validate PR body
- *(cli)* Simplify logging format to avoid contrast readability issues

### Other

- *(dpes)* update GitHub GraphQL schema
- Merge pull request #184 from mrjones2014/renovate/lock-file-maintenance
- *(deps)* lock file maintenance
- *(deps)* update cargo minor and patch
- *(fmt)* Use turbofish over type ascription
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).