### PR TITLE
refactor(api): Refactor architecture to abstract repeated algorithms

### DIFF
--- a/src/commands/pr/auto_merge.rs
+++ b/src/commands/pr/auto_merge.rs
@@ -1,9 +1,4 @@
-use crate::{
-    cli::GlobalOpts,
-    config::AutoMergeMethod,
-    gh::{Gh, pr_lookup},
-    jj::{Jj, JjExt},
-};
+use crate::{cli::GlobalOpts, config::AutoMergeMethod, gh::Gh, model::Model};
 use anyhow::{Context, Result, bail};
 use jj_gh_config_derive::subcommand_args;
 
@@ -21,11 +16,8 @@ subcommand_args! {
     }
 }
 
-pub async fn run<J, G>(jj: &J, gh: &G, args: &AutoMergeArgs) -> Result<()>
-where
-    J: Jj,
-    G: Gh,
-{
+pub async fn run(model: &impl Model, args: &AutoMergeArgs) -> Result<()> {
+    let gh = model.gh();
     let AutoMergeArgs {
         number_or_rev,
         auto_merge_method,
@@ -41,8 +33,9 @@ where
             },
     } = args;
 
-    let remote = jj.resolve_default_remote(remote.as_ref()).await?;
-    let pr = pr_lookup::get_pr(jj, gh, &remote, upstream_remote, number_or_rev).await?;
+    let pr = model
+        .resolve_pr(remote.as_ref(), upstream_remote, number_or_rev)
+        .await?;
 
     if pr.in_merge_queue {
         bail!(

--- a/src/commands/pr/create/mod.rs
+++ b/src/commands/pr/create/mod.rs
@@ -1,15 +1,15 @@
 use crate::{
-    auth::EnvReader,
     cli::GlobalOpts,
     config::{self, AutoMergeMethod},
-    editor::{self, ApplyChangesCtx, Editor, resolve_editor_argv},
+    editor::{self, ApplyChangesCtx, resolve_editor_argv},
     frontmatter::Frontmatter,
     fs::RealFs,
     gh::{CreatePrRequest, Gh, remote},
     jj::{
-        self, Jj, JjExt,
+        self, Jj,
         inject::{TemplateAliases, escape_jj_string},
     },
+    model::Model,
     template::{self, TemplateSource},
 };
 use anyhow::{Context, Result, anyhow, bail};
@@ -137,19 +137,11 @@ subcommand_args! {
 ///
 /// Returns an error from any step (rev resolution, GH API, push, editor, etc.).
 #[expect(clippy::too_many_lines)]
-pub async fn run<J, G, E, ENV>(
-    jj: &J,
-    gh: &G,
-    env: &ENV,
-    editor: &E,
-    args: &CreateArgs,
-) -> Result<()>
-where
-    J: Jj,
-    G: Gh,
-    E: Editor,
-    ENV: EnvReader,
-{
+pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
+    let jj = model.jj();
+    let gh = model.gh();
+    let env = model.env();
+    let editor = model.editor();
     let args @ CreateArgs {
         globals:
             GlobalOpts {
@@ -179,16 +171,11 @@ where
         title_template,
     } = args;
 
-    let remote = jj.resolve_default_remote(remote.as_ref()).await?;
+    let (remote, target) = model
+        .resolve_target(remote.as_ref(), Some(upstream_remote))
+        .await?;
     let info = jj.resolve_rev(rev).await?;
     let existing_branch = info.bookmarks.first().cloned();
-
-    let origin_url = jj
-        .remote_url(&remote)
-        .await?
-        .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
-    let upstream_url = jj.remote_url(upstream_remote).await?;
-    let target = remote::target(&origin_url, upstream_url.as_deref())?;
 
     // Pre-flight only when we already have a bookmark; an unpushed rev can't have
     // a matching open PR.
@@ -387,8 +374,8 @@ impl TitleCandidate {
     }
 }
 
-async fn resolve_title_candidates<J: Jj>(
-    jj: &J,
+async fn resolve_title_candidates(
+    jj: &impl Jj,
     title_revset: &str,
     title_template: &str,
 ) -> Result<Vec<TitleCandidate>> {
@@ -428,9 +415,9 @@ fn parse_title_candidates(rendered: &str) -> Result<Vec<TitleCandidate>> {
     Ok(candidates)
 }
 
-async fn load_template_for<J: Jj>(
+async fn load_template_for(
     args: &CreateArgs,
-    jj: &J,
+    jj: &impl Jj,
     title_revset: &str,
     default_title: &str,
     base: &str,

--- a/src/commands/pr/edit.rs
+++ b/src/commands/pr/edit.rs
@@ -1,17 +1,12 @@
 use crate::{
-    auth::EnvReader,
     cli::GlobalOpts,
-    editor::{self, ApplyChangesCtx, Editor, resolve_editor_argv},
+    editor::{self, ApplyChangesCtx, resolve_editor_argv},
     frontmatter::Frontmatter,
-    gh::{
-        Gh, PrDetails,
-        pr_lookup::{self, PrLookup},
-        remote::Target,
-    },
-    jj::{Jj, JjExt},
+    gh::{Gh, PrDetails},
+    model::Model,
     ui::Spinner,
 };
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use jj_gh_config_derive::subcommand_args;
 use std::collections::HashMap;
 
@@ -41,13 +36,10 @@ subcommand_args! {
 /// # Errors
 ///
 /// Returns an error from any step (rev resolution, GH API, editor, etc.).
-pub async fn run<J, G, E, ENV>(jj: &J, gh: &G, env: &ENV, editor: &E, args: &EditArgs) -> Result<()>
-where
-    J: Jj,
-    G: Gh,
-    E: Editor,
-    ENV: EnvReader,
-{
+pub async fn run(model: &impl Model, args: &EditArgs) -> Result<()> {
+    let gh = model.gh();
+    let env = model.env();
+    let editor = model.editor();
     let EditArgs {
         number_or_rev,
         force,
@@ -65,12 +57,11 @@ where
     } = args;
 
     let editor_argv = resolve_editor_argv(editor_cfg.as_deref(), env)?;
-    let remote = jj.resolve_default_remote(remote.as_ref()).await?;
-
     let spinner = Spinner::start("Resolving PR");
 
-    let (target, pr_number) =
-        resolve_pr_target(jj, gh, &remote, upstream_remote, number_or_rev).await?;
+    let (target, pr_number) = model
+        .resolve_pr_number_with_target(remote.as_ref(), upstream_remote, number_or_rev)
+        .await?;
     let details = gh
         .get_pr(&target.owner, &target.repo, pr_number)
         .await
@@ -154,34 +145,4 @@ where
     log::info!("Updated PR #{number}");
     println!("{html_url}");
     Ok(())
-}
-
-/// Resolve the target repo plus PR number from either a numeric PR or a
-/// revision whose local bookmark has an open PR.
-async fn resolve_pr_target<J: Jj, G: Gh>(
-    jj: &J,
-    gh: &G,
-    default_remote: &str,
-    upstream_remote: &str,
-    number_or_rev: &str,
-) -> Result<(Target, u64)> {
-    if let Ok(num) = number_or_rev.parse::<u64>() {
-        let origin_url = jj
-            .remote_url(default_remote)
-            .await?
-            .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
-        let upstream_url = jj.remote_url(upstream_remote).await?;
-        let target = crate::gh::remote::target(&origin_url, upstream_url.as_deref())?;
-        return Ok((target, num));
-    }
-    let PrLookup {
-        target,
-        head_spec,
-        summary,
-        ..
-    } = pr_lookup::resolve_pr_for_rev(jj, gh, default_remote, upstream_remote, number_or_rev)
-        .await?;
-    let summary = summary
-        .ok_or_else(|| anyhow!("no open PR for revision `{number_or_rev}` (head `{head_spec}`)"))?;
-    Ok((target, summary.number))
 }

--- a/src/commands/pr/fetch.rs
+++ b/src/commands/pr/fetch.rs
@@ -11,11 +11,12 @@
 use crate::{
     cli::GlobalOpts,
     gh::{Gh, PrDetails},
-    git::{real::GitOps, url::parse_owner_repo},
+    git::real::GitOps,
     jj::{
-        Jj, JjExt,
+        Jj,
         inject::{TemplateAliases, escape_jj_string},
     },
+    model::Model,
     ui::Spinner,
 };
 use anyhow::{Context, Result, anyhow};
@@ -88,19 +89,13 @@ subcommand_args! {
     }
 }
 
-/// Run `pr fetch` end-to-end. Parameterized over [`GitOps`] so tests can
-/// swap in a fake; production callers pass [`crate::git::real::RealGit`].
-///
 /// # Errors
 ///
 /// Propagates errors from any step (auth, GH API, colocation, git fetch, jj
 /// import, template eval).
-pub async fn run<J: Jj, G: Gh, GO: GitOps>(
-    jj: &J,
-    gh: &G,
-    git: &GO,
-    args: &FetchArgs,
-) -> Result<()> {
+pub async fn run(model: &impl Model, args: &FetchArgs) -> Result<()> {
+    let jj = model.jj();
+    let gh = model.gh();
     let FetchArgs {
         pr: pr_num,
         template,
@@ -122,14 +117,9 @@ pub async fn run<J: Jj, G: Gh, GO: GitOps>(
 
     let spinner = Spinner::start("Resolving PR");
 
-    let remote = jj.resolve_default_remote(remote.as_ref()).await?;
-    let origin_url = jj
-        .remote_url(&remote)
-        .await?
-        .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
-    let (owner, repo) = parse_owner_repo(&origin_url)?;
+    let (remote, target) = model.resolve_target(remote.as_ref(), None).await?;
 
-    let pr = gh.get_pr(&owner, &repo, *pr_num).await?;
+    let pr = gh.get_pr(&target.owner, &target.repo, *pr_num).await?;
     if pr.head_user_login.is_none() || pr.head_repo_name.is_none() {
         log::warn!(
             "PR #{}: head fork appears deleted; `pr_head_user` / `pr_head_repo` will be empty",
@@ -153,13 +143,16 @@ pub async fn run<J: Jj, G: Gh, GO: GitOps>(
         ));
     }
 
-    if git.local_bookmark_exists(&bookmark).await? && !force {
+    if model.git().local_bookmark_exists(&bookmark).await? && !force {
         return Err(anyhow!(
             "local bookmark `{bookmark}` already exists; pass --force to overwrite"
         ));
     }
 
-    git.fetch_pr(&remote, *pr_num, &bookmark, *force).await?;
+    model
+        .git()
+        .fetch_pr(&remote, *pr_num, &bookmark, *force)
+        .await?;
     jj.git_import().await?;
     spinner.stop();
 
@@ -219,7 +212,9 @@ fn slugify(s: &str) -> String {
 mod tests {
     use super::*;
     use crate::gh::{BaseLookup, CreatePrRequest, PrCreated, PrSummary};
+    use crate::git::real::GitOps;
     use crate::jj::CommitInfo;
+    use crate::model::TestModel;
     use std::cell::RefCell;
     use std::path::PathBuf;
     use std::sync::Mutex;
@@ -367,6 +362,7 @@ mod tests {
             &self,
             _owner: &str,
             _repo: &str,
+            _head_owner: &str,
             _branches: &[String],
         ) -> Result<Vec<crate::gh::PrWithCiStatus>> {
             unimplemented!("fetch does not call local_pulls")
@@ -491,7 +487,9 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        run(&jj, &gh, &git, &args(1234, None, false)).await.unwrap();
+        run(&TestModel::new(&jj, &gh, &git), &args(1234, None, false))
+            .await
+            .unwrap();
 
         let calls = git.fetches.borrow();
         assert_eq!(calls.len(), 1);
@@ -512,9 +510,12 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        run(&jj, &gh, &git, &args_with_remote(1234, None, false, "fork"))
-            .await
-            .unwrap();
+        run(
+            &TestModel::new(&jj, &gh, &git),
+            &args_with_remote(1234, None, false, "fork"),
+        )
+        .await
+        .unwrap();
 
         let calls = git.fetches.borrow();
         assert_eq!(calls[0].remote, "fork");
@@ -529,7 +530,7 @@ mod tests {
             exists: true,
             fetches: RefCell::new(vec![]),
         };
-        let err = run(&jj, &gh, &git, &args(1234, None, false))
+        let err = run(&TestModel::new(&jj, &gh, &git), &args(1234, None, false))
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -546,7 +547,9 @@ mod tests {
             exists: true,
             fetches: RefCell::new(vec![]),
         };
-        run(&jj, &gh, &git, &args(1234, None, true)).await.unwrap();
+        run(&TestModel::new(&jj, &gh, &git), &args(1234, None, true))
+            .await
+            .unwrap();
 
         let calls = git.fetches.borrow();
         assert_eq!(calls.len(), 1);
@@ -564,9 +567,12 @@ mod tests {
         };
         let cfg_template = r#""cfg-" ++ pr_number ++ "-" ++ pr_head_user"#;
 
-        run(&jj, &gh, &git, &args(1234, Some(cfg_template), false))
-            .await
-            .unwrap();
+        run(
+            &TestModel::new(&jj, &gh, &git),
+            &args(1234, Some(cfg_template), false),
+        )
+        .await
+        .unwrap();
 
         let evals = jj.eval_template_calls.lock().unwrap();
         assert_eq!(evals.len(), 1);
@@ -587,9 +593,12 @@ mod tests {
         };
         let cli_template = r#""cli-" ++ pr_number"#;
 
-        run(&jj, &gh, &git, &args(1234, Some(cli_template), false))
-            .await
-            .unwrap();
+        run(
+            &TestModel::new(&jj, &gh, &git),
+            &args(1234, Some(cli_template), false),
+        )
+        .await
+        .unwrap();
 
         let evals = jj.eval_template_calls.lock().unwrap();
         assert_eq!(evals[0].template, cli_template);
@@ -604,7 +613,9 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        run(&jj, &gh, &git, &args(1234, None, false)).await.unwrap();
+        run(&TestModel::new(&jj, &gh, &git), &args(1234, None, false))
+            .await
+            .unwrap();
 
         let evals = jj.eval_template_calls.lock().unwrap();
         assert_eq!(evals[0].template, DEFAULT_FETCH_TEMPLATE);
@@ -619,7 +630,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let err = run(&jj, &gh, &git, &args(1234, None, false))
+        let err = run(&TestModel::new(&jj, &gh, &git), &args(1234, None, false))
             .await
             .unwrap_err();
         let msg = format!("{err:#}");
@@ -636,7 +647,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let err = run(&jj, &gh, &git, &args(1234, None, false))
+        let err = run(&TestModel::new(&jj, &gh, &git), &args(1234, None, false))
             .await
             .unwrap_err();
         assert!(
@@ -655,7 +666,7 @@ mod tests {
             exists: false,
             fetches: RefCell::new(vec![]),
         };
-        let err = run(&jj, &gh, &git, &args(1234, None, false))
+        let err = run(&TestModel::new(&jj, &gh, &git), &args(1234, None, false))
             .await
             .unwrap_err();
         let msg = format!("{err:#}");

--- a/src/commands/pr/log.rs
+++ b/src/commands/pr/log.rs
@@ -11,15 +11,12 @@
 
 use crate::{
     cli::GlobalOpts,
-    gh::{CiStatus, Gh, PrWithCiStatus},
-    git,
-    jj::{
-        Jj, JjExt,
-        inject::{TemplateAliases, escape_jj_string},
-    },
+    gh::{CiStatus, PrWithCiStatus},
+    jj::inject::{TemplateAliases, escape_jj_string},
+    model::Model,
     ui::Spinner,
 };
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use jj_gh_config_derive::subcommand_args;
 use std::collections::HashMap;
 
@@ -107,7 +104,7 @@ subcommand_args! {
     }
 }
 
-pub async fn run(gh: &impl Gh, jj: &impl Jj, args: &PrLogArgs) -> Result<()> {
+pub async fn run(model: &impl Model, args: &PrLogArgs) -> Result<()> {
     let PrLogArgs {
         jj_log_args,
         nerdfonts,
@@ -119,29 +116,29 @@ pub async fn run(gh: &impl Gh, jj: &impl Jj, args: &PrLogArgs) -> Result<()> {
                 verbose: _,
                 quiet: _,
                 log_level: _,
-                upstream_remote: _,
+                upstream_remote,
                 gh_askpass: _,
                 askpass_timeout_secs: _,
             },
     } = args;
 
     let spinner = Spinner::start("Resolving local PRs");
-    let remote = jj.resolve_default_remote(remote.as_ref()).await?;
-    let origin_url = jj
-        .remote_url(&remote)
-        .await?
-        .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
-    let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
-    let bookmarks = jj.pushed_bookmarks(&remote).await?;
-    let branch_to_local = bookmarks
+    let local = model
+        .local_pulls(remote.as_ref(), Some(upstream_remote))
+        .await?;
+    let branch_to_local = local
+        .bookmarks
         .iter()
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))
         .collect::<HashMap<String, String>>();
-    let names = bookmarks.into_iter().map(|b| b.name).collect::<Vec<_>>();
-    let prs = gh.local_pulls(&owner, &repo, &names).await?;
     spinner.stop();
 
-    let aliases = build_aliases(&prs, &branch_to_local, *nerdfonts, template.as_deref());
+    let aliases = build_aliases(
+        &local.prs,
+        &branch_to_local,
+        *nerdfonts,
+        template.as_deref(),
+    );
     let tmp = aliases.write_temp_config()?;
 
     // Stream so jj sees a tty and emits color; capturing would strip it.
@@ -319,6 +316,7 @@ mod tests {
             url: format!("https://github.com/o/r/pull/{number}"),
             title: format!("PR {number}"),
             head_ref_name: format!("branch-{number}"),
+            head_owner: Some("o".into()),
             head_sha: sha.into(),
             base_ref_name: "master".into(),
             is_draft: false,
@@ -341,6 +339,7 @@ mod tests {
             url: format!("https://github.com/o/r/pull/{number}"),
             title: format!("PR {number}"),
             head_ref_name: format!("branch-{number}"),
+            head_owner: Some("o".into()),
             head_sha: number.to_string(),
             base_ref_name: "master".into(),
             is_draft: false,

--- a/src/commands/pr/mod.rs
+++ b/src/commands/pr/mod.rs
@@ -12,13 +12,10 @@ mod restack;
 mod retry_failed;
 
 use crate::{
-    auth::{self, OsEnv},
+    auth,
     cli::{GlobalOpts, GlobalOptsInput},
-    config,
-    editor::TempfileEditor,
-    gh,
-    git::real::RealGit,
-    jj,
+    config, jj,
+    model::ModelImpl,
     ui::Spinner,
 };
 use anyhow::Result;
@@ -119,7 +116,7 @@ pub async fn dispatch(global: GlobalOptsInput, action: PrAction) -> Result<()> {
     // Discovering the workspace (`jj workspace root` + gix) is independent of
     // config/auth, so overlap the two cold-start chains. Within the config
     // chain, auth must run after config loads (it reads `gh_askpass`/`gh_token`).
-    let jj_fut = jj::real::JjCli::new();
+    let workspace_fut = jj::real::discover_workspace();
     let cfg_auth_fut = async {
         let mut fig = config::load_figment().merge(Serialized::defaults(&global));
         fig = match &action {
@@ -136,40 +133,39 @@ pub async fn dispatch(global: GlobalOptsInput, action: PrAction) -> Result<()> {
         let token = auth::resolve_token(&config).await?;
         anyhow::Ok((config, globals, token))
     };
-    let (jj, (config, globals, token)) = tokio::try_join!(jj_fut, cfg_auth_fut)?;
+    let ((repo, workspace_root), (config, globals, token)) =
+        tokio::try_join!(workspace_fut, cfg_auth_fut)?;
 
-    let gh = gh::real::OctocrabGh::new(&token)?;
-    let editor = TempfileEditor;
+    let model = ModelImpl::new(repo, workspace_root, &token)?;
     startup.stop();
     match action {
         PrAction::AutoMerge(input) => {
             let args = AutoMergeArgs::resolve(input, &config, &globals);
-            auto_merge::run(&jj, &gh, &args).await?;
+            auto_merge::run(&model, &args).await?;
         }
         PrAction::Create(input) => {
             let args = CreateArgs::resolve(input, &config, &globals);
-            create::run(&jj, &gh, &OsEnv, &editor, &args).await?;
+            create::run(&model, &args).await?;
         }
         PrAction::Edit(input) => {
             let args = EditArgs::resolve(input, &config, &globals);
-            edit::run(&jj, &gh, &OsEnv, &editor, &args).await?;
+            edit::run(&model, &args).await?;
         }
         PrAction::Fetch(input) => {
-            let git = RealGit::new(jj.repo().clone());
             let args = FetchArgs::resolve(input, &config, &globals);
-            fetch::run(&jj, &gh, &git, &args).await?;
+            fetch::run(&model, &args).await?;
         }
         PrAction::Log(input) => {
             let args = PrLogArgs::resolve(input, &config, &globals);
-            self::log::run(&gh, &jj, &args).await?;
+            self::log::run(&model, &args).await?;
         }
         PrAction::Restack(input) => {
             let args = RestackArgs::resolve(input, &config, &globals);
-            restack::run(&jj, &gh, &args).await?;
+            restack::run(&model, &args).await?;
         }
         PrAction::RetryFailed(input) => {
             let args = RetryFailedArgs::resolve(input, &config, &globals);
-            retry_failed::run(&jj, &gh, &args).await?;
+            retry_failed::run(&model, &args).await?;
         }
     }
     Ok(())

--- a/src/commands/pr/restack/interactive.rs
+++ b/src/commands/pr/restack/interactive.rs
@@ -92,8 +92,8 @@ struct UiState {
     viewport_height: usize,
 }
 
-pub async fn run<J: Jj>(
-    jj: &J,
+pub async fn run(
+    jj: &impl Jj,
     ctx: &RestackContext,
     args: &RestackArgs,
 ) -> Result<HashMap<u64, Decision>> {
@@ -838,7 +838,7 @@ fn commit_map_to_pr_map(commits: &HashMap<String, usize>, plans: &[PrPlan]) -> H
 /// Order PRs by topology (newest first) so cursor navigation matches what
 /// the user sees in the rendered log. Falls back to plan order for any PRs
 /// the jj query does not emit.
-async fn order_prs_topologically<J: Jj>(jj: &J, plans: &[PrPlan]) -> Result<Vec<u64>> {
+async fn order_prs_topologically(jj: &impl Jj, plans: &[PrPlan]) -> Result<Vec<u64>> {
     if plans.is_empty() {
         return Ok(Vec::new());
     }

--- a/src/commands/pr/restack/mod.rs
+++ b/src/commands/pr/restack/mod.rs
@@ -11,8 +11,8 @@ mod interactive;
 use crate::{
     cli::GlobalOpts,
     gh::{Gh, PrWithCiStatus, UpdatePr},
-    git,
-    jj::{Jj, JjExt, PushedBookmark},
+    jj::{Jj, PushedBookmark},
+    model::Model,
     ui::Spinner,
 };
 use anyhow::{Result, anyhow};
@@ -112,23 +112,18 @@ impl Decision {
     }
 }
 
-pub async fn run<J, G>(jj: &J, gh: &G, args: &RestackArgs) -> Result<()>
-where
-    J: Jj,
-    G: Gh,
-{
+pub async fn run(model: &impl Model, args: &RestackArgs) -> Result<()> {
     let GlobalOpts {
         remote,
         verbose: _,
         quiet: _,
         log_level: _,
-        upstream_remote: _,
+        upstream_remote,
         gh_askpass: _,
         askpass_timeout_secs: _,
     } = &args.globals;
 
-    let remote = jj.resolve_default_remote(remote.as_ref()).await?;
-    let ctx = gather_context(jj, gh, &remote).await?;
+    let ctx = gather_context(model, remote.as_ref(), upstream_remote).await?;
 
     let force_dry = args.dry_run
         || args.json
@@ -154,8 +149,8 @@ where
         return Ok(());
     }
 
-    let decisions = interactive::run(jj, &ctx, args).await?;
-    submit(gh, &ctx, &decisions).await
+    let decisions = interactive::run(model.jj(), &ctx, args).await?;
+    submit(model.gh(), &ctx, &decisions).await
 }
 
 /// Bundle of everything restack needs after the initial fetch: PR metadata,
@@ -166,30 +161,21 @@ pub(crate) struct RestackContext {
     pub bookmarks: Vec<PushedBookmark>,
 }
 
-async fn gather_context<J: Jj, G: Gh>(
-    jj: &J,
-    gh: &G,
-    default_remote: &str,
+async fn gather_context(
+    model: &impl Model,
+    remote: Option<&String>,
+    upstream_remote: &str,
 ) -> Result<RestackContext> {
     let spinner = Spinner::start("Resolving local PRs");
-    let origin_url = jj
-        .remote_url(default_remote)
-        .await?
-        .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
-    let (owner, repo) = git::url::parse_owner_repo(&origin_url)?;
-
-    let bookmarks = jj.pushed_bookmarks(default_remote).await?;
+    let local = model.local_pulls(remote, Some(upstream_remote)).await?;
+    let bookmarks = local.bookmarks;
     let branch_to_local = bookmarks
         .iter()
         .map(|b| (b.name.clone(), b.local_commit_id.clone()))
         .collect::<HashMap<String, String>>();
-    let names = bookmarks
-        .iter()
-        .map(|b| b.name.clone())
-        .collect::<Vec<String>>();
-    let prs = gh.local_pulls(&owner, &repo, &names).await?;
-    let trunk = jj.trunk_branch().await?;
-    let plans = propose_plans(jj, &prs, &branch_to_local, trunk.as_deref()).await?;
+    let prs = local.prs;
+    let trunk = model.jj().trunk_branch().await?;
+    let plans = propose_plans(model.jj(), &prs, &branch_to_local, trunk.as_deref()).await?;
     spinner.stop();
 
     Ok(RestackContext {
@@ -202,8 +188,8 @@ async fn gather_context<J: Jj, G: Gh>(
 /// Compute the proposed base for every PR. Pure aside from the per-PR
 /// `stacked_ancestor_bookmark` jj call; that's the only piece that needs the
 /// real graph.
-async fn propose_plans<J: Jj>(
-    jj: &J,
+async fn propose_plans(
+    jj: &impl Jj,
     prs: &[PrWithCiStatus],
     branch_to_local: &HashMap<String, String>,
     trunk: Option<&str>,
@@ -291,8 +277,8 @@ fn print_dry_run_text(plans: &[PrPlan]) {
     );
 }
 
-async fn submit<G: Gh>(
-    gh: &G,
+async fn submit(
+    gh: &impl Gh,
     ctx: &RestackContext,
     decisions: &HashMap<u64, Decision>,
 ) -> Result<()> {

--- a/src/commands/pr/retry_failed.rs
+++ b/src/commands/pr/retry_failed.rs
@@ -8,11 +8,11 @@
 
 use crate::{
     cli::GlobalOpts,
-    gh::{CiStatus, Gh, WorkflowRun, WorkflowRunStatus, pr_lookup, remote},
-    jj::{Jj, JjExt},
+    gh::{CiStatus, Gh, WorkflowRun, WorkflowRunStatus},
+    model::Model,
     ui::Spinner,
 };
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use jj_gh_config_derive::subcommand_args;
 use std::time::{Duration, Instant};
 
@@ -40,24 +40,16 @@ subcommand_args! {
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
-pub async fn run<J, G>(jj: &J, gh: &G, args: &RetryFailedArgs) -> Result<()>
-where
-    J: Jj,
-    G: Gh,
-{
-    run_with(jj, gh, args, DEFAULT_POLL_INTERVAL).await
+pub async fn run(model: &impl Model, args: &RetryFailedArgs) -> Result<()> {
+    run_with(model, args, DEFAULT_POLL_INTERVAL).await
 }
 
-async fn run_with<J, G>(
-    jj: &J,
-    gh: &G,
+async fn run_with(
+    model: &impl Model,
     args: &RetryFailedArgs,
     poll_interval: Duration,
-) -> Result<()>
-where
-    J: Jj,
-    G: Gh,
-{
+) -> Result<()> {
+    let gh = model.gh();
     let RetryFailedArgs {
         number_or_rev,
         all,
@@ -75,16 +67,10 @@ where
             },
     } = args;
 
-    let default_remote = jj.resolve_default_remote(remote.as_ref()).await?;
     if let Some(number_or_rev) = number_or_rev {
-        let (pr, target) = pr_lookup::resolve_pr_with_target(
-            jj,
-            gh,
-            &default_remote,
-            upstream_remote,
-            number_or_rev,
-        )
-        .await?;
+        let (pr, target) = model
+            .resolve_pr_with_target(remote.as_ref(), upstream_remote, number_or_rev)
+            .await?;
         retry_pr(
             gh,
             &target.owner,
@@ -99,21 +85,11 @@ where
         .await?;
         Ok(())
     } else if *all {
-        let origin_url = jj
-            .remote_url(&default_remote)
-            .await?
-            .ok_or_else(|| anyhow!("`{default_remote}` remote is not configured"))?;
-        let upstream_url = jj.remote_url(upstream_remote).await?;
-        let target = remote::target(&origin_url, upstream_url.as_deref())?;
-        let names = jj
-            .pushed_bookmarks(&default_remote)
-            .await?
-            .into_iter()
-            .map(|bookmark| bookmark.name)
-            .collect::<Vec<_>>();
-        let prs = gh
-            .local_pulls(&target.owner, &target.repo, &names)
-            .await?
+        let local = model
+            .local_pulls(remote.as_ref(), Some(upstream_remote))
+            .await?;
+        let prs = local
+            .prs
             .into_iter()
             .filter(|pr| matches!(pr.ci_status, CiStatus::Failed))
             .collect::<Vec<_>>();
@@ -124,8 +100,8 @@ where
         for pr in prs {
             retry_pr(
                 gh,
-                &target.owner,
-                &target.repo,
+                &local.target.owner,
+                &local.target.repo,
                 pr.number,
                 &pr.head_sha,
                 &pr.url,
@@ -142,8 +118,8 @@ where
 }
 
 #[expect(clippy::too_many_arguments)]
-async fn retry_pr<G: Gh>(
-    gh: &G,
+async fn retry_pr(
+    gh: &impl Gh,
     owner: &str,
     repo: &str,
     pr_number: u64,
@@ -226,8 +202,8 @@ async fn retry_pr<G: Gh>(
     Ok(())
 }
 
-async fn retry_failed_jobs<G: Gh>(
-    gh: &G,
+async fn retry_failed_jobs(
+    gh: &impl Gh,
     owner: &str,
     repo: &str,
     pr_number: u64,
@@ -261,8 +237,8 @@ async fn retry_failed_jobs<G: Gh>(
     Ok(())
 }
 
-async fn retry_each<G: Gh>(
-    gh: &G,
+async fn retry_each(
+    gh: &impl Gh,
     owner: &str,
     repo: &str,
     pr_number: u64,
@@ -281,8 +257,8 @@ async fn retry_each<G: Gh>(
     Ok(())
 }
 
-async fn cancel_each<G: Gh>(
-    gh: &G,
+async fn cancel_each(
+    gh: &impl Gh,
     owner: &str,
     repo: &str,
     pr_number: u64,
@@ -296,8 +272,8 @@ async fn cancel_each<G: Gh>(
     Ok(())
 }
 
-async fn rerun_each<G: Gh>(
-    gh: &G,
+async fn rerun_each(
+    gh: &impl Gh,
     owner: &str,
     repo: &str,
     pr_number: u64,
@@ -311,8 +287,8 @@ async fn rerun_each<G: Gh>(
     Ok(())
 }
 
-async fn poll_until_completed<G: Gh>(
-    gh: &G,
+async fn poll_until_completed(
+    gh: &impl Gh,
     owner: &str,
     repo: &str,
     head_sha: &str,
@@ -348,6 +324,7 @@ mod tests {
             UpdatePr, WorkflowRun, WorkflowRunConclusion, WorkflowRunStatus,
         },
         jj::{CommitInfo, PushedBookmark},
+        model::TestModel,
     };
     use std::path::{Path, PathBuf};
     use std::sync::Mutex;
@@ -543,6 +520,7 @@ mod tests {
             &self,
             _o: &str,
             _r: &str,
+            _head_owner: &str,
             _b: &[String],
         ) -> Result<Vec<PrWithCiStatus>> {
             Ok(std::mem::take(&mut *self.local_prs.lock().unwrap()))
@@ -607,6 +585,7 @@ mod tests {
             url: format!("https://github.com/o/r/pull/{number}"),
             title: "t".into(),
             head_ref_name: "feat".into(),
+            head_owner: Some("o".into()),
             head_sha: sha.into(),
             base_ref_name: "main".into(),
             is_draft: false,
@@ -645,9 +624,13 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs]);
         let jj = FakeJj::new();
 
-        run_with(&jj, &gh, &args("42", false, 30), Duration::from_millis(5))
-            .await
-            .expect("default path should succeed");
+        run_with(
+            &TestModel::without_git(&jj, &gh),
+            &args("42", false, 30),
+            Duration::from_millis(5),
+        )
+        .await
+        .expect("default path should succeed");
 
         let calls = gh.calls.lock().unwrap();
         assert_eq!(calls.rerun_failed, vec![2, 3]);
@@ -669,9 +652,13 @@ mod tests {
         ]);
         let jj = FakeJj::new();
 
-        run_with(&jj, &gh, &all_args(false, 30), Duration::from_millis(1))
-            .await
-            .expect("all-local path should retry failed PRs");
+        run_with(
+            &TestModel::without_git(&jj, &gh),
+            &all_args(false, 30),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("all-local path should retry failed PRs");
 
         let calls = gh.calls.lock().unwrap();
         assert_eq!(calls.rerun_failed, vec![2]);
@@ -694,9 +681,13 @@ mod tests {
         .with_local_prs(vec![local_pr(42, "failed", CiStatus::Failed)]);
         let jj = FakeJj::new();
 
-        run_with(&jj, &gh, &all_args(true, 5), Duration::from_millis(1))
-            .await
-            .expect("all-local cancel path should restart failed PRs");
+        run_with(
+            &TestModel::without_git(&jj, &gh),
+            &all_args(true, 5),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("all-local cancel path should restart failed PRs");
 
         let calls = gh.calls.lock().unwrap();
         assert_eq!(calls.cancelled, vec![1]);
@@ -718,9 +709,13 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs]);
         let jj = FakeJj::new();
 
-        let err = run_with(&jj, &gh, &args("7", false, 30), Duration::from_millis(5))
-            .await
-            .expect_err("should refuse while CI in progress");
+        let err = run_with(
+            &TestModel::without_git(&jj, &gh),
+            &args("7", false, 30),
+            Duration::from_millis(5),
+        )
+        .await
+        .expect_err("should refuse while CI in progress");
         let msg = format!("{err:#}");
         assert!(msg.contains("still in progress"), "msg: {msg}");
 
@@ -748,9 +743,13 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs]);
         let jj = FakeJj::new();
 
-        run_with(&jj, &gh, &args("9", false, 30), Duration::from_millis(5))
-            .await
-            .unwrap();
+        run_with(
+            &TestModel::without_git(&jj, &gh),
+            &args("9", false, 30),
+            Duration::from_millis(5),
+        )
+        .await
+        .unwrap();
 
         let calls = gh.calls.lock().unwrap();
         assert!(calls.rerun_failed.is_empty());
@@ -805,9 +804,13 @@ mod tests {
         let gh = FakeGh::new(pr, vec![initial, still_running, all_done, post_poll]);
         let jj = FakeJj::new();
 
-        run_with(&jj, &gh, &args("11", true, 5), Duration::from_millis(1))
-            .await
-            .expect("cancel path should succeed once runs settle");
+        run_with(
+            &TestModel::without_git(&jj, &gh),
+            &args("11", true, 5),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("cancel path should succeed once runs settle");
 
         let calls = gh.calls.lock().unwrap();
         assert_eq!(calls.cancelled, vec![2, 3]);
@@ -823,8 +826,7 @@ mod tests {
         let jj = FakeJj::new();
 
         let err = run_with(
-            &jj,
-            &gh,
+            &TestModel::without_git(&jj, &gh),
             // 0s timeout: the very first poll iteration sees elapsed >= timeout and errors.
             &args("13", true, 0),
             Duration::from_millis(1),
@@ -858,9 +860,13 @@ mod tests {
         let gh = FakeGh::new(pr, vec![runs.clone(), runs]);
         let jj = FakeJj::new();
 
-        run_with(&jj, &gh, &args("21", true, 30), Duration::from_millis(1))
-            .await
-            .unwrap();
+        run_with(
+            &TestModel::without_git(&jj, &gh),
+            &args("21", true, 30),
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
 
         let calls = gh.calls.lock().unwrap();
         assert!(calls.cancelled.is_empty());

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -289,8 +289,9 @@ pub trait Gh {
     async fn enable_auto_merge(&self, pr_node_id: &str, method: AutoMergeMethod) -> Result<()>;
 
     /// Fetch open PRs with head commit SHA and CI status, scoped to the given
-    /// `branches` (head ref names). Used by `pr log` to build a `commit_id` →
-    /// PR mapping for jj template aliases.
+    /// `branches` (head ref names) and `head_owner`. Used by `pr log` to build
+    /// a `commit_id` → PR mapping for jj template aliases. Owner filtering is
+    /// required because unrelated forks commonly use the same branch names.
     ///
     /// The search is `is:pr is:open head:<b1> head:<b2> ...`. Implementations
     /// may batch large `branches` lists into multiple requests to stay under
@@ -305,6 +306,7 @@ pub trait Gh {
         &self,
         owner: &str,
         repo: &str,
+        head_owner: &str,
         branches: &[String],
     ) -> Result<Vec<PrWithCiStatus>>;
 

--- a/src/gh/queries/prs_with_ci_status.gql
+++ b/src/gh/queries/prs_with_ci_status.gql
@@ -9,6 +9,12 @@ query PrsWithCiStatusInternal($query: String!) {
         title
         headRefName
         headRefOid
+        headRepository {
+          owner {
+            __typename
+            login
+          }
+        }
         baseRefName
         isDraft
         merged

--- a/src/gh/queries/prs_with_ci_status.rs
+++ b/src/gh/queries/prs_with_ci_status.rs
@@ -65,6 +65,8 @@ pub struct PrWithCiStatus {
     /// renders on the local commit even when it has diverged from the remote
     /// head SHA.
     pub head_ref_name: String,
+    /// Owner of the repository containing the PR head branch.
+    pub head_owner: Option<String>,
     /// SHA of the commit at the head of the PR's branch on the remote. May
     /// not match the local bookmark target if the local bookmark has diverged
     /// from the remote PR head (e.g. if you rebase the PR on `trunk()` but have
@@ -109,6 +111,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                      title,
                      head_ref_name,
                      head_ref_oid,
+                     head_repository,
                      base_ref_name,
                      is_draft,
                      merged,
@@ -127,6 +130,7 @@ impl From<prs_with_ci_status_internal::ResponseData> for Vec<PrWithCiStatus> {
                     is_draft,
                     is_in_merge_queue,
                     head_ref_name,
+                    head_owner: head_repository.map(|repo| repo.owner.login),
                     head_sha: head_ref_oid,
                     base_ref_name,
                     ci_status: status_check_rollup.into(),

--- a/src/gh/real.rs
+++ b/src/gh/real.rs
@@ -433,6 +433,7 @@ impl Gh for OctocrabGh {
         &self,
         owner: &str,
         repo: &str,
+        head_owner: &str,
         branches: &[String],
     ) -> Result<Vec<PrWithCiStatus>> {
         if branches.is_empty() {
@@ -454,13 +455,17 @@ impl Gh for OctocrabGh {
                     .context("fetching local PRs")?,
             );
             for pr in batch {
-                if seen.insert(pr.number) {
+                if is_local_pull(&pr, head_owner) && seen.insert(pr.number) {
                     out.push(pr);
                 }
             }
         }
         Ok(out)
     }
+}
+
+fn is_local_pull(pr: &PrWithCiStatus, head_owner: &str) -> bool {
+    pr.head_owner.as_deref() == Some(head_owner)
 }
 
 /// Split reviewers into `(user_logins, team_names)` as the REST review-request
@@ -585,6 +590,31 @@ fn humanize(e: octocrab::Error) -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pr_with_owner(owner: Option<&str>) -> PrWithCiStatus {
+        PrWithCiStatus {
+            id: "id".into(),
+            number: 1,
+            url: "https://github.com/o/r/pull/1".into(),
+            title: "title".into(),
+            head_ref_name: "master".into(),
+            head_owner: owner.map(str::to_string),
+            head_sha: "sha".into(),
+            base_ref_name: "master".into(),
+            is_draft: false,
+            merged: false,
+            is_in_merge_queue: false,
+            ci_status: crate::gh::CiStatus::None,
+            auto_merge_enabled: false,
+        }
+    }
+
+    #[test]
+    fn local_pull_requires_matching_head_owner() {
+        assert!(is_local_pull(&pr_with_owner(Some("local")), "local"));
+        assert!(!is_local_pull(&pr_with_owner(Some("fork")), "local"));
+        assert!(!is_local_pull(&pr_with_owner(None), "local"));
+    }
 
     #[test]
     fn empty_branches_produces_no_queries() {

--- a/src/gh/remote.rs
+++ b/src/gh/remote.rs
@@ -16,6 +16,11 @@ pub struct Target {
 }
 
 impl Target {
+    #[must_use]
+    pub fn origin_owner(&self) -> &str {
+        &self.origin_owner
+    }
+
     /// Compose the GitHub `head` filter for `branch` in this target context.
     #[must_use]
     pub fn head_spec(&self, branch: &str) -> String {

--- a/src/git/real.rs
+++ b/src/git/real.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::rc::Rc;
 
 /// Operations against the workspace's git store. Abstracted so tests can
 /// supply a fake.
@@ -20,13 +21,14 @@ pub trait GitOps {
 
 /// Production [`GitOps`] backed by a shared `gix::Repository` discovered
 /// once at the workspace root.
+#[repr(transparent)]
 pub struct RealGit {
-    repo: gix::Repository,
+    repo: Rc<gix::Repository>,
 }
 
 impl RealGit {
     #[must_use]
-    pub fn new(repo: gix::Repository) -> Self {
+    pub fn new(repo: Rc<gix::Repository>) -> Self {
         Self { repo }
     }
 }

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -7,6 +7,7 @@
 use super::{CommitInfo, Jj, PushedBookmark, jj_argv};
 use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 /// Build a jj template that emits a JSON object: each `(key, expr)` becomes
 /// `"key": json(expr)`.
@@ -24,7 +25,7 @@ fn json_object_template(fields: &[(&str, &str)]) -> String {
 /// Caches the workspace root and a `gix::Repository` discovered at
 /// construction so all gix-backed reads share one handle.
 pub struct JjCli {
-    repo: gix::Repository,
+    repo: Rc<gix::Repository>,
     workspace_root: PathBuf,
 }
 
@@ -36,18 +37,15 @@ impl JjCli {
     ///
     /// Propagates failures from `jj workspace root` or gix discovery.
     pub async fn new() -> Result<Self> {
-        let workspace_root = workspace_root().await?;
-        let repo = gix::discover(&workspace_root)?;
-        Ok(Self {
-            repo,
-            workspace_root,
-        })
+        let (repo, workspace_root) = discover_workspace().await?;
+        Ok(Self::from_repository(Rc::new(repo), workspace_root))
     }
 
-    /// Shared handle to the discovered git repository.
-    #[must_use]
-    pub fn repo(&self) -> &gix::Repository {
-        &self.repo
+    pub(crate) fn from_repository(repo: Rc<gix::Repository>, workspace_root: PathBuf) -> Self {
+        Self {
+            repo,
+            workspace_root,
+        }
     }
 }
 
@@ -244,6 +242,12 @@ impl Jj for JjCli {
         bookmarks.dedup_by(|a, b| a.name == b.name);
         Ok(bookmarks)
     }
+}
+
+pub(crate) async fn discover_workspace() -> Result<(gix::Repository, PathBuf)> {
+    let workspace_root = workspace_root().await?;
+    let repo = gix::discover(&workspace_root)?;
+    Ok((repo, workspace_root))
 }
 
 async fn workspace_root() -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod gh;
 mod git;
 mod jj;
 mod macro_support;
+mod model;
 mod proc;
 mod template;
 mod ui;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,272 @@
+//! High-level application model shared by command handlers.
+//!
+//! Commands depend only on [`Model`]. Low-level traits remain available behind
+//! the model for focused helpers and test fakes, while cross-system workflows
+//! have one canonical home.
+
+use crate::{
+    auth::{EnvReader, OsEnv},
+    editor::{Editor, TempfileEditor},
+    gh::{
+        Gh, PrDetails, PrWithCiStatus,
+        pr_lookup::{self, PrLookup},
+        real::OctocrabGh,
+        remote::{self, Target},
+    },
+    git::real::{GitOps, RealGit},
+    jj::{Jj, JjExt, PushedBookmark, real::JjCli},
+};
+use anyhow::{Result, anyhow};
+use secrecy::SecretString;
+use std::{path::PathBuf, rc::Rc};
+
+pub trait Model {
+    type Editor: Editor;
+    type Env: EnvReader;
+    type Gh: Gh;
+    type Git: GitOps;
+    type Jj: Jj;
+
+    fn editor(&self) -> &Self::Editor;
+    fn env(&self) -> &Self::Env;
+    fn gh(&self) -> &Self::Gh;
+    fn git(&self) -> &Self::Git;
+    fn jj(&self) -> &Self::Jj;
+
+    /// Resolve the local push remote and PR target, then return open PRs whose
+    /// head belongs to that push remote owner and matches a tracked bookmark.
+    async fn local_pulls(
+        &self,
+        remote: Option<&String>,
+        upstream_remote: Option<&str>,
+    ) -> Result<LocalPulls> {
+        let (remote, target) = self.resolve_target(remote, upstream_remote).await?;
+        let bookmarks = self.jj().pushed_bookmarks(&remote).await?;
+        let names = bookmarks
+            .iter()
+            .map(|bookmark| bookmark.name.clone())
+            .collect::<Vec<_>>();
+        let prs = self
+            .gh()
+            .local_pulls(&target.owner, &target.repo, target.origin_owner(), &names)
+            .await?;
+        Ok(LocalPulls {
+            target,
+            bookmarks,
+            prs,
+        })
+    }
+
+    async fn resolve_pr(
+        &self,
+        remote: Option<&String>,
+        upstream_remote: &str,
+        number_or_rev: &str,
+    ) -> Result<PrDetails> {
+        let remote = self.jj().resolve_default_remote(remote).await?;
+        pr_lookup::get_pr(
+            self.jj(),
+            self.gh(),
+            &remote,
+            upstream_remote,
+            number_or_rev,
+        )
+        .await
+    }
+
+    async fn resolve_pr_number_with_target(
+        &self,
+        remote: Option<&String>,
+        upstream_remote: &str,
+        number_or_rev: &str,
+    ) -> Result<(Target, u64)> {
+        let (remote, target) = self.resolve_target(remote, Some(upstream_remote)).await?;
+        if let Ok(number) = number_or_rev.parse::<u64>() {
+            return Ok((target, number));
+        }
+        let PrLookup {
+            target,
+            head_spec,
+            summary,
+            ..
+        } = pr_lookup::resolve_pr_for_rev(
+            self.jj(),
+            self.gh(),
+            &remote,
+            upstream_remote,
+            number_or_rev,
+        )
+        .await?;
+        let summary = summary.ok_or_else(|| {
+            anyhow!("no open PR for revision `{number_or_rev}` (head `{head_spec}`)")
+        })?;
+        Ok((target, summary.number))
+    }
+
+    async fn resolve_pr_with_target(
+        &self,
+        remote: Option<&String>,
+        upstream_remote: &str,
+        number_or_rev: &str,
+    ) -> Result<(PrDetails, Target)> {
+        let remote = self.jj().resolve_default_remote(remote).await?;
+        pr_lookup::resolve_pr_with_target(
+            self.jj(),
+            self.gh(),
+            &remote,
+            upstream_remote,
+            number_or_rev,
+        )
+        .await
+    }
+
+    async fn resolve_target(
+        &self,
+        remote: Option<&String>,
+        upstream_remote: Option<&str>,
+    ) -> Result<(String, Target)> {
+        let remote = self.jj().resolve_default_remote(remote).await?;
+        let origin_url = self
+            .jj()
+            .remote_url(&remote)
+            .await?
+            .ok_or_else(|| anyhow!("`{remote}` remote is not configured"))?;
+        let upstream_url = match upstream_remote {
+            Some(name) => self.jj().remote_url(name).await?,
+            None => None,
+        };
+        let target = remote::target(&origin_url, upstream_url.as_deref())?;
+        Ok((remote, target))
+    }
+}
+
+pub struct ModelImpl {
+    editor: TempfileEditor,
+    env: OsEnv,
+    gh: OctocrabGh,
+    git: RealGit,
+    jj: JjCli,
+}
+
+impl ModelImpl {
+    pub fn new(
+        repo: gix::Repository,
+        workspace_root: PathBuf,
+        token: &SecretString,
+    ) -> Result<Self> {
+        let repo = Rc::new(repo);
+        Ok(Self {
+            editor: TempfileEditor,
+            env: OsEnv,
+            gh: OctocrabGh::new(token)?,
+            git: RealGit::new(Rc::clone(&repo)),
+            jj: JjCli::from_repository(repo, workspace_root),
+        })
+    }
+}
+
+impl Model for ModelImpl {
+    type Editor = TempfileEditor;
+    type Env = OsEnv;
+    type Gh = OctocrabGh;
+    type Git = RealGit;
+    type Jj = JjCli;
+
+    fn editor(&self) -> &Self::Editor {
+        &self.editor
+    }
+
+    fn env(&self) -> &Self::Env {
+        &self.env
+    }
+
+    fn gh(&self) -> &Self::Gh {
+        &self.gh
+    }
+
+    fn git(&self) -> &Self::Git {
+        &self.git
+    }
+
+    fn jj(&self) -> &Self::Jj {
+        &self.jj
+    }
+}
+
+pub struct LocalPulls {
+    pub target: remote::Target,
+    pub bookmarks: Vec<PushedBookmark>,
+    pub prs: Vec<PrWithCiStatus>,
+}
+
+#[cfg(test)]
+pub(crate) struct TestModel<'a, J, G, GO = NoGit> {
+    editor: TempfileEditor,
+    env: OsEnv,
+    gh: &'a G,
+    git: &'a GO,
+    jj: &'a J,
+}
+
+#[cfg(test)]
+impl<'a, J, G, GO> TestModel<'a, J, G, GO> {
+    pub(crate) fn new(jj: &'a J, gh: &'a G, git: &'a GO) -> Self {
+        Self {
+            editor: TempfileEditor,
+            env: OsEnv,
+            gh,
+            git,
+            jj,
+        }
+    }
+}
+
+#[cfg(test)]
+impl<'a, J, G> TestModel<'a, J, G> {
+    pub(crate) fn without_git(jj: &'a J, gh: &'a G) -> Self {
+        Self::new(jj, gh, &NoGit)
+    }
+}
+
+#[cfg(test)]
+impl<J: Jj, G: Gh, GO: GitOps> Model for TestModel<'_, J, G, GO> {
+    type Editor = TempfileEditor;
+    type Env = OsEnv;
+    type Gh = G;
+    type Git = GO;
+    type Jj = J;
+
+    fn editor(&self) -> &Self::Editor {
+        &self.editor
+    }
+
+    fn env(&self) -> &Self::Env {
+        &self.env
+    }
+
+    fn gh(&self) -> &Self::Gh {
+        self.gh
+    }
+
+    fn git(&self) -> &Self::Git {
+        self.git
+    }
+
+    fn jj(&self) -> &Self::Jj {
+        self.jj
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct NoGit;
+
+#[cfg(test)]
+impl GitOps for NoGit {
+    async fn local_bookmark_exists(&self, _name: &str) -> Result<bool> {
+        unreachable!("test did not configure git operations")
+    }
+
+    async fn fetch_pr(&self, _remote: &str, _pr: u64, _bookmark: &str, _force: bool) -> Result<()> {
+        unreachable!("test did not configure git operations")
+    }
+}


### PR DESCRIPTION
Refactors the architecture to have a single `Model` for complex business logic
to live under. It provides its constituent APIs (i.e. `trait Jj` and `trait Gh` and friends)
via accessor methods, but provides top-level functions for cross-component calculations,
such as looking up locall-tracked PRs (that requires both `jj` and `gh` queries).

In the process, it fixes a bug where sometimes `jj pr log` or `jj pr restack`
would incorrectly associate a PR with a revision if the PR came from a fork
and the fork's PR/base branch have not changed.