### PR TITLE
feat(nix): use `home-manager`'s standard idiom for shell integration

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -50,6 +50,12 @@ in
       description = "The jj-gh package to install.";
     };
 
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
     aliases = mkOption {
       type = types.attrsOf types.str;
       default = {
@@ -249,7 +255,7 @@ in
     # `jj-gh-<alias>-overlay.fish` into `completions/` would never fire on
     # `jj <tab>`. Sourcing from interactive init registers the rules
     # against `jj` directly; fish then unions them with jj's own.
-    (mkIf (config.programs.fish.enable && cfg.aliases != { }) {
+    (mkIf (cfg.enableFishIntegration && cfg.aliases != { }) {
       programs.fish.interactiveShellInit = lib.mkOrder priority (
         lib.concatMapStringsSep "\n" (n: ''
           source ${mkOverlay "fish" n cfg.aliases.${n}}
@@ -262,7 +268,7 @@ in
     # completion to load before snapshotting the prior `complete -F`
     # handler, so we don't need to `eval "$(jj util completion bash)"`
     # here.
-    (mkIf (config.programs.bash.enable && cfg.aliases != { }) {
+    (mkIf (cfg.enableBashIntegration && cfg.aliases != { }) {
       programs.bash.initExtra = lib.mkOrder priority (
         lib.concatMapStringsSep "\n" (n: ''
           source ${mkOverlay "bash" n cfg.aliases.${n}}
@@ -274,7 +280,7 @@ in
     # in home-manager's .zshrc, so `_comps[jj]` is already populated from
     # `_jj` in fpath (nixpkgs jujutsu ships it under
     # share/zsh/site-functions) and the overlays can snapshot it directly.
-    (mkIf (config.programs.zsh.enable && cfg.aliases != { }) {
+    (mkIf (cfg.enableZshIntegration && cfg.aliases != { }) {
       programs.zsh.initContent = lib.mkOrder priority (
         lib.concatMapStringsSep "\n" (n: ''
           source ${mkOverlay "zsh" n cfg.aliases.${n}}


### PR DESCRIPTION
Injecting the shell integrations based on `programs.{shell}.enable` is incorrect. For example in my case `zsh` is used simply to gather all the nix-related environment variables and immediately `exec`s `nushell`. Consequently, I don't have any completion settings enabled for `zsh` even though `programs.zsh.enable` is set, so I get this error:

```bash
/nix/store/2zykqchcim16nf4aba63agn3ys4j107w-jj-gh-zsh-pr-overlay:113: command not found: compdef
```

This PR just moves the shell integration stuff to use home-manager's standard idiom of having `{program}.enable{Shell}Integration` options that default to `home.shell.enable{Shell}Integration`.