### PR TITLE
fix(ci): Remove no longer needed hack to get CI to run on automated PRs

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -22,8 +22,3 @@ jobs:
           commit-message: "chore(dpes): update GitHub GraphQL schema"
           title: "chore(deps): update GitHub GraphQL schema"
           branch: "automation/update-graphql-schema"
-      - name: Trigger CI
-        if: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: gh workflow run ci.yml --ref automation/update-graphql-schema
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This hack is no longer needed. PRs opened by `github-actions[bot]` can now run CI, albeit after manual human approval.

Related: #159