### PR TITLE
chore(contrib): Add `.#dev` package for faster local iteration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,9 @@ I also recommend setting the following repo configs for `jj`:
 
 ```toml
 [aliases]
-pr = ["util", "exec", "--", "nix", "run", ".#", "--", "pr"]
+# .#dev is the same as `.#default` but with `doCheck = false`
+# and skips completion installation, for faster local iteration
+pr = ["util", "exec", "--", "nix", "run", ".#dev", "--", "pr"]
 
 [fix.tools.treefmt]
 command = ["treefmt", "--quiet", "--stdin", "$path"]

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,14 @@
               '';
           }
         );
+        jj-gh-dev = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+            cargoExtraArgs = "--package jj-gh";
+            doCheck = false;
+          }
+        );
         gen-docs = craneLib.buildPackage (
           commonArgs
           // {
@@ -184,6 +192,7 @@
       {
         packages = {
           default = jj-gh;
+          dev = jj-gh-dev;
           inherit gen-docs gen-manpage;
           udeps = craneLibNightly.mkCargoDerivation (
             commonArgs


### PR DESCRIPTION
Add a `.#dev` Nix package to the flake for faster iterative testing, its like the default package but with `doCheck = false` and skips installing completions.