### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.10...jj-gh-v0.3.0) - 2026-09-04
+
+### Added
+
+- *(pr-create)* Allow configuring which commit title is generated from
+- *(pr-stack)* Allow customizable template and rework UI
+- *(pr-stack)* Add automatic/no-args mode to auto-stack local PRs
+- *(pr)* Add `jj-gh pr stack` subcommand
+- *(pr-restack)* Ensure GitHub PR Stacks are up to date
+- *(pr-create)* Automatically create GitHub PR Stacks
+- *(pr-create)* Accept multiple revisions to create multiple PRs from
+- *(model)* Add APIs for GitHub PR Stacks
+- *(completions)* add `nushell` completions
+- *(nix)* use `home-manager`'s standard idiom for shell integration
+
+### Fixed
+
+- *(pr-stack)* Make UI more untuitive and easier to understand
+- *(ui)* Add terminal hyperlinks, ensure output goes to correct channel
+- *(deps)* Update `gix`
+- *(pr-create)* use local commit IDs for stack detection
+- *(log)* Tweak log spec to avoid unhelpful log noise
+- *(help)* Improve help clarity by putting global opts in subheading
+- *(pr)* use the correct base revision
+- *(ci)* Fix version range to allow dependabot to update it
+- *(deps)* update cargo minor and patch
+- *(deps)* update rust crate syn to v3
+- *(nix)* use `zsh.initContent` instead of `zsh.initExtra`
+- *(deps)* update cargo minor and patch
+- *(deps)* update cargo minor and patch
+
+### Other
+
+- [**breaking**] Remove `jj-gh pr restack` in favor of `jj-gh pr stack`
+- *(lint)* Add ast-grep rule against `use super::*`
+- *(api)* Implement logic for detecting stacks
+- *(api)* Add Stack info to PR query
+- *(deps)* update GitHub GraphQL schema
+- *(deps)* bump noyalib from 0.0.18 to 0.0.22 ([#270](https://github.com/mrjones2014/jj-gh/pull/270))
+- *(deps)* bump the cargo-minor-patch group with 4 updates ([#269](https://github.com/mrjones2014/jj-gh/pull/269))
+- *(deps)* update GitHub GraphQL schema ([#266](https://github.com/mrjones2014/jj-gh/pull/266))
+- review
+- *(deps)* bump noyalib from 0.0.17 to 0.0.18 ([#261](https://github.com/mrjones2014/jj-gh/pull/261))
+- *(dpes)* update GitHub GraphQL schema ([#260](https://github.com/mrjones2014/jj-gh/pull/260))
+- *(fmt)* Reformat TOML files with Tombi
+- *(deps)* bump noyalib from 0.0.16 to 0.0.17 ([#256](https://github.com/mrjones2014/jj-gh/pull/256))
+- *(deps)* lock file maintenance
+- *(dpes)* update GitHub GraphQL schema ([#252](https://github.com/mrjones2014/jj-gh/pull/252))
+- *(dpes)* update GitHub GraphQL schema ([#241](https://github.com/mrjones2014/jj-gh/pull/241))
+- *(dpes)* update GitHub GraphQL schema ([#239](https://github.com/mrjones2014/jj-gh/pull/239))
+- *(dpes)* update GitHub GraphQL schema ([#237](https://github.com/mrjones2014/jj-gh/pull/237))
+- *(dpes)* update GitHub GraphQL schema
+
 ## [0.2.10](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.9...jj-gh-v0.2.10) - 2026-07-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.2.10"
+version = "0.3.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh-config-derive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jj-gh"
-version = "0.2.10"
+version = "0.3.0"
 edition = "2024"
 description = "Manage GitHub PR Stacks natively with `jj`"
 repository = "https://github.com/mrjones2014/jj-gh"
@@ -53,7 +53,7 @@ gix = { version = "0.87", default-features = false, features = [
 ] }
 graphql_client = "0.16"
 http = "1"
-jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.3" }
+jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.4" }
 log = "0.4"
 # see: https://github.com/dependabot/dependabot-core/issues/14196
 noyalib = "0.0"

--- a/tools/jj-gh-config-derive/Cargo.toml
+++ b/tools/jj-gh-config-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jj-gh-config-derive"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "You are probably looking for the `jj-gh` crate instead."
 repository = "https://github.com/mrjones2014/jj-gh"


### PR DESCRIPTION



## 🤖 New release

* `jj-gh-config-derive`: 0.1.3 -> 0.1.4
* `jj-gh`: 0.2.10 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `jj-gh`

<blockquote>

## [0.3.0](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.10...jj-gh-v0.3.0) - 2026-09-04

### Added

- *(pr-create)* Allow configuring which commit title is generated from
- *(pr-stack)* Allow customizable template and rework UI
- *(pr-stack)* Add automatic/no-args mode to auto-stack local PRs
- *(pr)* Add `jj-gh pr stack` subcommand
- *(pr-restack)* Ensure GitHub PR Stacks are up to date
- *(pr-create)* Automatically create GitHub PR Stacks
- *(pr-create)* Accept multiple revisions to create multiple PRs from
- *(model)* Add APIs for GitHub PR Stacks
- *(completions)* add `nushell` completions
- *(nix)* use `home-manager`'s standard idiom for shell integration

### Fixed

- *(pr-stack)* Make UI more untuitive and easier to understand
- *(ui)* Add terminal hyperlinks, ensure output goes to correct channel
- *(deps)* Update `gix`
- *(pr-create)* use local commit IDs for stack detection
- *(log)* Tweak log spec to avoid unhelpful log noise
- *(help)* Improve help clarity by putting global opts in subheading
- *(pr)* use the correct base revision
- *(ci)* Fix version range to allow dependabot to update it
- *(deps)* update cargo minor and patch
- *(deps)* update rust crate syn to v3
- *(nix)* use `zsh.initContent` instead of `zsh.initExtra`
- *(deps)* update cargo minor and patch
- *(deps)* update cargo minor and patch

### Other

- [**breaking**] Remove `jj-gh pr restack` in favor of `jj-gh pr stack`
- *(lint)* Add ast-grep rule against `use super::*`
- *(api)* Implement logic for detecting stacks
- *(api)* Add Stack info to PR query
- *(deps)* update GitHub GraphQL schema
- *(deps)* bump noyalib from 0.0.18 to 0.0.22 ([#270](https://github.com/mrjones2014/jj-gh/pull/270))
- *(deps)* bump the cargo-minor-patch group with 4 updates ([#269](https://github.com/mrjones2014/jj-gh/pull/269))
- *(deps)* update GitHub GraphQL schema ([#266](https://github.com/mrjones2014/jj-gh/pull/266))
- review
- *(deps)* bump noyalib from 0.0.17 to 0.0.18 ([#261](https://github.com/mrjones2014/jj-gh/pull/261))
- *(dpes)* update GitHub GraphQL schema ([#260](https://github.com/mrjones2014/jj-gh/pull/260))
- *(fmt)* Reformat TOML files with Tombi
- *(deps)* bump noyalib from 0.0.16 to 0.0.17 ([#256](https://github.com/mrjones2014/jj-gh/pull/256))
- *(deps)* lock file maintenance
- *(dpes)* update GitHub GraphQL schema ([#252](https://github.com/mrjones2014/jj-gh/pull/252))
- *(dpes)* update GitHub GraphQL schema ([#241](https://github.com/mrjones2014/jj-gh/pull/241))
- *(dpes)* update GitHub GraphQL schema ([#239](https://github.com/mrjones2014/jj-gh/pull/239))
- *(dpes)* update GitHub GraphQL schema ([#237](https://github.com/mrjones2014/jj-gh/pull/237))
- *(dpes)* update GitHub GraphQL schema
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).