### PR TITLE
fix(pr): use the correct base revision

### DIFF
--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -65,7 +65,7 @@ async fn print_rev(globals: &GlobalOpts, _config: &Config, rev: &str) -> Result<
         bookmarks,
     } = jj.resolve_rev(rev).await?;
     let ancestor = jj.stacked_ancestor_bookmark(rev).await?;
-    let title_revset = jj::title_base_revset(rev, ancestor.as_deref());
+    let title_revset = jj::title_base_revset(rev, ancestor.as_deref().unwrap_or("trunk()"));
     let default_title = jj.first_commit_description(&title_revset).await?;
 
     let origin_url = jj.remote_url(&remote).await?;

--- a/src/commands/pr/create/mod.rs
+++ b/src/commands/pr/create/mod.rs
@@ -202,24 +202,35 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
         }
     }
 
-    let ancestor = jj.stacked_ancestor_bookmark(rev).await?;
-    let base_branch = base
-        .resolve_or(
-            || async {
-                if let Some(a) = &ancestor {
-                    return Some(a.clone());
-                }
-                jj.trunk_branch()
-                    .await
-                    .inspect_err(|e| log::debug!("could not detect trunk bookmark: {e:#}"))
-                    .ok()
-                    .flatten()
-            },
+    let ancestor = if base.cli().is_none() {
+        jj.stacked_ancestor_bookmark(rev).await?
+    } else {
+        None
+    };
+    // Jujutsu gives us the revision for an automatic base. For an explicit or
+    // configured base, find the revision on the target remote. A local bookmark
+    // with the same name can point to a different revision.
+    let (base_branch, local_base_rev) = if let Some(branch) = base.cli() {
+        (branch.clone(), None)
+    } else if let Some(ancestor) = ancestor {
+        (ancestor.clone(), Some(ancestor))
+    } else if let Some(trunk) = jj
+        .trunk_branch()
+        .await
+        .inspect_err(|e| log::debug!("could not detect trunk bookmark: {e:#}"))
+        .ok()
+        .flatten()
+    {
+        (trunk, Some("trunk()".to_string()))
+    } else if let Some(branch) = base.fallback() {
+        (branch.clone(), None)
+    } else {
+        bail!(
             "could not detect base branch: `--base` not passed, no ancestor \
              bookmark on the stack, jj `trunk()` resolves to nothing, and \
-             `default_base_branch` is not set in config",
-        )
-        .await?;
+             `default_base_branch` is not set in config"
+        );
+    };
 
     let base_lookup = gh
         .lookup_base(&target.owner, &target.repo, &base_branch)
@@ -233,7 +244,24 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
     }
     let base_display = target.base_spec(&base_branch);
 
-    let title_revset = jj::title_base_revset(rev, ancestor.as_deref());
+    let base_rev = if let Some(base_rev) = local_base_rev {
+        base_rev
+    } else {
+        let target_remote = if jj.remote_url(upstream_remote).await?.is_some() {
+            upstream_remote
+        } else {
+            &remote
+        };
+        jj.remote_bookmark_sha(&base_branch, target_remote)
+            .await?
+            .with_context(|| {
+                format!(
+                    "base branch `{base_branch}` exists on GitHub, but the local repository does \
+                     not have `{base_branch}@{target_remote}`; fetch that remote and try again"
+                )
+            })?
+    };
+    let title_revset = jj::title_base_revset(rev, &base_rev);
     let candidates = resolve_title_candidates(jj, &title_revset, title_template).await?;
     let default_title = if *pick_title {
         crate::ui::tui::require_tty("--pick-title")?;

--- a/src/commands/pr/create/mod.rs
+++ b/src/commands/pr/create/mod.rs
@@ -202,17 +202,12 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
         }
     }
 
-    let ancestor = if base.cli().is_none() {
-        jj.stacked_ancestor_bookmark(rev).await?
-    } else {
-        None
-    };
     // Jujutsu gives us the revision for an automatic base. For an explicit or
     // configured base, find the revision on the target remote. A local bookmark
     // with the same name can point to a different revision.
     let (base_branch, local_base_rev) = if let Some(branch) = base.cli() {
         (branch.clone(), None)
-    } else if let Some(ancestor) = ancestor {
+    } else if let Some(ancestor) = jj.stacked_ancestor_bookmark(rev).await? {
         (ancestor.clone(), Some(ancestor))
     } else if let Some(trunk) = jj
         .trunk_branch()

--- a/src/jj/mod.rs
+++ b/src/jj/mod.rs
@@ -252,16 +252,10 @@ pub fn remote_resolution_error(remote_names: &[String]) -> anyhow::Error {
     )
 }
 
-/// Compose the revset used to compute the default PR title.
-///
-/// With a stacked ancestor: commits introduced from the ancestor to `rev`. Without:
-/// commits introduced from trunk to `rev`.
+/// Make the revset from the selected PR base revision to `rev`.
 #[must_use]
-pub fn title_base_revset(rev: &str, ancestor: Option<&str>) -> String {
-    match ancestor {
-        Some(ancestor) => format!("({ancestor})..({rev})"),
-        None => format!("trunk()..({rev})"),
-    }
+pub fn title_base_revset(rev: &str, base_rev: &str) -> String {
+    format!("({base_rev})..({rev})")
 }
 
 /// Build a `jj` command line, prepending the program and the
@@ -278,15 +272,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn revset_with_ancestor() {
+    fn revset_with_stacked_base() {
         assert_eq!(
-            title_base_revset("@-", Some("mrj/push-foo")),
+            title_base_revset("@-", "mrj/push-foo"),
             "(mrj/push-foo)..(@-)"
         );
     }
 
     #[test]
-    fn revset_without_ancestor() {
-        assert_eq!(title_base_revset("@-", None), "trunk()..(@-)");
+    fn revset_with_trunk_base() {
+        assert_eq!(title_base_revset("@-", "trunk()"), "(trunk())..(@-)");
+    }
+
+    #[test]
+    fn revset_with_resolved_remote_base() {
+        assert_eq!(
+            title_base_revset("@-", "0123456789abcdef"),
+            "(0123456789abcdef)..(@-)"
+        );
     }
 }

--- a/src/jj/real.rs
+++ b/src/jj/real.rs
@@ -92,7 +92,9 @@ impl Jj for JjCli {
     }
 
     async fn stacked_ancestor_bookmark(&self, rev: &str) -> Result<Option<String>> {
-        let revset = format!("ancestors(({rev})-) & bookmarks()");
+        // Ignore bookmarks that are already in trunk. They cannot be the base
+        // of an active PR stack.
+        let revset = format!("heads(ancestors(({rev})-) & bookmarks() & ~::trunk())");
         let stdout = run_jj(&[
             "log",
             "--no-graph",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 //! Small reusable helpers.
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::future::Future;
 
@@ -58,7 +58,7 @@ pub fn subprocess_error(stderr: &[u8]) -> String {
 ///
 /// Resolution order:
 /// 1. CLI override (if `Some`, the closure is never called);
-/// 2. result of the async closure passed to [`Self::resolve`] / [`Self::resolve_or`];
+/// 2. result of the async closure passed to [`Self::resolve`];
 /// 3. config fallback.
 #[derive(Debug, Clone)]
 pub struct EvalWithCfgFallback<T> {
@@ -109,18 +109,6 @@ impl<T: Clone> EvalWithCfgFallback<T> {
         }
         self.fallback.clone()
     }
-
-    /// Like [`Self::resolve`] but errors with `err` if every source is `None`.
-    pub async fn resolve_or<F, Fut, E>(&self, f: F, err: E) -> Result<T>
-    where
-        F: FnOnce() -> Fut,
-        Fut: Future<Output = Option<T>>,
-        E: Into<String>,
-    {
-        self.resolve(f)
-            .await
-            .ok_or_else(|| anyhow!("{}", err.into()))
-    }
 }
 
 #[cfg(test)]
@@ -157,41 +145,29 @@ mod tests {
     async fn cli_wins_and_closure_never_runs() {
         let calls = Cell::new(0);
         let r = pair(Some("from-cli"), Some("from-fallback"))
-            .resolve_or(
-                || async {
-                    calls.set(calls.get() + 1);
-                    Some("from-closure".into())
-                },
-                "should not error",
-            )
+            .resolve(|| async {
+                calls.set(calls.get() + 1);
+                Some("from-closure".into())
+            })
             .await;
-        assert_eq!(r.unwrap(), "from-cli");
+        assert_eq!(r.as_deref(), Some("from-cli"));
         assert_eq!(calls.get(), 0, "closure must not run when CLI is Some");
     }
 
     #[tokio::test]
     async fn closure_result_wins_over_fallback() {
         let r = pair(None, Some("from-fallback"))
-            .resolve_or(|| async { Some("from-closure".into()) }, "should not error")
+            .resolve(|| async { Some("from-closure".into()) })
             .await;
-        assert_eq!(r.unwrap(), "from-closure");
+        assert_eq!(r.as_deref(), Some("from-closure"));
     }
 
     #[tokio::test]
     async fn fallback_used_when_cli_and_closure_both_empty() {
         let r = pair(None, Some("from-fallback"))
-            .resolve_or(|| async { Option::<String>::None }, "should not error")
+            .resolve(|| async { Option::<String>::None })
             .await;
-        assert_eq!(r.unwrap(), "from-fallback");
-    }
-
-    #[tokio::test]
-    async fn error_when_every_source_is_none() {
-        let r = pair(None, None)
-            .resolve_or(|| async { Option::<String>::None }, "all sources empty")
-            .await;
-        let err = r.unwrap_err();
-        assert!(err.to_string().contains("all sources empty"));
+        assert_eq!(r.as_deref(), Some("from-fallback"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

I found this issue while I tried to create a PR for Helix from my fork. Running:

```console
jj-gh pr create nkz
```

Returned this error:

```text
ERROR base branch `search_position` does not exist on helix-editor/helix
```

This result was unexpected. The revision was directly on top of `master@upstream`, and my `trunk()` revset was configured as `master@upstream`.

## Investigation

My repository contains many bookmarks from old PRs. One of these bookmarks was `search_position`.

The commit at `search_position` was an ancestor of my revision. However, it was also already part of `trunk()`. It was an old, merged bookmark and not the base of an active PR stack.

`jj-gh` searched for the base with this revset:

```text
ancestors(<revision>-) & bookmarks()
```

This revset selected any bookmarked ancestor. It did not exclude bookmarks that were already part of trunk. As a result, `jj-gh` selected `search_position` instead of `master@upstream`.

The fix excludes bookmarks that are already ancestors of `trunk()`:

```text
heads(ancestors(<revision>-) & bookmarks() & ~::trunk())
```

An old merged bookmark is now ignored. If there is no unmerged bookmark in the stack, `jj-gh` uses `trunk()` as the base.

## Follow-up issue with `--base`

I first tried to work around the error with:

```console
jj-gh pr create nkz --base master
```

This did not fix the problem. In fact, it exposed another one!

`jj-gh` used `master` as the GitHub base branch, but it did not use `master` to calculate the PR commit range. It still used the incorrectly detected `search_position` bookmark for the title, body, and diff preview.

This produced a 3.8 MB editor file with a diff across more than 1,000 commits and more than 1,200 files. Instead of a clear failure, I got a very large and incorrect preview.

This was a separate problem: `--base` changed the GitHub base branch, but it was not taken into account when `jj-gh` calculated the PR revset.

The fix now keeps the base branch and the base revision together. An explicit or configured base is resolved from the target remote. This is important in fork workflows, because a local bookmark such as `master` can differ from `master@upstream`.

The same resolved base revision is now used for:

- The PR title
- The PR body template
- The diff preview
- The GitHub PR base

For my original case, `jj-gh debug rev nkz` under this change now reports:

```text
ancestor_bookmark: None
title_revset: (trunk())..(nkz)
default_title: "Hello :)"
```

An explicit `--base master` also produces a range that contains only the intended commit.