### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.7...jj-gh-v0.2.8) - 2026-06-15
+
+### Fixed
+
+- *(cli)* prevent shell-arg panic & precedence being wrong in some cases
+- *(meta)* Fix package descriptions
+
 ## [0.2.7](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.6...jj-gh-v0.2.7) - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh-config-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 name = "jj-gh"
 repository = "https://github.com/mrjones2014/jj-gh"
-version = "0.2.7"
+version = "0.2.8"
 include = [
   "/src/**/*.rs",
   "/src/**/*.gql",
@@ -55,7 +55,7 @@ gix = { version = "0.84", default-features = false, features = [
 ] }
 graphql_client = "0.16"
 http = "1"
-jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.2" }
+jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.3" }
 log = "0.4"
 octocrab = "0.53"
 schemars = { version = "1", optional = true }

--- a/tools/jj-gh-config-derive/Cargo.toml
+++ b/tools/jj-gh-config-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jj-gh-config-derive"
 edition = "2024"
 license = "MIT"
-version = "0.1.2"
+version = "0.1.3"
 repository = "https://github.com/mrjones2014/jj-gh"
 description = "You are probably looking for the `jj-gh` crate instead."
 


### PR DESCRIPTION



## 🤖 New release

* `jj-gh-config-derive`: 0.1.2 -> 0.1.3
* `jj-gh`: 0.2.7 -> 0.2.8

<details><summary><i><b>Changelog</b></i></summary><p>


## `jj-gh`

<blockquote>

## [0.2.8](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.7...jj-gh-v0.2.8) - 2026-06-15

### Fixed

- *(cli)* prevent shell-arg panic & precedence being wrong in some cases
- *(meta)* Fix package descriptions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).