### PR TITLE
feat(completions): add `nushell` completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933b05d5d83ff65fd7eaf5d106c792f2264908790a2642aca57429767b762ce2"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2264,7 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "crossterm",
  "figment",
  "flexi_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ anstyle = "1"
 anyhow = "1"
 clap = { workspace = true, features = ["derive", "wrap_help"] }
 clap_complete = "4"
+clap_complete_nushell = "4"
 crossterm = "0.29"
 futures = "0.3"
 figment = { version = "0.10", features = ["toml"] }

--- a/DOCS.md
+++ b/DOCS.md
@@ -338,7 +338,19 @@ Without flags, emits a standalone completion script for the `jj-gh` binary. With
 
 - `<SHELL>`
 
-  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+  Possible values:
+  - `bash`:
+    Bash
+  - `elvish`:
+    Elvish
+  - `fish`:
+    Fish
+  - `nushell`:
+    Nushell
+  - `powershell`:
+    PowerShell
+  - `zsh`:
+    Zsh
 
 ###### **Options:**
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Nix package installs the manpage automatically. Run `man jj-gh` to view it.
     enable = true;
     # Map of `jj` alias name -> `jj-gh` subcommand. Each entry installs the
     # alias *and* drops a completion overlay for `jj <name> <tab>` into any
-    # shell home-manager has enabled (fish/bash/zsh).
+    # shell home-manager has enabled (fish/bash/nushell/zsh).
     # aliases = { pr = "pr"; };
     settings = {
       gh_askpass = [
@@ -214,11 +214,17 @@ eval "$(jj-gh completions bash --jj-alias pr --subcommand pr)"
 # zsh (after compinit)
 source <(jj util completion zsh)
 source <(jj-gh completions zsh --jj-alias pr --subcommand pr)
+
+# nushell
+jj util completion nushell | save -f completions-jj.nu
+jj-gh completions nushell --jj-alias pr --subcommand pr | save -f completions-jj-gh-pr.nu
+source completions-jj.nu
+source completions-jj-gh-pr.nu
 ```
 
 The overlay must be sourced _after_ `jj util completion <shell>` so it can chain to jj's completer when the alias is not the one being completed.
 
-If you use the `home-manager` module with `programs.fish.enable` / `programs.bash.enable` / `programs.zsh.enable` set, the matching overlay is
+If you use the `home-manager` module with `programs.fish.enable` / `programs.bash.enable` / `programs.nushell.enable` / `programs.zsh.enable` set, the matching overlay is
 wired up automatically for every entry in `programs.jujutsu.gh.aliases`. You only need the manual steps above when installing via
 `cargo install` or from source.
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -54,6 +54,8 @@ in
 
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     aliases = mkOption {
@@ -70,7 +72,7 @@ in
         - Installs `programs.jujutsu.settings.aliases.<name>` dispatching to
           `jj-gh <subcommand>` (so e.g. `jj pr create` runs `jj-gh pr create`).
         - Drops a shell completion overlay for `jj <name> <tab>` into each
-          enabled shell (fish/bash/zsh), so completions work out of the box.
+          enabled shell (fish/bash/nushell/zsh), so completions work out of the box.
       '';
     };
 
@@ -272,6 +274,16 @@ in
       programs.bash.initExtra = lib.mkOrder priority (
         lib.concatMapStringsSep "\n" (n: ''
           source ${mkOverlay "bash" n cfg.aliases.${n}}
+        '') (lib.attrNames cfg.aliases)
+      );
+    })
+
+    # nushell: extern declarations for compound command names compose with
+    # jj's own completion module, so no completer wrapping is needed.
+    (mkIf (cfg.enableNushellIntegration && cfg.aliases != { }) {
+      programs.nushell.extraConfig = lib.mkOrder priority (
+        lib.concatMapStringsSep "\n" (n: ''
+          source ${mkOverlay "nushell" n cfg.aliases.${n}}
         '') (lib.attrNames cfg.aliases)
       );
     })

--- a/nix/pkgs/jj-gh.nix
+++ b/nix/pkgs/jj-gh.nix
@@ -27,6 +27,7 @@ craneLib.buildPackage (
         installShellCompletion --cmd jj-gh \
           --bash <(${jj-gh} completions bash) \
           --fish <(${jj-gh} completions fish) \
+          --nushell <(${jj-gh} completions nushell) \
           --zsh <(${jj-gh} completions zsh)
       '';
   }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,13 @@
 //! CLI arg parser
 
-use crate::commands::{completions::SubcommandStr, pr::PrAction};
+use crate::commands::{
+    completions::{CompletionShell, SubcommandStr},
+    pr::PrAction,
+};
 use clap::{
     Parser, Subcommand,
     builder::{Styles, styling::AnsiColor},
 };
-use clap_complete::Shell;
 use jj_gh_config_derive::subcommand_args;
 use log::LevelFilter;
 use std::io::IsTerminal;
@@ -116,7 +118,7 @@ pub enum Command {
     /// `jj <jj-alias> <tab>` on top of jj's own completion script (source
     /// the overlay *after* `jj util completion <shell>`).
     Completions {
-        shell: Shell,
+        shell: CompletionShell,
         /// Emit an overlay for `jj <NAME> <tab>` instead of the standalone
         /// `jj-gh` script. Pass the jj alias name (e.g. `pr`). Must be
         /// paired with `--subcommand`.

--- a/src/commands/completions/mod.rs
+++ b/src/commands/completions/mod.rs
@@ -17,6 +17,7 @@
 
 mod bash;
 mod fish;
+mod nushell;
 mod zsh;
 
 use crate::{Cli, commands::pr::PrAction};
@@ -26,51 +27,63 @@ use std::{fmt::Display, io::Write};
 
 pub fn run(
     bin_name: &str,
-    shell: clap_complete::Shell,
+    shell: CompletionShell,
     jj_alias: Option<String>,
     jj_gh_subcommand: Option<SubcommandStr>,
 ) -> Result<()> {
-    match (jj_alias, jj_gh_subcommand) {
-        (Some(alias), Some(subcommand)) => {
-            alias_completions(shell.into(), &alias, subcommand, &mut std::io::stdout())?;
-        }
-        _ => {
-            clap_complete::generate(shell, &mut Cli::command(), bin_name, &mut std::io::stdout());
-        }
+    if let (Some(alias), Some(subcommand)) = (jj_alias, jj_gh_subcommand) {
+        alias_completions(shell, &alias, subcommand, &mut std::io::stdout())?;
+    } else {
+        let mut cmd = Cli::command();
+        cmd.set_bin_name(bin_name);
+        cmd.build();
+        shell.generator().generate(&cmd, &mut std::io::stdout());
     }
 
     Ok(())
 }
 
-/// Shells for which an overlay can be emitted. Sibling to
-/// `clap_complete::Shell`, but narrower: only shells whose programmable
-/// completion model supports the layering we need (predicate-gated rules
-/// or wrapper functions) get a dedicated variant. Anything else lands in
-/// `Other` so the dispatch can produce a clear error referencing the name
-/// the user actually passed.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[non_exhaustive]
-pub enum Shell {
+/// Shell completion generators supported by jj-gh.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
+pub enum CompletionShell {
     /// Bash.
     Bash,
+    /// Elvish.
+    Elvish,
     /// Fish.
     Fish,
+    /// Nushell.
+    Nushell,
+    /// PowerShell.
+    #[value(name = "powershell")]
+    PowerShell,
     /// Zsh.
     Zsh,
-    /// Any shell name we don't have an overlay implementation for. The
-    /// inner string is whatever the user passed (e.g. `"powershell"`,
-    /// `"elvish"`).
-    Other(String),
 }
 
-impl From<clap_complete::Shell> for Shell {
-    fn from(shell: clap_complete::Shell) -> Self {
-        match shell {
-            clap_complete::Shell::Bash => Self::Bash,
-            clap_complete::Shell::Fish => Self::Fish,
-            clap_complete::Shell::Zsh => Self::Zsh,
-            other => Self::Other(other.to_string()),
+impl CompletionShell {
+    fn generator(&self) -> &dyn clap_complete::Generator {
+        match self {
+            Self::Bash => &clap_complete::Shell::Bash,
+            Self::Elvish => &clap_complete::Shell::Elvish,
+            Self::Fish => &clap_complete::Shell::Fish,
+            Self::Nushell => &clap_complete_nushell::Nushell,
+            Self::PowerShell => &clap_complete::Shell::PowerShell,
+            Self::Zsh => &clap_complete::Shell::Zsh,
         }
+    }
+}
+
+impl Display for CompletionShell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Bash => "bash",
+            Self::Elvish => "elvish",
+            Self::Fish => "fish",
+            Self::Nushell => "nushell",
+            Self::PowerShell => "powershell",
+            Self::Zsh => "zsh",
+        })
     }
 }
 
@@ -101,7 +114,7 @@ fn _ensure_subcmds_handled(cmd: crate::cli::Command) {
 
 /// Emit a completion overlay for `jj <alias> <tab>` to `out`.
 fn alias_completions<W: Write>(
-    shell: Shell,
+    shell: CompletionShell,
     alias: &str,
     subcommand: SubcommandStr,
     out: &mut W,
@@ -110,10 +123,13 @@ fn alias_completions<W: Write>(
         SubcommandStr::Pr => PrAction::augment_subcommands(Command::new("pr")),
     };
     match shell {
-        Shell::Fish => fish::emit(&cmd, alias, out)?,
-        Shell::Bash => bash::emit(&cmd, alias, out)?,
-        Shell::Zsh => zsh::emit(&cmd, alias, out)?,
-        Shell::Other(name) => bail!("--jj-alias overlay not supported for shell `{name}`"),
+        CompletionShell::Fish => fish::emit(&cmd, alias, out)?,
+        CompletionShell::Bash => bash::emit(&cmd, alias, out)?,
+        CompletionShell::Nushell => nushell::emit(&cmd, alias, out)?,
+        CompletionShell::Zsh => zsh::emit(&cmd, alias, out)?,
+        shell @ (CompletionShell::Elvish | CompletionShell::PowerShell) => {
+            bail!("--jj-alias overlay not supported for shell `{shell}`");
+        }
     }
     Ok(())
 }
@@ -197,7 +213,7 @@ pub(super) fn fake_pr_command() -> Command {
 mod tests {
     use super::*;
 
-    fn emit_string(shell: Shell) -> String {
+    fn emit_string(shell: CompletionShell) -> String {
         let mut buf = Vec::<u8>::new();
         alias_completions(shell, "pr", SubcommandStr::Pr, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
@@ -207,19 +223,19 @@ mod tests {
     fn real_pr_action_covers_all_visible_subcommands() {
         // Catches regressions when adding/renaming subcommands or visible
         // aliases on `PrAction`; fake_pr_command is too narrow to notice.
-        let bash = emit_string(Shell::Bash);
+        let bash = emit_string(CompletionShell::Bash);
         for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
             assert!(bash.contains(name), "bash overlay missing `{name}`");
         }
         assert!(bash.contains("complete -F _jj_gh_alias_wrapper_pr jj"));
 
-        let zsh = emit_string(Shell::Zsh);
+        let zsh = emit_string(CompletionShell::Zsh);
         for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
             assert!(zsh.contains(name), "zsh overlay missing `{name}`");
         }
         assert!(zsh.contains("compdef _jj_gh_alias_pr jj"));
 
-        let fish = emit_string(Shell::Fish);
+        let fish = emit_string(CompletionShell::Fish);
         for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
             assert!(
                 fish.contains(&format!("-a '{name}'")),
@@ -227,13 +243,21 @@ mod tests {
             );
         }
         assert!(fish.contains("__jj_gh_alias_no_subcommand pr"));
+
+        let nushell = emit_string(CompletionShell::Nushell);
+        for name in ["create", "c", "fetch", "f", "auto-merge", "am", "log", "l"] {
+            assert!(
+                nushell.contains(&format!(r#"export extern "jj pr {name}""#)),
+                "nushell overlay missing `{name}`"
+            );
+        }
     }
 
     #[test]
     fn unsupported_shell_errors_with_name() {
         let mut buf = Vec::<u8>::new();
         let err = alias_completions(
-            Shell::Other("powershell".into()),
+            CompletionShell::PowerShell,
             "pr",
             SubcommandStr::Pr,
             &mut buf,

--- a/src/commands/completions/nushell.rs
+++ b/src/commands/completions/nushell.rs
@@ -1,0 +1,66 @@
+use super::{ArgInfo, collect_subs, first_help_line};
+use anyhow::Result;
+use clap::Command;
+use std::io::Write;
+
+pub(super) fn emit<W: Write>(cmd: &Command, alias: &str, out: &mut W) -> Result<()> {
+    writeln!(
+        out,
+        "# jj-gh: completion overlay for `jj {alias} <tab>` (do not edit)"
+    )?;
+    writeln!(out, "module completions {{")?;
+    writeln!(out)?;
+
+    for sub in collect_subs(cmd) {
+        for name in std::iter::once(sub.name).chain(sub.aliases) {
+            if let Some(about) = &sub.about {
+                writeln!(out, "  # {}", first_help_line(about))?;
+            }
+            writeln!(out, r#"  export extern "jj {alias} {name}" ["#)?;
+            for arg in &sub.args {
+                writeln!(out, "    {}", arg_spec(arg))?;
+            }
+            writeln!(out, "  ]")?;
+            writeln!(out)?;
+        }
+    }
+    writeln!(out, "}}")?;
+    writeln!(out)?;
+    writeln!(out, "export use completions *")?;
+    Ok(())
+}
+
+fn arg_spec(arg: &ArgInfo) -> String {
+    let mut spec = match (arg.short, arg.long) {
+        (Some(short), Some(long)) => format!("--{long}(-{short})"),
+        (Some(short), None) => format!("-{short}"),
+        (None, Some(long)) => format!("--{long}"),
+        (None, None) => return String::new(),
+    };
+    if arg.takes_value {
+        spec.push_str(": string");
+    }
+    if let Some(about) = &arg.about {
+        spec.push_str(" # ");
+        spec.push_str(&first_help_line(about));
+    }
+    spec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::completions::fake_pr_command;
+
+    #[test]
+    fn emits_compound_externs_for_alias() {
+        let mut out = Vec::new();
+        emit(&fake_pr_command(), "pr", &mut out).unwrap();
+        let output = String::from_utf8(out).unwrap();
+
+        assert!(output.contains(r#"export extern "jj pr create" ["#));
+        assert!(output.contains(r#"export extern "jj pr c" ["#));
+        assert!(output.contains("--draft"));
+        assert!(output.contains("--base: string"));
+    }
+}


### PR DESCRIPTION
Follows the existing patterns, just uses`clap_complete_nushell` instead of `clap_complete`.

~Based on top of <https://github.com/mrjones2014/jj-gh/pull/245>, will rebase when that's merged~ (Done)