### PR TITLE
fix(ci): Don't create GitHub Releases for `jj-gh-config-derive` package

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,3 +25,4 @@ semver_check = false
 [[package]]
 name = "jj-gh-config-derive"
 changelog_update = false
+git_release_enable = false


### PR DESCRIPTION
It's confusing and unnecessary to create a GitHub Release for `jj-gh-config-derive`, its just some proc macros we use for the config structs. It's not really a stand-alone thing.