### PR TITLE
chore(nix): Refactor flake pkgs and checks for {read,maintain}ability

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-watch_file ./nix/treefmt.nix
+watch_dir ./nix
 use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
+  discover_checks:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.checks.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - id: checks
+        run: echo "targets=$(nix eval --json .#checks.x86_64-linux --apply builtins.attrNames)" >> "$GITHUB_OUTPUT"
   check:
+    needs: discover_checks
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: [jj-gh, clippy, nextest, treefmt, ast-grep, graphql-validate, hm-module-schema, docs, release-plz-patched]
+        target: ${{ fromJSON(needs.discover_checks.outputs.targets) }}
     steps:
       - uses: wimpysworld/nothing-but-nix@main
       - uses: actions/checkout@v6
@@ -30,19 +44,17 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community
       - run: nix build .#checks.x86_64-linux.${{ matrix.target }} --print-build-logs
-      - if: matrix.target == 'jj-gh' && github.event_name == 'push'
-        run: nix build .#checks.x86_64-linux.release-plz-patched --print-build-logs
       # we don't really ever need to rebuild this, so pin it in cachix
       - if: matrix.target == 'release-plz-patched' && github.event_name == 'push'
         run: |
           path=$(nix build .#checks.x86_64-linux.release-plz-patched --print-out-paths --no-link)
           cachix pin jj-gh release-plz-patched "$path"
   flake-check:
-    needs: check
+    needs: [discover_checks, check]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ contains(needs.check.result, 'failure') || contains(needs.check.result, 'cancelled') }}
+      - if: ${{ needs.discover_checks.result != 'success' || needs.check.result != 'success' }}
         run: exit 1
   udeps:
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "Configurable jj subcommand for GitHub PR workflows";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -18,10 +18,10 @@
   outputs =
     {
       self,
-      nixpkgs,
-      flake-utils,
-      rust-overlay,
       crane,
+      flake-utils,
+      nixpkgs,
+      rust-overlay,
       treefmt-nix,
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -34,8 +34,6 @@
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
-        nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);
-        craneLibNightly = (crane.mkLib pkgs).overrideToolchain nightlyToolchain;
         src =
           let
             root = ./.;
@@ -61,154 +59,34 @@
           nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.pkg-config ];
         };
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        cargoArtifactsNightly = craneLibNightly.buildDepsOnly commonArgs;
-        jj-gh = craneLib.buildPackage (
-          commonArgs
-          // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "--package jj-gh";
-
-            nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
-              pkgs.installShellFiles
-            ];
-
-            postInstall =
-              let
-                jj-gh = "${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} $out/bin/jj-gh";
-              in
-              ''
-                ${gen-manpage}/bin/gen-manpage > jj-gh.1
-                installManPage jj-gh.1
-              ''
-              + pkgs.lib.optionalString (pkgs.stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages) ''
-                installShellCompletion --cmd jj-gh \
-                  --bash <(${jj-gh} completions bash) \
-                  --fish <(${jj-gh} completions fish) \
-                  --zsh <(${jj-gh} completions zsh)
-              '';
-          }
-        );
-        jj-gh-dev = craneLib.buildPackage (
-          commonArgs
-          // {
-            inherit cargoArtifacts;
-            cargoExtraArgs = "--package jj-gh";
-            doCheck = false;
-          }
-        );
-        gen-docs = craneLib.buildPackage (
-          commonArgs
-          // {
-            inherit cargoArtifacts;
-            pname = "gen-docs";
-            cargoExtraArgs = "--package gen-docs";
-            doCheck = false;
-          }
-        );
-        gen-manpage = craneLib.buildPackage (
-          commonArgs
-          // {
-            inherit cargoArtifacts;
-            pname = "gen-manpage";
-            cargoExtraArgs = "--package gen-manpage";
-            doCheck = false;
-          }
-        );
-        schemaArtifacts = craneLib.buildDepsOnly (
-          commonArgs
-          // {
-            pname = "print-config-schema-deps";
-            cargoExtraArgs = "--package print-config-schema";
-          }
-        );
-        print-config-schema = craneLib.buildPackage (
-          commonArgs
-          // {
-            cargoArtifacts = schemaArtifacts;
-            pname = "print-config-schema";
-            cargoExtraArgs = "--package print-config-schema";
-            doCheck = false;
-          }
-        );
-        hmModuleSettingsOptsJson =
-          let
-            mod = (import ./nix/hm-module.nix self) {
-              config = { };
-              inherit (pkgs) lib;
-              inherit pkgs;
-            };
-            names = builtins.attrNames mod.options.programs.jujutsu.gh.settings;
-          in
-          pkgs.writeText "hm-module-settings-opts.json" (
-            builtins.toJSON (builtins.sort builtins.lessThan names)
-          );
         treefmtEval = treefmt-nix.lib.evalModule pkgs (import ./nix/treefmt.nix { inherit rustToolchain; });
-        astGrepSrc = pkgs.lib.fileset.toSource {
-          root = ./.;
-          fileset = ./.;
-        };
-        gen-docs-app = pkgs.writeShellApplication {
-          name = "gen-docs";
-          runtimeInputs = [
-            gen-docs
-            treefmtEval.config.build.wrapper
-          ];
-          text = ''
-            gen-docs > DOCS.md
-            treefmt --no-cache DOCS.md
-          '';
-        };
-        # TODO remove when PR merges and nixpkgs updated: https://github.com/release-plz/release-plz/pull/2857
-        release-plz-patched = pkgs.release-plz.overrideAttrs (old: {
-          patches = (old.patches or [ ]) ++ [
-            (pkgs.fetchpatch {
-              name = "walk-all-branches-2857.patch";
-              url = "https://github.com/release-plz/release-plz/commit/0bf9940e70958cb3777dae063bfda2db77d40502.patch";
-              hash = "sha256-ii1SQ64Wg38sbboafTReOJji8brBYOBfaDjKHbe7SoI=";
-            })
-          ];
-        });
-        release-app = pkgs.writeShellApplication {
-          name = "release";
-          runtimeInputs = [
+        packageSet = import ./nix/pkgs {
+          inherit
+            pkgs
+            crane
+            craneLib
+            commonArgs
+            cargoArtifacts
             rustToolchain
-            release-plz-patched
-            pkgs.cargo-semver-checks
-            pkgs.git
-          ];
-          text = ''
-            release-plz release-pr --git-token "$GITHUB_TOKEN" "$@"
-            release-plz release --git-token "$GITHUB_TOKEN" "$@"
-          '';
+            treefmtEval
+            ;
         };
-        fetch-schema-app = pkgs.writeShellApplication {
-          name = "fetch-schema";
-          runtimeInputs = [ pkgs.python3 ];
-          text = ''
-            python3 ${./tools/fetch-schema.py}
-          '';
-        };
+        inherit (packageSet)
+          fetch-schema-app
+          jj-gh
+          print-config-schema
+          release-app
+          release-plz-patched
+          update-docs
+          ;
       in
       {
-        packages = {
-          default = jj-gh;
-          dev = jj-gh-dev;
-          inherit gen-docs gen-manpage;
-          udeps = craneLibNightly.mkCargoDerivation (
-            commonArgs
-            // {
-              cargoArtifacts = cargoArtifactsNightly;
-              pnameSuffix = "-udeps";
-              buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --locked";
-              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
-            }
-          );
-        };
+        inherit (packageSet) packages;
         apps = {
           default = flake-utils.lib.mkApp { drv = jj-gh; };
           docs = flake-utils.lib.mkApp {
-            drv = gen-docs-app;
-            name = "gen-docs";
+            drv = update-docs;
+            name = "update-docs";
           };
           release = flake-utils.lib.mkApp {
             drv = release-app;
@@ -232,88 +110,20 @@
             treefmtEval.config.build.wrapper
           ];
         };
-        checks = {
-          inherit jj-gh;
-          clippy = craneLib.cargoClippy (
+        checks = import ./nix/checks {
+          inherit
+            self
+            pkgs
+            craneLib
             commonArgs
-            // {
-              inherit cargoArtifacts;
-              cargoClippyExtraArgs = "--workspace -- -D warnings";
-            }
-          );
-          nextest = craneLib.cargoNextest (
-            commonArgs
-            // {
-              inherit cargoArtifacts;
-              cargoNextestExtraArgs = "--workspace";
-              partitions = 1;
-              partitionType = "count";
-            }
-          );
-          treefmt = treefmtEval.config.build.check self;
-          ast-grep = pkgs.runCommand "ast-grep-check" { nativeBuildInputs = [ pkgs.ast-grep ]; } ''
-            cd ${astGrepSrc}
-            ast-grep scan --error
-            ast-grep test
-            touch $out
-          '';
-          graphql-validate =
-            pkgs.runCommand "graphql-validate"
-              {
-                nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
-                  (pkgs.python3.withPackages (ps: [ ps.graphql-core ]))
-                ];
-              }
-              ''
-                shopt -s nullglob
-                docs=(${./src/gh/queries}/*.gql)
-                if (( ''${#docs[@]} == 0 )); then
-                  echo "no .gql files found under src/gh" >&2
-                  exit 1
-                fi
-                python3 ${./tools/graphql-validate.py} ${./src/gh/github.graphql} "''${docs[@]}"
-                touch $out
-              '';
-          hm-module-schema =
-            pkgs.runCommand "hm-module-schema"
-              {
-                nativeBuildInputs = [
-                  pkgs.jq
-                  pkgs.diffutils
-                ];
-              }
-              ''
-                ${print-config-schema}/bin/print-config-schema > schema.json
-                jq -r '.properties | keys[]' schema.json | sort > rust-fields.txt
-                jq -r '.[]' ${hmModuleSettingsOptsJson} | sort > nix-fields.txt
-                if ! diff -u rust-fields.txt nix-fields.txt >&2; then
-                  echo "" >&2
-                  echo "ERROR: jj-gh Config struct fields drifted from hm-module.nix settings options." >&2
-                  exit 1
-                fi
-                touch $out
-              '';
-          docs =
-            pkgs.runCommand "docs-check"
-              {
-                nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.diffutils ];
-              }
-              ''
-                mkdir -p $out
-                cp ${./DOCS.md} "$out/expected.md"
-                touch "$out/flake.nix"
-                cd "$out"
-                ${gen-docs-app}/bin/gen-docs
-                if ! diff -u expected.md DOCS.md; then
-                  echo "DOCS.md out of date; run \`nix run .#docs\`" >&2
-                  exit 1
-                fi
-              '';
-        }
-        // (pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          # so that the patched version gets cached by CI
-          inherit release-plz-patched;
-        });
+            cargoArtifacts
+            treefmtEval
+            jj-gh
+            print-config-schema
+            release-plz-patched
+            update-docs
+            ;
+        };
       }
     )
     // {

--- a/nix/checks/ast-grep.nix
+++ b/nix/checks/ast-grep.nix
@@ -1,0 +1,14 @@
+{ pkgs }:
+let
+  root = ../..;
+  src = pkgs.lib.fileset.toSource {
+    inherit root;
+    fileset = root;
+  };
+in
+pkgs.runCommand "ast-grep-check" { nativeBuildInputs = [ pkgs.ast-grep ]; } ''
+  cd ${src}
+  ast-grep scan --error
+  ast-grep test
+  touch $out
+''

--- a/nix/checks/clippy.nix
+++ b/nix/checks/clippy.nix
@@ -1,0 +1,12 @@
+{
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+}:
+craneLib.cargoClippy (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    cargoClippyExtraArgs = "--workspace -- -D warnings";
+  }
+)

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -1,0 +1,42 @@
+{
+  self,
+  pkgs,
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+  treefmtEval,
+  update-docs,
+  jj-gh,
+  print-config-schema,
+  release-plz-patched,
+}:
+let
+  callPackage = pkgs.lib.callPackageWith {
+    inherit
+      self
+      pkgs
+      craneLib
+      commonArgs
+      cargoArtifacts
+      treefmtEval
+      update-docs
+      jj-gh
+      print-config-schema
+      ;
+  };
+  checkFiles = pkgs.lib.filterAttrs (
+    name: type: type == "regular" && name != "default.nix" && pkgs.lib.hasSuffix ".nix" name
+  ) (builtins.readDir ./.);
+  checks = pkgs.lib.mapAttrs' (
+    name: _:
+    pkgs.lib.nameValuePair (pkgs.lib.removeSuffix ".nix" name) (callPackage (./. + "/${name}") { })
+  ) checkFiles;
+in
+checks
+// {
+  inherit jj-gh;
+}
+// (pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+  # so that the patched version gets cached by CI
+  inherit release-plz-patched;
+})

--- a/nix/checks/docs.nix
+++ b/nix/checks/docs.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  commonArgs,
+  update-docs,
+}:
+pkgs.runCommand "docs-check"
+  {
+    nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.diffutils ];
+  }
+  ''
+    mkdir -p $out
+    cp ${../../DOCS.md} "$out/expected.md"
+    touch "$out/flake.nix"
+    cd "$out"
+    ${update-docs}/bin/update-docs
+    if ! diff -u expected.md DOCS.md; then
+      echo "DOCS.md out of date; run \`nix run .#docs\`" >&2
+      exit 1
+    fi
+  ''

--- a/nix/checks/graphql-validate.nix
+++ b/nix/checks/graphql-validate.nix
@@ -1,0 +1,17 @@
+{ pkgs, commonArgs }:
+pkgs.runCommand "graphql-validate"
+  {
+    nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+      (pkgs.python3.withPackages (ps: [ ps.graphql-core ]))
+    ];
+  }
+  ''
+    shopt -s nullglob
+    docs=(${../../src/gh/queries}/*.gql)
+    if (( ''${#docs[@]} == 0 )); then
+      echo "no .gql files found under src/gh" >&2
+      exit 1
+    fi
+    python3 ${../../tools/graphql-validate.py} ${../../src/gh/github.graphql} "''${docs[@]}"
+    touch $out
+  ''

--- a/nix/checks/hm-module-schema.nix
+++ b/nix/checks/hm-module-schema.nix
@@ -1,0 +1,37 @@
+{
+  self,
+  pkgs,
+  print-config-schema,
+}:
+let
+  hmModuleSettingsOptsJson =
+    let
+      mod = (import ../hm-module.nix self) {
+        config = { };
+        inherit (pkgs) lib;
+        inherit pkgs;
+      };
+      names = builtins.attrNames mod.options.programs.jujutsu.gh.settings;
+    in
+    pkgs.writeText "hm-module-settings-opts.json" (
+      builtins.toJSON (builtins.sort builtins.lessThan names)
+    );
+in
+pkgs.runCommand "hm-module-schema"
+  {
+    nativeBuildInputs = [
+      pkgs.jq
+      pkgs.diffutils
+    ];
+  }
+  ''
+    ${print-config-schema}/bin/print-config-schema > schema.json
+    jq -r '.properties | keys[]' schema.json | sort > rust-fields.txt
+    jq -r '.[]' ${hmModuleSettingsOptsJson} | sort > nix-fields.txt
+    if ! diff -u rust-fields.txt nix-fields.txt >&2; then
+      echo "" >&2
+      echo "ERROR: jj-gh Config struct fields drifted from hm-module.nix settings options." >&2
+      exit 1
+    fi
+    touch $out
+  ''

--- a/nix/checks/nextest.nix
+++ b/nix/checks/nextest.nix
@@ -1,0 +1,14 @@
+{
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+}:
+craneLib.cargoNextest (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    cargoNextestExtraArgs = "--workspace";
+    partitions = 1;
+    partitionType = "count";
+  }
+)

--- a/nix/checks/treefmt.nix
+++ b/nix/checks/treefmt.nix
@@ -1,0 +1,2 @@
+{ self, treefmtEval }:
+treefmtEval.config.build.check self

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -1,0 +1,52 @@
+{
+  pkgs,
+  crane,
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+  rustToolchain,
+  treefmtEval,
+}:
+let
+  nightlyToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);
+  craneLibNightly = (crane.mkLib pkgs).overrideToolchain nightlyToolchain;
+  cargoArtifactsNightly = craneLibNightly.buildDepsOnly commonArgs;
+
+  callPackage = pkgs.lib.callPackageWith {
+    inherit
+      pkgs
+      craneLib
+      craneLibNightly
+      commonArgs
+      cargoArtifacts
+      cargoArtifactsNightly
+      rustToolchain
+      treefmtEval
+      ;
+  };
+
+  gen-docs = callPackage ./gen-docs.nix { };
+  gen-manpage = callPackage ./gen-manpage.nix { };
+  jj-gh = callPackage ./jj-gh.nix { inherit gen-manpage; };
+  print-config-schema = callPackage ./print-config-schema.nix { };
+  release-plz-patched = callPackage ./release-plz-patched.nix { };
+  update-docs = callPackage ./update-docs.nix { inherit gen-docs; };
+in
+{
+  inherit
+    jj-gh
+    print-config-schema
+    release-plz-patched
+    update-docs
+    ;
+
+  fetch-schema-app = callPackage ./fetch-schema.nix { };
+  release-app = callPackage ./release.nix { inherit release-plz-patched; };
+
+  packages = {
+    default = jj-gh;
+    dev = callPackage ./jj-gh-dev.nix { };
+    inherit gen-docs gen-manpage;
+    udeps = callPackage ./udeps.nix { };
+  };
+}

--- a/nix/pkgs/fetch-schema.nix
+++ b/nix/pkgs/fetch-schema.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+pkgs.writeShellApplication {
+  name = "fetch-schema";
+  runtimeInputs = [ pkgs.python3 ];
+  text = ''
+    python3 ${../../tools/fetch-schema.py}
+  '';
+}

--- a/nix/pkgs/gen-docs.nix
+++ b/nix/pkgs/gen-docs.nix
@@ -1,0 +1,14 @@
+{
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+}:
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    pname = "gen-docs";
+    cargoExtraArgs = "--package gen-docs";
+    doCheck = false;
+  }
+)

--- a/nix/pkgs/gen-manpage.nix
+++ b/nix/pkgs/gen-manpage.nix
@@ -1,0 +1,14 @@
+{
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+}:
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    pname = "gen-manpage";
+    cargoExtraArgs = "--package gen-manpage";
+    doCheck = false;
+  }
+)

--- a/nix/pkgs/jj-gh-dev.nix
+++ b/nix/pkgs/jj-gh-dev.nix
@@ -1,0 +1,13 @@
+{
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+}:
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    cargoExtraArgs = "--package jj-gh";
+    doCheck = false;
+  }
+)

--- a/nix/pkgs/jj-gh.nix
+++ b/nix/pkgs/jj-gh.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  craneLib,
+  commonArgs,
+  cargoArtifacts,
+  gen-manpage,
+}:
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    cargoExtraArgs = "--package jj-gh";
+
+    nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+      pkgs.installShellFiles
+    ];
+
+    postInstall =
+      let
+        jj-gh = "${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} $out/bin/jj-gh";
+      in
+      ''
+        ${gen-manpage}/bin/gen-manpage > jj-gh.1
+        installManPage jj-gh.1
+      ''
+      + pkgs.lib.optionalString (pkgs.stdenv.hostPlatform.emulatorAvailable pkgs.buildPackages) ''
+        installShellCompletion --cmd jj-gh \
+          --bash <(${jj-gh} completions bash) \
+          --fish <(${jj-gh} completions fish) \
+          --zsh <(${jj-gh} completions zsh)
+      '';
+  }
+)

--- a/nix/pkgs/print-config-schema.nix
+++ b/nix/pkgs/print-config-schema.nix
@@ -1,0 +1,19 @@
+{ craneLib, commonArgs }:
+let
+  cargoArtifacts = craneLib.buildDepsOnly (
+    commonArgs
+    // {
+      pname = "print-config-schema-deps";
+      cargoExtraArgs = "--package print-config-schema";
+    }
+  );
+in
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+    pname = "print-config-schema";
+    cargoExtraArgs = "--package print-config-schema";
+    doCheck = false;
+  }
+)

--- a/nix/pkgs/release-plz-patched.nix
+++ b/nix/pkgs/release-plz-patched.nix
@@ -1,0 +1,11 @@
+{ pkgs }:
+# TODO remove when PR merges and nixpkgs updated: https://github.com/release-plz/release-plz/pull/2857
+pkgs.release-plz.overrideAttrs (old: {
+  patches = (old.patches or [ ]) ++ [
+    (pkgs.fetchpatch {
+      name = "walk-all-branches-2857.patch";
+      url = "https://github.com/release-plz/release-plz/commit/0bf9940e70958cb3777dae063bfda2db77d40502.patch";
+      hash = "sha256-ii1SQ64Wg38sbboafTReOJji8brBYOBfaDjKHbe7SoI=";
+    })
+  ];
+})

--- a/nix/pkgs/release.nix
+++ b/nix/pkgs/release.nix
@@ -1,0 +1,18 @@
+{
+  pkgs,
+  rustToolchain,
+  release-plz-patched,
+}:
+pkgs.writeShellApplication {
+  name = "release";
+  runtimeInputs = [
+    rustToolchain
+    release-plz-patched
+    pkgs.cargo-semver-checks
+    pkgs.git
+  ];
+  text = ''
+    release-plz release-pr --git-token "$GITHUB_TOKEN" "$@"
+    release-plz release --git-token "$GITHUB_TOKEN" "$@"
+  '';
+}

--- a/nix/pkgs/udeps.nix
+++ b/nix/pkgs/udeps.nix
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  craneLibNightly,
+  commonArgs,
+  cargoArtifactsNightly,
+}:
+craneLibNightly.mkCargoDerivation (
+  commonArgs
+  // {
+    cargoArtifacts = cargoArtifactsNightly;
+    pnameSuffix = "-udeps";
+    buildPhaseCargoCommand = "cargo udeps --workspace --all-targets --locked";
+    nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-udeps ];
+  }
+)

--- a/nix/pkgs/update-docs.nix
+++ b/nix/pkgs/update-docs.nix
@@ -1,0 +1,16 @@
+{
+  pkgs,
+  gen-docs,
+  treefmtEval,
+}:
+pkgs.writeShellApplication {
+  name = "update-docs";
+  runtimeInputs = [
+    gen-docs
+    treefmtEval.config.build.wrapper
+  ];
+  text = ''
+    gen-docs > DOCS.md
+    treefmt --no-cache DOCS.md
+  '';
+}


### PR DESCRIPTION
Splits up `flake.nix` into multiple nix files for maintainability and readability.

Also makes `ci.yml` discover flake checks dynamically isntead of have to keep that matrix up to date by hand.