### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.3.0...jj-gh-v0.3.1) - 2026-09-11
+
+### Added
+
+- *(pr)* Move `print-config-schema` devtool to `jj-gh config schema`
+
+### Fixed
+
+- *(lint)* Remove unused async
+- *(pr-stack)* Accept `-T|--template` CLI flag
+
+### Other
+
+- *(deps)* bump noyalib from 0.0.27 to 0.0.28 ([#302](https://github.com/mrjones2014/jj-gh/pull/302))
+- *(deps)* bump the cargo-minor-patch group with 2 updates ([#301](https://github.com/mrjones2014/jj-gh/pull/301))
+- *(deps)* bump noyalib from 0.0.22 to 0.0.27 ([#297](https://github.com/mrjones2014/jj-gh/pull/297))
+- *(deps)* update GitHub GraphQL schema ([#294](https://github.com/mrjones2014/jj-gh/pull/294))
+
 ## [0.3.0](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.2.10...jj-gh-v0.3.0) - 2026-09-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "jj-gh-config-derive"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jj-gh"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Manage GitHub PR Stacks natively with `jj`"
 repository = "https://github.com/mrjones2014/jj-gh"
@@ -48,7 +48,7 @@ gix = { version = "0.87", default-features = false, features = [
 ] }
 graphql_client = "0.16"
 http = "1"
-jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.4" }
+jj-gh-config-derive = { path = "tools/jj-gh-config-derive", version = "0.1.5" }
 log = "0.4"
 # see: https://github.com/dependabot/dependabot-core/issues/14196
 noyalib = "0.0"

--- a/tools/jj-gh-config-derive/Cargo.toml
+++ b/tools/jj-gh-config-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jj-gh-config-derive"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "You are probably looking for the `jj-gh` crate instead."
 repository = "https://github.com/mrjones2014/jj-gh"


### PR DESCRIPTION



## 🤖 New release

* `jj-gh-config-derive`: 0.1.4 -> 0.1.5
* `jj-gh`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `jj-gh`

<blockquote>

## [0.3.1](https://github.com/mrjones2014/jj-gh/compare/jj-gh-v0.3.0...jj-gh-v0.3.1) - 2026-09-17

### Added

- *(pr)* Move `print-config-schema` devtool to `jj-gh config schema`

### Fixed

- *(pr)* Mark positional arguments as required
- *(lint)* Fix clippy lints against next Rust version update
- *(pr-stack)* Pass `--no-pager` to `jj log` when rendering log
- *(lint)* Remove unused async
- *(pr-stack)* Accept `-T|--template` CLI flag

### Other

- *(deps)* update GitHub GraphQL schema ([#300](https://github.com/mrjones2014/jj-gh/pull/300))
- *(deps)* bump noyalib from 0.0.27 to 0.0.28 ([#302](https://github.com/mrjones2014/jj-gh/pull/302))
- *(deps)* bump the cargo-minor-patch group with 2 updates ([#301](https://github.com/mrjones2014/jj-gh/pull/301))
- *(deps)* bump noyalib from 0.0.22 to 0.0.27 ([#297](https://github.com/mrjones2014/jj-gh/pull/297))
- *(deps)* update GitHub GraphQL schema ([#294](https://github.com/mrjones2014/jj-gh/pull/294))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).