### PR TITLE
fix(bookmarks): Fix logic to use existing bookmark if one exists

### DIFF
--- a/src/commands/pr/create/mod.rs
+++ b/src/commands/pr/create/mod.rs
@@ -309,7 +309,7 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
         lookup
     };
 
-    jj.push(rev, remote).await?;
+    jj.push(rev, existing_branch.as_deref(), remote).await?;
 
     let branch = if let Some(b) = existing_branch {
         b

--- a/src/commands/pr/fetch.rs
+++ b/src/commands/pr/fetch.rs
@@ -257,7 +257,7 @@ mod tests {
         async fn remote_bookmark_sha(&self, _: &str, _: &str) -> Result<Option<String>> {
             unimplemented!("fetch does not call remote_bookmark_sha")
         }
-        async fn push(&self, _rev: &str, _remote: String) -> Result<()> {
+        async fn push(&self, _rev: &str, _bookmark: Option<&str>, _remote: String) -> Result<()> {
             unimplemented!("fetch does not call push")
         }
         async fn trunk_branch(&self) -> Result<Option<String>> {

--- a/src/commands/pr/retry_failed.rs
+++ b/src/commands/pr/retry_failed.rs
@@ -400,7 +400,7 @@ mod tests {
         async fn remote_bookmark_sha(&self, _: &str, _: &str) -> Result<Option<String>> {
             unimplemented!()
         }
-        async fn push(&self, _rev: &str, _remote: String) -> Result<()> {
+        async fn push(&self, _rev: &str, _bookmark: Option<&str>, _remote: String) -> Result<()> {
             unimplemented!()
         }
         async fn trunk_branch(&self) -> Result<Option<String>> {

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -75,12 +75,14 @@ pub trait Jj {
     /// Propagates jj errors.
     async fn remote_bookmark_sha(&self, bookmark: &str, remote: &str) -> Result<Option<String>>;
 
-    /// `jj git push --remote <remote> -c <rev>`. Pushes the change and creates a bookmark if needed.
+    /// Pushes `rev` to `remote`. With an existing `bookmark`, pushes it via
+    /// `-b <bookmark>`; otherwise `-c <rev>`, which creates a `push-<change_id>`
+    /// bookmark.
     ///
     /// # Errors
     ///
     /// Propagates jj failures.
-    async fn push(&self, rev: &str, remote: String) -> Result<()>;
+    async fn push(&self, rev: &str, bookmark: Option<&str>, remote: String) -> Result<()>;
 
     /// Bookmark at jj's `trunk()` revset, or `Ok(None)` if `trunk()` is empty.
     ///

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -130,10 +130,16 @@ impl Jj for JjCli {
         }))
     }
 
-    async fn push(&self, rev: &str, remote: String) -> Result<()> {
-        run_jj_passthrough(&["git", "push", "--remote", &remote, "-c", rev])
-            .await
-            .context("pushing revision")
+    async fn push(&self, rev: &str, bookmark: Option<&str>, remote: String) -> Result<()> {
+        let argv = ["git", "push", "--remote", &remote]
+            .into_iter()
+            .chain(match bookmark {
+                Some(b) => ["-b", b],
+                None => ["-c", rev],
+            })
+            .collect::<Vec<_>>();
+
+        run_jj_passthrough(&argv).await.context("pushing revision")
     }
 
     async fn trunk_branch(&self) -> Result<Option<String>> {


### PR DESCRIPTION
- fix(bookmarks): Fix logic to use existing bookmark if one exists

I wasn't passing the existing bookmark along to `jj.push()` before.
Now it should use the existing bookmark if one exists. It will still
call `jj.push()` with that bookmark to ensure it is up to date on the
remote.

Fixes #215