### PR TITLE
fix(pr-create): use local commit IDs for stack detection

### DIFF
--- a/src/commands/pr/create/mod.rs
+++ b/src/commands/pr/create/mod.rs
@@ -240,8 +240,26 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
         let spinner = crate::ui::Spinner::start("Fetching PR details for stack detection");
         let pr_details = fetch_pr_details(gh, &target, &created_prs).await;
         spinner.stop();
+
+        // Build head_ref -> local_commit_id mapping from the revisions we created
+        let commit_infos = revs
+            .iter()
+            .map(|rev| jj.resolve_rev(rev))
+            .collect::<futures::future::JoinAll<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?;
+        let head_to_local = commit_infos
+            .iter()
+            .filter_map(|info| {
+                info.bookmarks
+                    .first()
+                    .map(|bookmark| (bookmark.clone(), info.commit_id.clone()))
+            })
+            .collect::<HashMap<String, String>>();
+
         let spinner = crate::ui::Spinner::start("Detecting stack chains");
-        link_stacks(gh, jj, &target, &pr_details).await?;
+        link_stacks(gh, jj, &target, &pr_details, &head_to_local).await?;
         spinner.stop();
     } else if created_prs.len() == 1 {
         // For single-revision: detect chains among all pushed PRs + the new one
@@ -260,6 +278,12 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
             )
             .await?;
         spinner.stop();
+
+        // Build head_to_local_commit mapping from bookmarks
+        let head_to_local = bookmarks
+            .iter()
+            .map(|b| (b.name.clone(), b.local_commit_id.clone()))
+            .collect::<HashMap<String, String>>();
 
         // Fetch full details for stack detection
         let spinner = crate::ui::Spinner::start("Fetching PR details for stack detection");
@@ -283,7 +307,7 @@ pub async fn run(model: &impl Model, args: &CreateArgs) -> Result<()> {
         spinner.stop();
 
         let spinner = crate::ui::Spinner::start("Detecting stack chains");
-        link_stacks(gh, jj, &target, &pr_details).await?;
+        link_stacks(gh, jj, &target, &pr_details, &head_to_local).await?;
         spinner.stop();
     }
 
@@ -317,8 +341,10 @@ async fn link_stacks(
     jj: &impl Jj,
     target: &crate::gh::remote::Target,
     pr_details: &[crate::gh::PrDetails],
+    head_to_local_commit: &HashMap<String, String>,
 ) -> Result<()> {
-    let chains = crate::gh::stack_detect::detect_stack_chains(pr_details, jj).await?;
+    let chains =
+        crate::gh::stack_detect::detect_stack_chains(pr_details, jj, head_to_local_commit).await?;
     for chain in chains {
         let result = gh.create_stack(&target.owner, &target.repo, &chain).await;
         if let Err(e) = &result {

--- a/src/commands/pr/restack/mod.rs
+++ b/src/commands/pr/restack/mod.rs
@@ -179,6 +179,7 @@ pub(crate) struct RestackContext {
     pub plans: Vec<PrPlan>,
     pub prs: Vec<PrWithCiStatus>,
     pub bookmarks: Vec<PushedBookmark>,
+    pub branch_to_local: HashMap<String, String>,
 }
 
 async fn gather_context(
@@ -202,6 +203,7 @@ async fn gather_context(
         plans,
         prs,
         bookmarks,
+        branch_to_local,
     })
 }
 
@@ -385,7 +387,8 @@ async fn submit(
     }
 
     // Detect and link stacks
-    let chains = crate::gh::stack_detect::detect_stack_chains(&pr_details, jj).await?;
+    let chains =
+        crate::gh::stack_detect::detect_stack_chains(&pr_details, jj, &ctx.branch_to_local).await?;
     for chain in chains {
         let result = gh.create_stack(&target.owner, &target.repo, &chain).await;
         if let Err(e) = &result {

--- a/src/gh/stack_detect.rs
+++ b/src/gh/stack_detect.rs
@@ -10,7 +10,16 @@ use std::collections::HashMap;
 /// Returns a list of chains, where each chain is a list of PR numbers
 /// ordered from bottom (closest to trunk) to top (furthest from trunk).
 /// A chain has length >= 2 (single PRs are not returned).
-pub async fn detect_stack_chains(prs: &[PrDetails], jj: &impl Jj) -> Result<Vec<Vec<u64>>> {
+///
+/// # Arguments
+/// * `prs` - The PRs to analyze
+/// * `jj` - The jj interface for querying local commit information
+/// * `head_to_local_commit` - Mapping from PR head branch names to local jj commit IDs
+pub async fn detect_stack_chains(
+    prs: &[PrDetails],
+    jj: &impl Jj,
+    head_to_local_commit: &HashMap<String, String>,
+) -> Result<Vec<Vec<u64>>> {
     if prs.len() < 2 {
         return Ok(Vec::new());
     }
@@ -21,10 +30,15 @@ pub async fn detect_stack_chains(prs: &[PrDetails], jj: &impl Jj) -> Result<Vec<
         .map(|pr| (pr.head_ref.clone(), pr.number))
         .collect::<HashMap<String, u64>>();
 
-    // For each PR, find its stacked ancestor bookmark
+    // For each PR, find its stacked ancestor bookmark using local commit ID
     let mut pr_to_ancestor = HashMap::<u64, Option<String>>::new();
     for pr in prs {
-        let ancestor = jj.stacked_ancestor_bookmark(&pr.head_sha).await?;
+        let local_commit = head_to_local_commit.get(&pr.head_ref);
+        let ancestor = if let Some(commit) = local_commit {
+            jj.stacked_ancestor_bookmark(commit).await?
+        } else {
+            None
+        };
         pr_to_ancestor.insert(pr.number, ancestor);
     }
 
@@ -176,7 +190,8 @@ mod tests {
     #[tokio::test]
     async fn no_prs_returns_empty() {
         let jj = MockJj::new();
-        let chains = detect_stack_chains(&[], &jj).await.unwrap();
+        let head_to_local = HashMap::<String, String>::new();
+        let chains = detect_stack_chains(&[], &jj, &head_to_local).await.unwrap();
         assert!(chains.is_empty());
     }
 
@@ -184,7 +199,11 @@ mod tests {
     async fn single_pr_returns_empty() {
         let jj = MockJj::new();
         let prs = vec![pr(1, "branch-a", "sha1")];
-        let chains = detect_stack_chains(&prs, &jj).await.unwrap();
+        let mut head_to_local = HashMap::new();
+        head_to_local.insert("branch-a".to_string(), "sha1".to_string());
+        let chains = detect_stack_chains(&prs, &jj, &head_to_local)
+            .await
+            .unwrap();
         assert!(chains.is_empty());
     }
 
@@ -194,7 +213,12 @@ mod tests {
             .with_ancestor("sha1", None)
             .with_ancestor("sha2", None);
         let prs = vec![pr(1, "branch-a", "sha1"), pr(2, "branch-b", "sha2")];
-        let chains = detect_stack_chains(&prs, &jj).await.unwrap();
+        let mut head_to_local = HashMap::new();
+        head_to_local.insert("branch-a".to_string(), "sha1".to_string());
+        head_to_local.insert("branch-b".to_string(), "sha2".to_string());
+        let chains = detect_stack_chains(&prs, &jj, &head_to_local)
+            .await
+            .unwrap();
         assert!(chains.is_empty());
     }
 
@@ -204,7 +228,12 @@ mod tests {
             .with_ancestor("sha1", None)
             .with_ancestor("sha2", Some("branch-a"));
         let prs = vec![pr(1, "branch-a", "sha1"), pr(2, "branch-b", "sha2")];
-        let chains = detect_stack_chains(&prs, &jj).await.unwrap();
+        let mut head_to_local = HashMap::new();
+        head_to_local.insert("branch-a".to_string(), "sha1".to_string());
+        head_to_local.insert("branch-b".to_string(), "sha2".to_string());
+        let chains = detect_stack_chains(&prs, &jj, &head_to_local)
+            .await
+            .unwrap();
         assert_eq!(chains.len(), 1);
         assert_eq!(chains[0], vec![1, 2]);
     }
@@ -220,7 +249,13 @@ mod tests {
             pr(2, "branch-b", "sha2"),
             pr(3, "branch-c", "sha3"),
         ];
-        let chains = detect_stack_chains(&prs, &jj).await.unwrap();
+        let mut head_to_local = HashMap::new();
+        head_to_local.insert("branch-a".to_string(), "sha1".to_string());
+        head_to_local.insert("branch-b".to_string(), "sha2".to_string());
+        head_to_local.insert("branch-c".to_string(), "sha3".to_string());
+        let chains = detect_stack_chains(&prs, &jj, &head_to_local)
+            .await
+            .unwrap();
         assert_eq!(chains.len(), 1);
         assert_eq!(chains[0], vec![1, 2, 3]);
     }
@@ -238,7 +273,14 @@ mod tests {
             pr(3, "branch-c", "sha3"),
             pr(4, "branch-d", "sha4"),
         ];
-        let chains = detect_stack_chains(&prs, &jj).await.unwrap();
+        let mut head_to_local = HashMap::new();
+        head_to_local.insert("branch-a".to_string(), "sha1".to_string());
+        head_to_local.insert("branch-b".to_string(), "sha2".to_string());
+        head_to_local.insert("branch-c".to_string(), "sha3".to_string());
+        head_to_local.insert("branch-d".to_string(), "sha4".to_string());
+        let chains = detect_stack_chains(&prs, &jj, &head_to_local)
+            .await
+            .unwrap();
         assert_eq!(chains.len(), 2);
         assert!(chains.contains(&vec![1, 2]));
         assert!(chains.contains(&vec![3, 4]));
@@ -250,7 +292,12 @@ mod tests {
             .with_ancestor("sha1", None)
             .with_ancestor("sha2", Some("branch-not-in-set"));
         let prs = vec![pr(1, "branch-a", "sha1"), pr(2, "branch-b", "sha2")];
-        let chains = detect_stack_chains(&prs, &jj).await.unwrap();
+        let mut head_to_local = HashMap::new();
+        head_to_local.insert("branch-a".to_string(), "sha1".to_string());
+        head_to_local.insert("branch-b".to_string(), "sha2".to_string());
+        let chains = detect_stack_chains(&prs, &jj, &head_to_local)
+            .await
+            .unwrap();
         assert!(chains.is_empty());
     }
 }


### PR DESCRIPTION
- fix(pr-create): use local commit IDs for stack detection

The stack detection was incorrectly using GitHub commit SHAs
(`pr.head_sha`) when calling `jj.stacked_ancestor_bookmark()`, but that
function expects local jj revision IDs. This caused stack detection to
fail silently.

Now we build a mapping from PR head branch names to local jj commit IDs
and pass that to `detect_stack_chains()`, which uses the local commit
IDs when querying for stacked ancestors.