### PR TITLE
feat(ci): Upload binaries to GitHub Releases for `cargo-binstall`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,32 @@
+name: cd
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+jobs:
+  upload-binaries:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: aarch64-apple-darwin
+            os: macos-15
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: jj-gh
+          package: jj-gh
+          target: ${{ matrix.target }}
+          locked: true
+          checksum: sha256

--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ Public Key: `jj-gh.cachix.org-1:N1uFBMDd9znlhDa68BRqLSXYzXXJ2+WHVuwxpGxCtDo=`
 
 <details>
 
+  <summary>Precompiled binary</summary>
+
+Download and extract the archive for your platform from the [latest GitHub release](https://github.com/mrjones2014/jj-gh/releases/latest), then
+place the `jj-gh` binary somewhere in your `$PATH`.
+
+</details>
+
+<details>
+
+  <summary>with <code>cargo-binstall</code></summary>
+
+Requires [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
+
+```sh
+cargo binstall jj-gh
+```
+
+</details>
+
+<details>
+
   <summary>From crates.io</summary>
 
 Requires a Rust toolchain.


### PR DESCRIPTION
Upload precompiled binaries to GitHub Releases so `cargo-binstall` users can install them.