### PR TITLE
fix: stop `stdenv.is{Linux,Darwin}` deprecation warning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786507911,
-        "narHash": "sha256-w5aZRLbiu7H6TqsYXVMdRKg0S4DRaJpxyqxx86AwxVk=",
+        "lastModified": 1786849542,
+        "narHash": "sha256-MS8cOa/ii1+QA8R3JWVzqEIoXimu9n50GwQDiBVTFOM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "39db48099ad16834af7e27485a4babf9c28b3897",
+        "rev": "b211eadeba8b180da9453ec3413a8a3535c85b3f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,13 +50,13 @@
           inherit src;
           strictDeps = true;
           buildInputs =
-            (pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            (pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
               pkgs.libiconv
             ])
-            ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [
+            ++ (pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
               pkgs.openssl
             ]);
-          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.pkg-config ];
+          nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.pkg-config ];
         };
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
         treefmtEval = treefmt-nix.lib.evalModule pkgs (

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -36,7 +36,7 @@ checks
 // {
   inherit jj-gh;
 }
-// (pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+// (pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   # so that the patched version gets cached by CI
   inherit release-plz-patched;
 })


### PR DESCRIPTION
Note that this also requires updating the `rust-overlay` input to include https://github.com/oxalica/rust-overlay/commit/892c035d7c2ff75acd5da10424a47ab454e1f3dc